### PR TITLE
Configuration, performance and task -> rollout state mapping fixes.

### DIFF
--- a/rollout-dashboard/README.md
+++ b/rollout-dashboard/README.md
@@ -79,6 +79,10 @@ set to the correct value (though sometimes the defaults are OK):
    production -- only for development).
 4. `RUST_LOG` set to `info` ideally to observe at least log
    messages of info level and above.
+5. `MAX_ROLLOUTS` optionally set to a nonzero positive integer
+   to limit the number of rollouts (default 15).
+6. `REFRESH_INTERVAL` optionally set to a nonzero positive integer
+   as the number of seconds to wait between queries to Airflow.
 
 ## To-do
 

--- a/rollout-dashboard/frontend/src/lib/Batch.svelte
+++ b/rollout-dashboard/frontend/src/lib/Batch.svelte
@@ -21,6 +21,7 @@
         complete: { icon: "✅", name: "Complete" },
         skipped: { icon: "⏩", name: "Skipped" },
         error: { icon: "❌", name: "Error" },
+        unknown: { icon: "❓", name: "Unknown (check backend logs)" },
     };
 </script>
 


### PR DESCRIPTION
* Add configuration parameters to tune behavior.
* Revamp task -> rollout state mapping.
* Substantially improve performance by only requesting tasks that have been updated recently.

The task -> rollout state mapping needed to be revamped to cover two corner cases:

1. What happens when a task state is None (has not run)?  I had to close that gap.
2. What happens when a task is cleared and it precedes tasks already running or ran? The rollout could show false information in that case (e.g. if wait_for_other_rollouts must re-run and has not re-run yet, the state of the rollout should be waiting rather than rolling out other subnets).