### PR TITLE
Support SSE in dashboard server and frontend.

### DIFF
--- a/rollout-dashboard/server/Cargo.lock
+++ b/rollout-dashboard/server/Cargo.lock
@@ -102,6 +102,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1202,7 @@ name = "rollout-dashboard"
 version = "0.1.0"
 dependencies = [
  "async-recursion",
+ "async-stream",
  "axum",
  "axum-server",
  "chrono",

--- a/rollout-dashboard/server/Cargo.toml
+++ b/rollout-dashboard/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-recursion = "1.1.1"
+async-stream = "0.3.5"
 axum = { version = "0.7.5", features = ["macros"] }
 axum-server = "0.6.0"
 chrono = { version = "0.4.38", features = ["serde"] }


### PR DESCRIPTION
This modifies the client to use a newly-available SSE endpoint that transfers the rollouts using server-sent events, which means that there is no longer a periodic delay between when the server sees changes to the rollouts and the client see them.