### PR TITLE
Rollout dashboard fixes.

### DIFF
--- a/rollout-dashboard/frontend/src/lib/Batch.svelte
+++ b/rollout-dashboard/frontend/src/lib/Batch.svelte
@@ -49,13 +49,22 @@
     {#each batch.subnets as subnet}
         <ul>
             <li class="subnet">
-                <div class="subnet_state_icon tooltip">
-                    {batchStateIcon(subnet.state)}<span
-                        class="subnet_state tooltiptext"
-                        >{batchStateName(subnet.state)}{#if subnet.comment}<br
-                            />{subnet.comment}{/if}</span
-                    >
-                </div>
+                <a
+                    rel="external"
+                    href={subnet.display_url || ""}
+                    target="_blank"
+                    data-sveltekit-preload-data="off"
+                >
+                    <div class="subnet_state_icon tooltip">
+                        {batchStateIcon(subnet.state)}<span
+                            class="subnet_state tooltiptext"
+                            >{batchStateName(
+                                subnet.state,
+                            )}{#if subnet.comment}<br
+                                />{subnet.comment}{/if}</span
+                        >
+                    </div></a
+                >
                 <div
                     class="subnet_id"
                     role="link"

--- a/rollout-dashboard/frontend/src/lib/Rollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/Rollout.svelte
@@ -9,26 +9,26 @@
 <section class="rollout">
     <div class="general_info">
         <div class="name">
-            {#if rollout.url}<a
-                    rel="external"
-                    href={rollout.url}
-                    target="_blank"
-                    data-sveltekit-preload-data="off"
-                    >{rollout.name}
-                    <svg
-                        style="display: inline-block"
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        viewBox="0 0 15 15"
-                        ><path
-                            fill="currentColor"
-                            fill-rule="evenodd"
-                            d="M12 13a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v3.5a.5.5 0 0 0 1 0V3h9v9H8.5a.5.5 0 0 0 0 1zM9 6.5v3a.5.5 0 0 1-1 0V7.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 7H5.5a.5.5 0 0 1 0-1h3a.498.498 0 0 1 .5.497"
-                            clip-rule="evenodd"
-                        /></svg
-                    ></a
-                >{:else}{rollout.name}{/if}
+            <a
+                rel="external"
+                href={rollout.display_url}
+                target="_blank"
+                data-sveltekit-preload-data="off"
+                >{rollout.name}
+                <svg
+                    style="display: inline-block"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 15 15"
+                    ><path
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                        d="M12 13a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v3.5a.5.5 0 0 0 1 0V3h9v9H8.5a.5.5 0 0 0 0 1zM9 6.5v3a.5.5 0 0 1-1 0V7.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 7H5.5a.5.5 0 0 1 0-1h3a.498.498 0 0 1 .5.497"
+                        clip-rule="evenodd"
+                    /></svg
+                ></a
+            >
             {#if rollout.conf.simulate}<i class="simulated">(simulated)</i>{/if}
         </div>
         <div class="state_icon tooltip">

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -31,6 +31,7 @@ export type Subnet = {
     git_revision: string;
     state: keyof typeof subnet_rollout_states;
     comment: String;
+    display_url: string;
 };
 export type Batch = {
     subnets: Subnet[];
@@ -61,7 +62,7 @@ export type RolloutConfiguration = {
 };
 export type Rollout = {
     name: String;
-    url?: string;
+    display_url: string;
     note?: String;
     conf: RolloutConfiguration;
     state: keyof typeof rollout_states;


### PR DESCRIPTION
**Fix 1**

When rollout dashboard asks for a rollout's task instances, rollout dashboard attempts to retrieve the tasks in a paged way to avoid overcoming Airflow's baked-in 100-item limit.  For some reason, when tasks are retrieved, the result is unordered, so when page 2, 3, 4 of task instances are fetched, some task instances are missing and some task instances are duplicated. https://github.com/apache/airflow/issues/41283 explains the issue in detail. The impact to us is that, sometimes, subnets have no associated state, despite the fact that Airflow clearly has progressed on that subnet.

To mitigate this, we transgress the limitation and ask for 500 task instances. This seems to work fine, much to my surprise!  With that, the issue of rollout subnets sometimes not having any associated state is fixed.

**Fix 2**

The URL is always present in the rollout data structure, so stop pretending it is not, and remove unnecessary conditional.

**Fix 3**

Subnet state icons gain a hyperlink to the pertinent running, failed, or last completed Airflow task instance (specifically, to the log tab).  This way, one can directly access the log by clicking on the subnet state icon.

This improves usability of the dashboard and speed to diagnose an issue that may be occurring during a rollout.