### PR TITLE
Retry the unassigned nodes.

### DIFF
--- a/dags/rollout_ic_os_to_subnets.py
+++ b/dags/rollout_ic_os_to_subnets.py
@@ -185,6 +185,7 @@ for network_name, network in IC_NETWORKS.items():
             task_id="upgrade_unassigned_nodes",
             simulate=cast(bool, "{{ params.simulate }}"),
             network=network,
+            retries=retries,
         )
 
         task_groups = []


### PR DESCRIPTION
Increases robustness against sporadic failures of ic-admin or dre.