### PR TITLE
Attempt to fix / diagnose the "not yet computed rollout" problem.

### DIFF
--- a/bin/airflow
+++ b/bin/airflow
@@ -7,7 +7,7 @@ export PYTHONPATH=$(dirname "$SCRIPT_DIR")/shared
 
 if [ "$1" == "setup" ]
 then
-    python -m venv "$VENV_DIR"
+    /usr/bin/python3 -m venv "$VENV_DIR"
     "$VENV_DIR"/bin/pip3 install "apache-airflow[celery]==2.9.1" \
         apache-airflow-providers-slack[common.sql] \
         apache-airflow-providers-google \

--- a/rollout-dashboard/server/src/airflow_client.rs
+++ b/rollout-dashboard/server/src/airflow_client.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use reqwest::cookie::Jar;
 use reqwest::header::{ACCEPT, CONTENT_TYPE, REFERER};
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::cmp::min;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -166,7 +166,7 @@ pub struct XComEntryResponse {
     pub value: String,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Display)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Display)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskInstanceState {
     Success,
@@ -216,7 +216,7 @@ where
     })
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TaskInstancesResponseItem {
     pub task_id: String,
     #[allow(dead_code)]


### PR DESCRIPTION
Two things happen in this PR:

1. An endpoint to fetch the internal cache is added, in order to help diagnose any logic errors that may be causing the API to return "not yet computed rollout" for rollouts started during the weekend.
2. The logic of when to fetch the rollout plan is changed to the task evaluation loop.

I cannot reproduce this locally with Airflow so the hope is that item #1 in this PR will help diagnose next week if the problem is not resolved by #2.
