### PR TITLE
fix: Correct the query if the "other" tECDSA subnet was updated in the last 24h

### DIFF
--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -634,7 +634,13 @@ class WaitForPreconditions(ICRolloutSensorBaseOperator):
                 f"Checking that {other} has not been updated in the"
                 f" last 1 day before {subnet_id}"
             )
-            query = "sum(changes(ic_replica_info{" + f'ic_subnet="{other}"' + "}[1d]))"
+            query = (
+                'sum(changes(ic_replica_info{ic_subnet="'
+                + other
+                + '"}[1d])) > count (ic_replica_info{ic_subnet="'
+                + other
+                + '"}) / 3"'
+            )
             print("::group::Querying Prometheus servers")
             self.log.info(query)
             print("::endgroup::")


### PR DESCRIPTION
We now tolerate up to 1/3 of nodes that may have changed the version they are running independently from the subnet upgrade (e.g. if a node was offline and came back online, or if it was just added to the subnet)


Here is a [test query](https://grafana.mainnet.dfinity.network/explore?schemaVersion=1&panes=%7B%22oao%22:%7B%22datasource%22:%22P119963096DF10E67%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%28changes%28ic_replica_info%7Bic_subnet%3D%5C%22uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe%5C%22%7D%5B1d%5D%29%29%20%3E%20count%20%28ic_replica_info%7Bic_subnet%3D%5C%22uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe%5C%22%7D%29%20%2F%203%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P119963096DF10E67%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)
vs [the original query](https://grafana.mainnet.dfinity.network/explore?schemaVersion=1&panes=%7B%22oao%22:%7B%22datasource%22:%22P119963096DF10E67%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%28changes%28ic_replica_info%7Bic_subnet%3D%5C%22uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe%5C%22%7D%5B1d%5D%29%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P119963096DF10E67%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)