### PR TITLE
Update ic-admin version

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -93,7 +93,7 @@ class DRE:
         # FIXME:
         # Newer versions are linked against glibc 2.39 and
         # we don't have that on airflow ATM.
-        self.ic_admin_version = "957689f550775c7dfb7767dc2085a7845cf52533"
+        self.ic_admin_version = "72a6598aaa193edc965e0860da731cc5af7c89e0"
 
     def authenticated(self) -> "AuthenticatedDRE":
         """


### PR DESCRIPTION
to fix:

```
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO -  2024-12-09T12:06:53.957Z INFO  dre::store > Using ic-admin: /home/airflow/.cache/dre-store/ic-admin.revisions/957689f550775c7dfb7767dc2085a7845cf52533/ic-admin
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - Error: ic-admin failed with non-zero exit code 2 stderr ==>
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - error: Found argument '--silence-notices' which wasn't expected, or isn't valid in this context
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - 
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - 	If you tried to supply `--silence-notices` as a value rather than a flag, use `-- --silence-notices`
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - 
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - USAGE:
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO -     ic-admin propose-to-update-subnet-replica-version [OPTIONS] <SUBNET> <REPLICA_VERSION_ID>
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - 
[2024-12-09, 12:06:53 UTC] {subprocess.py:93} INFO - For more information try --help
```