### PR TITLE
core: reverting `ic-admin` hardocded versions

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -90,10 +90,6 @@ class DRE:
         self.dre_path = os.path.join(self.base_dir, "dre")
         self.subprocess_hook = subprocess_hook
         self.network = network
-        # FIXME:
-        # Newer versions are linked against glibc 2.39 and
-        # we don't have that on airflow ATM.
-        self.ic_admin_version = "957689f550775c7dfb7767dc2085a7845cf52533"
 
     def authenticated(self) -> "AuthenticatedDRE":
         """
@@ -142,12 +138,7 @@ class DRE:
                     nid = ["--neuron-id", str(self.network.proposer_neuron_id)]
                 else:
                     pem, nid = [], []
-                cmd = [self.dre_path] + nnsurl + nid + pem
-
-                if self.ic_admin_version:
-                    cmd += ["--ic-admin-version", self.ic_admin_version]
-
-                cmd += list(args)
+                cmd = [self.dre_path] + nnsurl + nid + pem + list(args)
                 if dry_run:
                     cmd.append("--dry-run")
                 if yes and not dry_run:

--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -93,7 +93,7 @@ class DRE:
         # FIXME:
         # Newer versions are linked against glibc 2.39 and
         # we don't have that on airflow ATM.
-        self.ic_admin_version = "72a6598aaa193edc965e0860da731cc5af7c89e0"
+        self.ic_admin_version = "957689f550775c7dfb7767dc2085a7845cf52533"
 
     def authenticated(self) -> "AuthenticatedDRE":
         """


### PR DESCRIPTION
This PR reverts the hardcoded ic-admin versions because of the issue with glibc.

Tested that ic-admin would work with:
```bash
dre get subnet-list
```

It was performed on ubuntu `20.04` with the following glibc version:
```bash
root@13e031180f1c:/# ldd --version
ldd (Ubuntu GLIBC 2.31-0ubuntu9.16) 2.31
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```