### PR TITLE
Restore the condition to publish the rollout dashboard container.

### DIFF
--- a/.github/workflows/rollout-dashboard.yaml
+++ b/.github/workflows/rollout-dashboard.yaml
@@ -109,7 +109,7 @@ jobs:
           context: rollout-dashboard
   publish-rollout-dashboard-container:
     name: Publish rollout dashboard container
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Also fix the automation to actually run.