### PR TITLE
fix: dynamically generate K8S_REPO_BRANCH name

### DIFF
--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -40,7 +40,7 @@ runs:
         git config user.email "idx@dfinity.org"
         git config user.name "IDX Automation"
         SOURCE_BRANCH="${{ github.head_ref || github.ref_name }}"
-        K8S_REPO_BRANCH="update-oncall-sync-$COMPONENT-images-from-$SOURCE_BRANCH"
+        K8S_REPO_BRANCH="update-$(basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH"
         base_regex='${{ inputs.text-prefix }}'
 
         if [ -n "$base_regex" ]


### PR DESCRIPTION
This change updates the `K8S_REPO_BRANCH` variable to dynamically include the repository name using `basename $GITHUB_REPOSITORY`. This ensures that each deployment branch is uniquely named based on the GitHub repository, enhancing organization and reducing potential naming conflicts. No new features are introduced.