### PR TITLE
Use latest DRE.

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -21,7 +21,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.subprocess import SubprocessHook, SubprocessResult
 
 DRE_URL = (
-    "https://github.com/dfinity/dre/releases/download/latest/dre-x86_64-unknown-linux"
+    "https://github.com/dfinity/dre/releases/latest/download/dre-x86_64-unknown-linux"
 )
 FAKE_PROPOSAL_NUMBER = -123456
 

--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -21,7 +21,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.subprocess import SubprocessHook, SubprocessResult
 
 DRE_URL = (
-    "https://github.com/dfinity/dre/releases/download/v0.5.9/dre-x86_64-unknown-linux"
+    "https://github.com/dfinity/dre/releases/download/latest/dre-x86_64-unknown-linux"
 )
 FAKE_PROPOSAL_NUMBER = -123456
 


### PR DESCRIPTION
To get this rolled out, worker containers must be restarted in the ch1-rel1 cluster.

This was a temporary measure now this needs to be reverted.