### PR TITLE
Pipelines are failing because Airflow 2.9.1 contains an issue in its Google provider.

### DIFF
--- a/.github/workflows/airflow-content.yaml
+++ b/.github/workflows/airflow-content.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test-airflow-content:
     name: Test Airflow content
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Test

--- a/bin/airflow
+++ b/bin/airflow
@@ -60,10 +60,10 @@ function setup_airflow_variables_and_connections() {
 if [ "$1" == "setup" ]
 then
     /usr/bin/python3 -m venv "$VENV_DIR"
-    "$VENV_DIR"/bin/pip3 install "apache-airflow[celery]==2.9.1" \
+    "$VENV_DIR"/bin/pip3 install "apache-airflow[celery]==2.10.5" \
         apache-airflow-providers-slack[common.sql] \
         apache-airflow-providers-google \
-        --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.9.1/constraints-3.11.txt
+        --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt
     mkdir -p "$AIRFLOW_HOME"
     if ! test -f "$AIRFLOW_HOME"/airflow.db
     then

--- a/bin/airflow
+++ b/bin/airflow
@@ -60,10 +60,10 @@ function setup_airflow_variables_and_connections() {
 if [ "$1" == "setup" ]
 then
     /usr/bin/python3 -m venv "$VENV_DIR"
-    "$VENV_DIR"/bin/pip3 install "apache-airflow[celery]==2.10.5" \
+    "$VENV_DIR"/bin/pip3 install "apache-airflow[celery]==2.9.1" \
         apache-airflow-providers-slack[common.sql] \
         apache-airflow-providers-google \
-        --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt
+        --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.9.1/constraints-3.11.txt
     mkdir -p "$AIRFLOW_HOME"
     if ! test -f "$AIRFLOW_HOME"/airflow.db
     then


### PR DESCRIPTION
While we are not ready to upgrade to latest Airflow, testing by using old setuptools (what ships in the Ubuntu 22.04 container) should address pipeline failure.