### PR TITLE
Ask the DRE tool to omit forum post link when upgrading unassigned nodes

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -291,6 +291,7 @@ class AuthenticatedDRE(DRE):
         """
         return self.run(
             "update-unassigned-nodes",
+            "--forum-post-link=omit",
             dry_run=dry_run,
             yes=True,
         )


### PR DESCRIPTION
This allows the default (which is `ask`) not to crash the tool when running it noninteractively.

Fixes this backtrace:

```
Error: IO error: not a terminal

Caused by:
    not a terminalError: IO error: not a terminal

Caused by:
    not a terminal

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: <dre::forum::impls::Discourse as dre::forum::ForumPostHandler>::forum_post::{{closure}}
   2: dre::submitter::Submitter::propose::{{closure}}
   3: dre::submitter::Submitter::propose_and_print::{{closure}}
   4: <dre::commands::main_command::Subcommands as dre::exe::ExecutableCommand>::execute::{{closure}}
   5: dre::main::{{closure}}
   6: tokio::runtime::park::CachedParkThread::block_on
   7: tokio::runtime::context::runtime::enter_runtime
   8: tokio::runtime::runtime::Runtime::block_on
   9: dre::main
  10: std::sys::backtrace::__rust_begin_short_backtrace
  11: std::rt::lang_start::{{closure}}
  12: std::rt::lang_start_internal
  13: main
  14: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  15: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  16: _start


Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: <dre::forum::impls::Discourse as dre::forum::ForumPostHandler>::forum_post::{{closure}}
   2: dre::submitter::Submitter::propose::{{closure}}
   3: dre::submitter::Submitter::propose_and_print::{{closure}}
   4: <dre::commands::main_command::Subcommands as dre::exe::ExecutableCommand>::execute::{{closure}}
   5: dre::main::{{closure}}
   6: tokio::runtime::park::CachedParkThread::block_on
   7: tokio::runtime::context::runtime::enter_runtime
   8: tokio::runtime::runtime::Runtime::block_on
   9: dre::main
  10: std::sys::backtrace::__rust_begin_short_backtrace
  11: std::rt::lang_start::{{closure}}
  12: std::rt::lang_start_internal
  13: main
  14: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  15: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
```