### PR TITLE
API boundary nodes rollout.

### DIFF
--- a/.github/workflows/airflow-content.yaml
+++ b/.github/workflows/airflow-content.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test-airflow-content:
     name: Test Airflow content
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Test

--- a/dags/auto_compute_rollout.py
+++ b/dags/auto_compute_rollout.py
@@ -9,7 +9,7 @@ import operators.auto_rollout as auto_rollout
 import operators.github_rollout as github_rollout
 import operators.gsheets_rollout as gsheets_rollout
 import pendulum
-from dfinity.ic_os_rollout import DEFAULT_PLANS, PLAN_FORM
+from dfinity.ic_os_rollout import DEFAULT_SUBNET_ROLLOUT_PLANS, PLAN_FORM
 from dfinity.ic_types import IC_NETWORKS
 
 from airflow import DAG
@@ -62,7 +62,7 @@ for network_name, network in IC_NETWORKS.items():
                 description="How many days to look back for releases in release index.",
             ),
             "plan": Param(
-                default=DEFAULT_PLANS[network_name].strip(),
+                default=DEFAULT_SUBNET_ROLLOUT_PLANS[network_name].strip(),
                 type="string",
                 title="Rollout plan",
                 description="A YAML-formatted string describing the rollout schedule.",
@@ -128,6 +128,5 @@ for network_name, network in IC_NETWORKS.items():
 
 
 if __name__ == "__main__":
-
     dag = DAGS["mainnet"]
     dag.test(run_conf={})

--- a/dags/deploy_ic_os_to_subnet.py
+++ b/dags/deploy_ic_os_to_subnet.py
@@ -76,7 +76,7 @@ for network_name, network in IC_NETWORKS.items():
                 task_id="wait_until_start_time",
                 target_time="{{ params.start_time }}",
             )
-            >> ic_os_rollout.CreateProposalIdempotently(
+            >> ic_os_rollout.CreateSubnetUpdateProposalIdempotently(
                 task_id="create_proposal_if_none_exists",
                 subnet_id="{{ params.subnet_id }}",
                 git_revision="{{ params.git_revision }}",

--- a/dags/rollout_ic_os_to_boundary_nodes.py
+++ b/dags/rollout_ic_os_to_boundary_nodes.py
@@ -1,0 +1,238 @@
+"""
+Rollout IC OS to boundary nodes in batches.
+"""
+
+import datetime
+import pprint
+import typing
+
+import dfinity.ic_types as ic_types
+import operators.ic_os_rollout as ic_os_rollout
+import pendulum
+import sensors.ic_os_rollout as ic_os_sensor
+from dfinity.ic_os_rollout import (
+    DEFAULT_BOUNDARY_NODE_ROLLOUT_PLANS,
+    PLAN_FORM,
+    boundary_node_batch_create,
+    boundary_node_batch_timetable,
+)
+from dfinity.rollout_types import ProposalInfo, yaml_to_BoundaryNodeRolloutPlanSpec
+
+from airflow.decorators import dag, task, task_group
+from airflow.models.baseoperator import chain
+from airflow.models.param import Param
+from airflow.models.taskinstance import TaskInstance
+from airflow.operators.empty import EmptyOperator
+from airflow.sensors.base import PokeReturnValue
+
+
+class DagParams(typing.TypedDict):
+    git_revision: str
+    plan: str
+    simulate: bool
+
+
+BatchSpec = tuple[datetime.datetime, list[str]]
+
+
+BATCH_COUNT: int = 20
+
+
+for network_name, network in ic_types.IC_NETWORKS.items():
+
+    @dag(
+        dag_id=f"rollout_ic_os_to_{network_name}_boundary_nodes",
+        schedule=None,
+        start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
+        catchup=False,
+        dagrun_timeout=datetime.timedelta(days=14),
+        tags=["rollout", "DRE", "IC OS", "boundary nodes"],
+        render_template_as_native_obj=True,
+        params={
+            "git_revision": Param(
+                "0000000000000000000000000000000000000000",
+                type="string",
+                pattern="^[a-f0-9]{40}$",
+                title="Main Git revision",
+                description="Git revision of the IC OS GuestOS release to roll out to"
+                " subnets, unless specified otherwise directly for a specific subnet;"
+                " the version must have been elected before but the rollout will check",
+            ),
+            "plan": Param(
+                default=DEFAULT_BOUNDARY_NODE_ROLLOUT_PLANS[network_name].strip(),
+                type="string",
+                title="Rollout plan",
+                description="A YAML-formatted string describing the rollout schedule",
+                custom_html_form=PLAN_FORM,
+            ),
+            "simulate": Param(
+                True,
+                type="boolean",
+                title="Simulate",
+                description="If enabled (the default), the update proposal will be"
+                " simulated but not created, and its acceptance will be simulated too",
+            ),
+        },
+    )
+    def rollout_ic_os_to_boundary_nodes() -> None:
+        retries = int(86400 / 60 / 5)  # one day worth of retries
+
+        @task()
+        def schedule(
+            params: DagParams,
+        ) -> list[BatchSpec]:
+            spec = yaml_to_BoundaryNodeRolloutPlanSpec(params["plan"])
+            timetable: list[datetime.datetime] = boundary_node_batch_timetable(
+                spec, batch_count=BATCH_COUNT
+            )
+            batches: list[list[str]] = boundary_node_batch_create(
+                spec["nodes"], batch_count=BATCH_COUNT
+            )
+            assert len(timetable) == len(batches), (
+                "The length of the timetable %s differs from the "
+                "length of the batches %s\ntimetable: %s\nbatches: %s"
+            ) % (len(timetable), len(batches), timetable, batches)
+            t = list(zip(timetable, batches))
+            print("Timetable:\n%s" % pprint.pformat(t))
+            return t
+
+        @task.branch
+        def prepare(
+            batch_num: int,
+            task_instance: TaskInstance,
+        ) -> list[str]:
+            timetable = typing.cast(
+                list[BatchSpec], task_instance.xcom_pull("schedule")
+            )
+            run = bool(timetable[batch_num][1])
+            if run:
+                print(
+                    "There are %s nodes for this batch, we must run."
+                    % len(timetable[batch_num][1])
+                )
+            else:
+                print("No nodes for this run, we will skip.")
+            return (
+                [f"batch_{batch_num+1}.wait_until_start_time"]
+                if run
+                else [f"batch_{batch_num+1}.join"]
+            )
+
+        @task.sensor(poke_interval=60, timeout=86400 * 7, mode="reschedule")
+        def wait_until_start_time(
+            batch_num: int,
+            task_instance: TaskInstance,
+            params: DagParams,
+        ) -> PokeReturnValue:
+            timetable = typing.cast(
+                list[BatchSpec], task_instance.xcom_pull("schedule")
+            )
+            until, nodes = timetable[batch_num]
+            if params["simulate"]:
+                print("Simulating waiting until %s", until)
+            else:
+                print("Waiting until", until)
+                now = datetime.datetime.now().replace(tzinfo=None)
+                if now < until:
+                    return PokeReturnValue(is_done=False)
+
+            return PokeReturnValue(is_done=True, xcom_value=nodes)
+
+        @task(retries=retries)
+        def create_proposal_if_none_exists(
+            nodes: list[str], params: DagParams
+        ) -> ProposalInfo:
+            git_revision = params["git_revision"]
+            return ic_os_rollout.create_boundary_nodes_proposal_if_none_exists(
+                nodes, git_revision, network, simulate=params["simulate"]
+            )
+
+        @task.sensor(
+            retries=retries, poke_interval=120, timeout=86400 * 7, mode="reschedule"
+        )
+        def wait_until_proposal_is_accepted(
+            nodes: list[str],
+            proposal_info: ProposalInfo,
+            params: DagParams,
+        ) -> PokeReturnValue:
+            return PokeReturnValue(
+                is_done=ic_os_sensor.has_proposal_executed(
+                    proposal_info, network, params["simulate"]
+                ),
+                xcom_value=nodes,
+            )
+
+        @task.sensor(
+            retries=retries, poke_interval=120, timeout=86400 * 7, mode="reschedule"
+        )
+        def wait_for_revision_adoption(
+            nodes: list[str], params: DagParams
+        ) -> PokeReturnValue:
+            return PokeReturnValue(
+                is_done=ic_os_sensor.have_boundary_nodes_adopted_revision(
+                    nodes, params["git_revision"], network
+                ),
+                xcom_value=nodes,
+            )
+
+        @task.sensor(
+            retries=retries, poke_interval=60, timeout=86400 * 7, mode="reschedule"
+        )
+        def wait_until_nodes_healthy(
+            nodes: list[str], params: DagParams
+        ) -> PokeReturnValue:
+            return PokeReturnValue(
+                is_done=ic_os_sensor.have_boundary_nodes_stopped_alerting(
+                    nodes, network
+                )
+            )
+
+        # Begin composition of the flow based on the operators above and imported.
+
+        timetable = schedule()
+
+        batches = []
+        for batch_index in range(BATCH_COUNT):
+
+            @task_group(group_id=f"batch_{batch_index+1}")
+            def batch(batch_index: int) -> None:
+                should_run = prepare(batch_index)
+                nodes_to_rollout = wait_until_start_time(batch_index)
+                chain(should_run, nodes_to_rollout)
+                proposed = create_proposal_if_none_exists(nodes_to_rollout)
+                announced = ic_os_rollout.RequestProposalVote(
+                    task_id="request_proposal_vote",
+                    source_task_id=f"batch_{batch_index+1}.create_proposal_if_none_exists",
+                    retries=retries,
+                )
+                accepted = wait_until_proposal_is_accepted(
+                    nodes=nodes_to_rollout, proposal_info=proposed
+                )
+                chain(proposed, announced)
+                adopted = wait_for_revision_adoption(nodes=nodes_to_rollout)
+                chain(accepted, adopted)
+                healthy = wait_until_nodes_healthy(nodes_to_rollout)
+                chain(adopted, healthy)
+                join = EmptyOperator(
+                    task_id="join",
+                    trigger_rule="none_failed_min_one_success",
+                )
+                chain([should_run, healthy, announced], join)
+
+            batches.append(batch(batch_index))
+
+        wait_for_election = ic_os_sensor.WaitForRevisionToBeElected(
+            task_id="wait_for_revision_to_be_elected",
+            simulate_elected=typing.cast(bool, "{{ params.simulate }}"),
+            network=network,
+            retries=retries,
+            git_revision=typing.cast(str, "{{ params.git_revision }}"),
+        )
+
+        wait_for_other_rollouts = ic_os_sensor.WaitForOtherDAGs(
+            task_id="wait_for_other_rollouts"
+        )
+
+        chain([timetable, wait_for_election, wait_for_other_rollouts], *batches)
+
+    rollout_ic_os_to_boundary_nodes()

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -31,10 +31,10 @@ with DAG(
         >> test_operator.TestTask(
             task_id="task_2",
         )
-        >> TimeDeltaSensorAsync(
+        >> TimeDeltaSensorAsync(  # type: ignore
             task_id="wait_2_minutes",
             delta=datetime.timedelta(minutes=2),
-        )  # type: ignore
+        )
         >> test_operator.TestTask(
             task_id="task_3",
         )

--- a/plugins/operators/auto_rollout.py
+++ b/plugins/operators/auto_rollout.py
@@ -146,7 +146,7 @@ class AutoComputeRolloutPlan(BaseOperator):
         ) -> SubnetNameOrNumberWithRevision:
             if isinstance(subnet, dict) and subnet.get("git_revision"):
                 # Manually overridden, return the same.
-                return cast(SubnetNameOrNumberWithRevision, subnet)
+                return subnet
 
             if isinstance(subnet, dict):
                 subnet = subnet["subnet"]

--- a/plugins/operators/auto_rollout.py
+++ b/plugins/operators/auto_rollout.py
@@ -9,9 +9,9 @@ import yaml
 from dfinity.rollout_types import (
     Releases,
     RolloutFeatures,
-    RolloutPlanSpec,
     SubnetNameOrNumber,
     SubnetNameOrNumberWithRevision,
+    SubnetRolloutPlanSpec,
 )
 
 from airflow.exceptions import DagRunAlreadyExists
@@ -28,7 +28,6 @@ def next_weekday(d: datetime.date, weekday: int) -> datetime.date:
 
 
 class AutoComputeRolloutPlan(BaseOperator):
-
     template_fields = ["max_days_lookbehind", "default_rollout_plan"]
 
     def __init__(
@@ -181,7 +180,7 @@ class AutoComputeRolloutPlan(BaseOperator):
             )
 
         # Now compute rollout map.
-        spec = cast(RolloutPlanSpec, yaml.safe_load(self.default_rollout_plan))
+        spec = cast(SubnetRolloutPlanSpec, yaml.safe_load(self.default_rollout_plan))
 
         for hours in spec.values():
             for subnets in hours.values():
@@ -206,7 +205,6 @@ class AutoComputeRolloutPlan(BaseOperator):
 
 
 class TriggerRollout(TriggerDagRunOperator):
-
     def __init__(
         self, plan_task_id: str, simulate_rollout: bool, *args: Any, **kwargs: Any
     ) -> None:

--- a/plugins/operators/ic_os_rollout.py
+++ b/plugins/operators/ic_os_rollout.py
@@ -13,8 +13,8 @@ from dfinity.ic_os_rollout import (
     DR_DRE_SLACK_ID,
     SLACK_CHANNEL,
     SLACK_CONNECTION_ID,
-    RolloutPlanWithRevision,
     SubnetIdWithRevision,
+    SubnetRolloutPlanWithRevision,
     assign_default_revision,
     check_plan,
     rollout_planner,
@@ -67,7 +67,7 @@ class ICRolloutBaseOperator(RolloutParams, BaseOperator):
         BaseOperator.__init__(self, task_id=task_id, **kwargs)
 
 
-class CreateProposalIdempotently(ICRolloutBaseOperator):
+class CreateSubnetUpdateProposalIdempotently(ICRolloutBaseOperator):
     template_fields = tuple(
         itertools.chain.from_iterable(
             (ICRolloutBaseOperator.template_fields, ("simulate_proposal",))
@@ -300,7 +300,7 @@ class UpgradeUnassignedNodes(BaseOperator):
 @task
 def schedule(
     network: ic_types.ICNetwork, **context: dict[str, Any]
-) -> RolloutPlanWithRevision:
+) -> SubnetRolloutPlanWithRevision:
     plan_data_structure = yaml.safe_load(
         context["task"].render_template(  # type: ignore
             "{{ params.plan }}",

--- a/plugins/operators/ic_os_rollout.py
+++ b/plugins/operators/ic_os_rollout.py
@@ -120,9 +120,7 @@ class CreateSubnetUpdateProposalIdempotently(ICRolloutBaseOperator):
             res = int(
                 prom.query_prometheus_servers(
                     self.network.prometheus_urls,
-                    "sum(ic_replica_info{"
-                    f'ic_subnet="{subnet_id}"'
-                    "}) by (ic_subnet)",
+                    f'sum(ic_replica_info{{ic_subnet="{subnet_id}"}}) by (ic_subnet)',
                 )[0]["value"]
             )
             self.log.info("Remembering current replica count (%s)...", res)
@@ -328,7 +326,7 @@ def schedule(
     )
 
     for nstr, (_, members) in plan.items():
-        print(f"Batch {int(nstr)+1}:")
+        print(f"Batch {int(nstr) + 1}:")
         for item in members:
             print(
                 f"    Subnet {item.subnet_id} ({item.subnet_num}) will start"
@@ -345,8 +343,8 @@ def schedule(
     return plan
 
 
-def create_boundary_nodes_proposal_if_none_exists(
-    boundary_node_ids: list[str],
+def create_api_boundary_nodes_proposal_if_none_exists(
+    api_boundary_node_ids: list[str],
     git_revision: str,
     network: ic_types.ICNetwork,
     simulate: bool,
@@ -362,8 +360,8 @@ def create_boundary_nodes_proposal_if_none_exists(
 
     # Get proposals sorted by proposal number.
     props = sorted(
-        runner.get_ic_os_version_deployment_proposals_for_boundary_nodes(
-            boundary_node_ids=boundary_node_ids,
+        runner.get_ic_os_version_deployment_proposals_for_api_boundary_nodes(
+            api_boundary_node_ids=api_boundary_node_ids,
         ),
         key=lambda prop: -prop["proposal_id"],
     )
@@ -436,13 +434,13 @@ def create_boundary_nodes_proposal_if_none_exists(
         }
 
     print(
-        f"Creating proposal for boundary nodes {boundary_node_ids} to "
+        f"Creating proposal for boundary nodes {api_boundary_node_ids} to "
         + f"adopt revision {git_revision} (simulate {simulate})."
     )
 
     proposal_number = (
-        runner.authenticated().propose_to_update_subnet_boundary_nodes_version(
-            boundary_node_ids, git_revision, dry_run=simulate
+        runner.authenticated().propose_to_update_api_boundary_nodes_version(
+            api_boundary_node_ids, git_revision, dry_run=simulate
         )
     )
 

--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -753,7 +753,7 @@ def have_boundary_nodes_adopted_revision(
     query = (
         "sum(ic_orchestrator_info{"
         + f'ic_node=~"{joined}"'
-        + "}) by (ic_active_version, ic_subnet)"
+        + "}) by (ic_active_version)"
     )
     print("::group::Querying Prometheus servers")
     print(query)

--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -727,7 +727,7 @@ def has_proposal_executed(
 
     # There is an open proposal, but not yet voted to execution.
     if simulate:
-        print("Simulating that the open proposal" " has been created and accepted.")
+        print("Simulating that the open proposal has been created and accepted.")
         return True
 
     print(
@@ -739,17 +739,16 @@ def has_proposal_executed(
     return False
 
 
-def have_boundary_nodes_adopted_revision(
-    boundary_node_ids: list[str],
+def have_api_boundary_nodes_adopted_revision(
+    api_boundary_node_ids: list[str],
     git_revision: str,
     network: ic_types.ICNetwork,
 ) -> bool:
     print(
-        "Waiting for specified boundary nodes to have"
-        f" adopted revision {git_revision}."
+        f"Waiting for specified boundary nodes to have adopted revision {git_revision}."
     )
 
-    joined = "|".join(boundary_node_ids)
+    joined = "|".join(api_boundary_node_ids)
     query = (
         "sum(ic_orchestrator_info{"
         + f'ic_node=~"{joined}"'
@@ -761,7 +760,7 @@ def have_boundary_nodes_adopted_revision(
     res = prom.query_prometheus_servers(network.prometheus_urls, query)
     if len(res) == 1 and res[0]["metric"]["ic_active_version"] == git_revision:
         current_replica_count = int(res[0]["value"])
-        if current_replica_count >= len(boundary_node_ids):
+        if current_replica_count >= len(api_boundary_node_ids):
             print(
                 "All %s boundary nodes have updated to revision %s."
                 % (
@@ -775,7 +774,7 @@ def have_boundary_nodes_adopted_revision(
                 "The updated boundary node count is %d but %d is expected; waiting."
                 % (
                     current_replica_count,
-                    len(boundary_node_ids),
+                    len(api_boundary_node_ids),
                 )
             )
     if res:
@@ -788,13 +787,13 @@ def have_boundary_nodes_adopted_revision(
     else:
         print(
             f"Upgrade has not begun yet -- Prometheus show no results for the"
-            f" specified boundary nodes {boundary_node_ids}."
+            f" specified boundary nodes {api_boundary_node_ids}."
         )
     return False
 
 
-def have_boundary_nodes_stopped_alerting(
-    boundary_node_ids: list[str],
+def have_api_boundary_nodes_stopped_alerting(
+    api_boundary_node_ids: list[str],
     network: ic_types.ICNetwork,
 ) -> bool:
     """
@@ -802,7 +801,7 @@ def have_boundary_nodes_stopped_alerting(
 
     Return True if no alerts, False otherwise.
     """
-    joineds = "|".join(boundary_node_ids)
+    joineds = "|".join(api_boundary_node_ids)
 
     print("Waiting for alerts on boundary nodes to subside.")
     query = """

--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -178,7 +178,8 @@ class WaitForProposalAcceptance(ICRolloutSensorBaseOperator):
         )
 
         def per_status(
-            props: list[ic_types.AbbrevProposal], status: ic_types.ProposalStatus
+            props: list[ic_types.AbbrevProposal],
+            status: ic_types.ProposalStatus,
         ) -> list[ic_types.AbbrevProposal]:
             return [p for p in props if p["status"] == status]
 

--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -179,9 +179,9 @@ class WaitForProposalAcceptance(ICRolloutSensorBaseOperator):
         )
 
         def per_status(
-            props: list[ic_types.AbbrevProposal],
+            props: list[ic_types.AbbrevSubnetUpdateProposal],
             status: ic_types.ProposalStatus,
-        ) -> list[ic_types.AbbrevProposal]:
+        ) -> list[ic_types.AbbrevSubnetUpdateProposal]:
             return [p for p in props if p["status"] == status]
 
         executeds = per_status(props, ic_types.ProposalStatus.PROPOSAL_STATUS_EXECUTED)

--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -10,6 +10,7 @@ from typing import Any, TypedDict, cast
 import dfinity.dre as dre
 import dfinity.ic_types as ic_types
 import dfinity.prom_api as prom
+import dfinity.rollout_types as rollout_types
 from dfinity.ic_os_rollout import (
     SLACK_CHANNEL,
     SLACK_CONNECTION_ID,
@@ -663,6 +664,169 @@ class WaitForPreconditions(ICRolloutSensorBaseOperator):
                 )
 
             self.log.info(f"It is now safe to continue with the update of {subnet_id}.")
+
+
+def has_proposal_executed(
+    proposal_info: rollout_types.ProposalInfo,
+    network: ic_types.ICNetwork,
+    simulate: bool,
+) -> bool:
+    """
+    Waits until a proposal matching the input parameters has been adopted.
+
+    Returns PokeReturnValue(is_done=bool) indicating whether that has happened or not.
+
+    Intended to be wrapped by an Airflow @task.sensor decorator.
+    """
+    props = dre.DRE(network=network, subprocess_hook=SubprocessHook()).get_proposals()
+
+    props = [p for p in props if p["proposal_id"] == proposal_info["proposal_id"]]
+
+    def per_status(
+        props: list[ic_types.AbbrevProposal],
+        status: ic_types.ProposalStatus,
+    ) -> list[ic_types.AbbrevProposal]:
+        return [p for p in props if p["status"] == status]
+
+    executeds = per_status(props, ic_types.ProposalStatus.PROPOSAL_STATUS_EXECUTED)
+    opens = per_status(props, ic_types.ProposalStatus.PROPOSAL_STATUS_OPEN)
+
+    if not opens and not executeds:
+        # No proposal exists.
+        if simulate:
+            # Ah, so this is why the proposal does not exist.
+            print(
+                "Simulating that the nonexistent proposal"
+                " has been created and accepted."
+                f" (simulate={simulate})"
+            )
+            return True
+
+        for p in props:
+            print(
+                "Matching proposal not open and not executed:"
+                f" {network.proposal_display_url}/{p}"
+            )
+
+        print(
+            "No matching proposal is either open or executed."
+            "  Waiting one minute until a proposal appears executed."
+        )
+        return False
+
+    if executeds:
+        for p in executeds:
+            print(f"Proposal: {p}")
+        print(
+            "Proposal"
+            f" {network.proposal_display_url}/{executeds[0]['proposal_id']}"
+            f" titled {executeds[0]['title']}"
+            " has executed.  We can proceed."
+        )
+        return False
+
+    # There is an open proposal, but not yet voted to execution.
+    if simulate:
+        print("Simulating that the open proposal" " has been created and accepted.")
+        return True
+
+    print(
+        "Proposal"
+        f" {network.proposal_display_url}/{opens[0]['proposal_id']}"
+        f" titled {opens[0]['title']}"
+        " is still open.  Waiting until it has executed."
+    )
+    return False
+
+
+def have_boundary_nodes_adopted_revision(
+    boundary_node_ids: list[str],
+    git_revision: str,
+    network: ic_types.ICNetwork,
+) -> bool:
+    print(
+        "Waiting for specified boundary nodes to have"
+        f" adopted revision {git_revision}."
+    )
+
+    joined = "|".join(boundary_node_ids)
+    query = (
+        "sum(ic_orchestrator_info{"
+        + f'ic_node=~"{joined}"'
+        + "}) by (ic_active_version, ic_subnet)"
+    )
+    print("::group::Querying Prometheus servers")
+    print(query)
+    print("::endgroup::")
+    res = prom.query_prometheus_servers(network.prometheus_urls, query)
+    if len(res) == 1 and res[0]["metric"]["ic_active_version"] == git_revision:
+        current_replica_count = int(res[0]["value"])
+        if current_replica_count >= len(boundary_node_ids):
+            print(
+                "All %s boundary nodes have updated to revision %s."
+                % (
+                    current_replica_count,
+                    git_revision,
+                )
+            )
+            return True
+        else:
+            print(
+                "The updated boundary node count is %d but %d is expected; waiting."
+                % (
+                    current_replica_count,
+                    len(boundary_node_ids),
+                )
+            )
+    if res:
+        print(
+            f"Upgrade of boundary nodes to {git_revision}"
+            " is not complete yet.  From Prometheus:"
+        )
+        for r in res:
+            print(r)
+    else:
+        print(
+            f"Upgrade has not begun yet -- Prometheus show no results for the"
+            f" specified boundary nodes {boundary_node_ids}."
+        )
+    return False
+
+
+def have_boundary_nodes_stopped_alerting(
+    boundary_node_ids: list[str],
+    network: ic_types.ICNetwork,
+) -> bool:
+    """
+    Check for 15 minutes of no alerts (pending or firing) on any of the BNs.
+
+    Return True if no alerts, False otherwise.
+    """
+    joineds = "|".join(boundary_node_ids)
+
+    print("Waiting for alerts on boundary nodes to subside.")
+    query = """
+        sum_over_time(
+            ALERTS{
+                ic_node=~"%(joineds)s",
+                severity="page"
+            }[15m]
+        )""" % (
+        {
+            "joineds": joineds,
+        }
+    )
+    print("::group::Querying Prometheus servers")
+    print(query)
+    print("::endgroup::")
+    res = prom.query_prometheus_servers(network.prometheus_urls, query)
+    if len(res) > 0:
+        print("There are still Prometheus alerts on the subnet:")
+        for r in res:
+            print(r)
+        return False
+    print("There are no more alerts on boundary nodes.")
+    return True
 
 
 if __name__ == "__main__":

--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -255,30 +255,30 @@ class DRE:
     def get_ic_os_version_deployment_proposals_for_boundary_nodes_and_revision(
         self,
         git_revision: str,
-        boundary_node_ids: list[str],
+        api_boundary_node_ids: list[str],
         limit: int = 1000,
-    ) -> list[ic_types.AbbrevBoundaryNodesUpdateProposal]:
+    ) -> list[ic_types.AbbrevApiBoundaryNodesUpdateProposal]:
         return [
             r
-            for r in self.get_ic_os_version_deployment_proposals_for_boundary_nodes(
-                boundary_node_ids,
+            for r in self.get_ic_os_version_deployment_proposals_for_api_boundary_nodes(
+                api_boundary_node_ids,
                 limit=limit,
             )
             if r["payload"]["version"] == git_revision
         ]
 
-    def get_ic_os_version_deployment_proposals_for_boundary_nodes(
+    def get_ic_os_version_deployment_proposals_for_api_boundary_nodes(
         self,
-        boundary_node_ids: list[str],
+        api_boundary_node_ids: list[str],
         limit: int = 1000,
-    ) -> list[ic_types.AbbrevBoundaryNodesUpdateProposal]:
+    ) -> list[ic_types.AbbrevApiBoundaryNodesUpdateProposal]:
         return [
-            cast(ic_types.AbbrevBoundaryNodesUpdateProposal, r)
+            cast(ic_types.AbbrevApiBoundaryNodesUpdateProposal, r)
             for r in self.get_proposals(
                 topic=ic_types.ProposalTopic.TOPIC_IC_OS_VERSION_DEPLOYMENT,
                 limit=limit,
             )
-            if all(x in r["payload"].get("node_ids", []) for x in boundary_node_ids)
+            if all(x in r["payload"].get("node_ids", []) for x in api_boundary_node_ids)
             and r["payload"].get("version") is not None
         ]
 
@@ -380,14 +380,14 @@ class AuthenticatedDRE(DRE):
                 f"its standard output: {r.output.rstrip()}"
             )
 
-    def propose_to_update_subnet_boundary_nodes_version(
+    def propose_to_update_api_boundary_nodes_version(
         self,
-        boundary_node_ids: list[str],
+        api_boundary_node_ids: list[str],
         git_revision: str,
         dry_run: bool = False,
     ) -> int:
         """
-        Create proposal to update subnet to a blessed version.
+        Create proposal to update some API boundary nodes.
 
         Args:
         * dry_run: if true, tell ic-admin to only simulate the proposal.
@@ -400,17 +400,17 @@ class AuthenticatedDRE(DRE):
         """
         git_revision_short = git_revision[:7]
         proposal_title = (
-            f"Update {len(boundary_node_ids)} API boundary node(s)"
+            f"Update {len(api_boundary_node_ids)} API boundary node(s)"
             f" to replica version {git_revision_short}"
         )
         proposal_summary = (
             f"""Update API boundary nodes to GuestOS version """
             f"""[{git_revision}]({self.network.release_display_url}/{git_revision})"""
             f"""\n\nMotivation: update the API boundary nodes"""
-            f""" {', '.join(boundary_node_ids)}."""
+            f""" {", ".join(api_boundary_node_ids)}."""
         )
         nodesparms: list[str] = []
-        for n in boundary_node_ids:
+        for n in api_boundary_node_ids:
             nodesparms.append("--nodes")
             nodesparms.append(n)
 

--- a/shared/dfinity/ic_os_rollout.py
+++ b/shared/dfinity/ic_os_rollout.py
@@ -12,6 +12,7 @@ from dfinity.ic_types import (
     SubnetRolloutInstanceWithRevision,
 )
 from dfinity.rollout_types import (
+    BoundaryNodeRolloutPlanSpec,
     SubnetNameOrNumber,
     SubnetNameOrNumberWithRevision,
     SubnetNumberWithRevision,
@@ -61,6 +62,45 @@ PLAN_FORM = """
            type="text"
            required="" rows="24">{value}</textarea>
 """
+# Corresponds to type BoundaryNodeRolloutPlanSpec.
+DEFAULT_BOUNDARY_NODE_ROLLOUT_PLANS: dict[str, str] = {
+    "mainnet": """
+# See documentation at the end of this configuration block.
+nodes:
+  - 4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae
+  - 4p3lu-7sy3a-ph47t-wlvb6-naehi-oki2f-pkokv-hovam-s5iul-sxvwk-3ae
+  - 5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae
+  - atrq6-prjsa-w2b32-gyukj-ivjd6-kc4gq-ufi6v-yier6-puxtx-n2ipp-fqe
+  - bcbz4-w2ogq-jt7xk-xd7b2-ylhei-ygp3n-pjpdy-253tu-fpn3s-f5asy-fqe
+  - bfj6y-cmhcf-6fxs7-ku2u4-tucww-b2eej-2dmap-snurk-3yaks-ss7xe-rae
+  - coqzx-lgyi2-hizw4-nax6t-mshs6-y4ml6-xon24-ioon4-rer4r-qtuan-cae
+  - dl74z-6vpps-k6bpu-5hjsj-fb6lb-34tsv-ue5gt-bdkjn-35pt5-fdu2a-rae
+  - ec62l-q44va-5lyw2-gbl4w-xcx55-c3qv4-q67vc-fu6s7-xpm2r-7tjrw-tae
+  - ek6px-kxr47-noli7-nyjql-au5uc-tmj3k-777mf-lfla5-k4xx4-msu3j-dae
+  - gvqb5-b2623-3twpd-mruy4-3grts-agp2t-wgmt4-hspvj-5oyl6-kje32-aqe
+  - jlifv-mddo3-zfwdc-x2wmu-xklbj-dai3i-3pvjy-j4hqm-sarqr-fhkq6-zae
+  - lwxeh-xayoz-wu5eb-hwraj-a3pew-yeioj-cnwat-5uow4-ugxkc-kx44o-4ae
+  - mbsyf-dtlsd-ccjq4-63rmh-u2lv7-dwxuq-ym6bk-63i2l-5uyki-zccek-mqe
+  - mj4qw-5oxqx-5jgpn-66re3-gzgjb-rphz5-hmwhc-ahaa5-vespc-s4maj-vqe
+  - pxxcj-h2sa5-q2yql-4j7od-jwtvq-uisnw-w2ox6-xtfqi-noxva-nlgxx-wqe
+  - q6hk7-hplmv-xsedz-5bv7n-vfkws-rjyel-ijhge-hx2zg-nk7wb-tzisp-xqe
+  - ubipk-gibrt-gr23n-u4mrg-iwgaa-4jz42-y6gt6-3htxw-3mq2m-dwhv2-pqe
+  - upg5h-ggk5u-6qxp7-ksz3r-osynn-z2wou-65klx-cuala-sd6y3-3lorr-dae
+  - yqbqe-whgvn-teyic-zvtln-rcolf-yztin-ecal6-smlwy-6imph-6isdn-qqe
+start_day: Wednesday
+resume_at: 9:00
+suspend_at: 17:00
+minimum_minutes_per_batch: 60
+"""
+    + (
+        "# "
+        + "# ".join(
+            textwrap.dedent(cast(str, BoundaryNodeRolloutPlanSpec.__doc__))
+            .strip()
+            .splitlines(True)
+        )
+    )
+}
 
 
 def week_planner(now: datetime.datetime | None = None) -> dict[str, datetime.datetime]:
@@ -154,6 +194,42 @@ def convert_timespec_or_minutes_to_datetime(
         return datetime.datetime.strptime(time_s, "%H:%M")
     except Exception as exc:
         raise ValueError(f"{org_time_s} is not a valid hh:mm time") from exc
+
+
+def next_day_of_the_week(
+    day_of_the_week: str, now: datetime.datetime | None = None
+) -> datetime.datetime:
+    """
+    Given a day of the week, create a date/time whose time is the same as now, but the
+    date is the same day of the week seven days from now.
+
+    If the given day of the week is the same as now, this will return a date/time
+    referring to today, rather than the next week.  To refer to the same day next week,
+    pass "X next week" as the day of the week.  To give a clearer example, if this
+    function runs at 14:00 of Monday, and the passed day of the week is "Monday",
+    then the returned date/time will be today (Monday) at 14:00.
+    """
+
+    if now is None:
+        now = datetime.datetime.now()
+    days = {
+        "Monday": now - datetime.timedelta(days=now.weekday()),
+        "Tuesday": now - datetime.timedelta(days=now.weekday() - 1),
+        "Wednesday": now - datetime.timedelta(days=now.weekday() - 2),
+        "Thursday": now - datetime.timedelta(days=now.weekday() - 3),
+        "Friday": now - datetime.timedelta(days=now.weekday() - 4),
+        "Saturday": now - datetime.timedelta(days=now.weekday() - 5),
+        "Sunday": now - datetime.timedelta(days=now.weekday() - 6),
+    }
+    for k, v in list(days.items()):
+        if v < now:
+            days[k] = v + datetime.timedelta(days=7)
+    for k, v in list(days.items()):
+        days[k + " next week"] = v + datetime.timedelta(days=7)
+    try:
+        return days[day_of_the_week]
+    except KeyError:
+        raise ValueError("Invalid day of the week %r" % day_of_the_week)
 
 
 def rollout_planner(
@@ -339,3 +415,191 @@ def check_plan(plan: SubnetRolloutPlanWithRevision) -> None:
                 )
                 % (pzp6e_start_time, uzr34_start_time, delta)
             )
+
+
+def boundary_node_batch_timetable(
+    spec: BoundaryNodeRolloutPlanSpec,
+    batch_count: int,
+    now: datetime.datetime | None = None,
+) -> list[datetime.datetime]:
+    """
+    Formulates a timetable (list of datetimes) with a batch_count number of elements
+    based on the plan spec passed, with each element respecting the time window
+    between resume_at and suspend_at of the spec, staggered by the number of
+    minimum_minutes_per_batch in the spec.  The start_day in the spec (optional)
+    defines which day is picked for the first item in the timetable -- if absent,
+    the day will correspond to now (or the value of now passed to this function).
+    """
+    if batch_count < 1:
+        raise ValueError("batch_count must be a positive integer")
+
+    run_at = convert_timespec_or_minutes_to_datetime(spec["resume_at"])
+    stop_at = convert_timespec_or_minutes_to_datetime(spec["suspend_at"])
+
+    increment = datetime.timedelta(minutes=spec["minimum_minutes_per_batch"])
+
+    if run_at < stop_at:
+        if increment > stop_at - run_at:
+            raise ValueError(
+                f"the minimum time per batch {increment} is smaller than the operating"
+                f" window of time {stop_at - run_at}"
+            )
+    elif run_at > stop_at:
+        if increment > run_at - stop_at:
+            raise ValueError(
+                f"the minimum time per batch {increment} is smaller than the operating"
+                f" window of time {run_at - stop_at}"
+            )
+    else:
+        raise ValueError(
+            f"cannot use the same resume and suspend times ({spec['resume_at']}"
+            f" and {spec['suspend_at']})"
+        )
+
+    if now is None:
+        now = datetime.datetime.now()
+
+    def at(now: datetime.datetime, tgt: datetime.datetime) -> datetime.datetime:
+        return now.replace(
+            hour=tgt.hour,
+            minute=tgt.minute,
+            second=tgt.second,
+            microsecond=tgt.microsecond,
+        )
+
+    def hm(d: datetime.datetime) -> float:
+        return d.hour * 3600 + d.minute * 60 + d.second + d.microsecond / 1000000
+
+    batch_start_time = (
+        at(
+            next_day_of_the_week(spec["start_day"], now=now),
+            run_at,
+        )
+        if "start_day" in spec
+        else at(now, run_at)
+    )
+    batches = []
+    tries = 0
+    for _ in range(batch_count):
+        while True:
+            tries = tries + 1
+            if tries > batch_count * 24 * 60 / spec["minimum_minutes_per_batch"]:
+                raise ValueError(
+                    "could not find a timetable in a reasonable amount of attempts"
+                )
+            run_at = at(batch_start_time, run_at)
+            stop_at = at(batch_start_time, stop_at)
+            if run_at > stop_at:
+                if batch_start_time < stop_at:
+                    run_at = run_at - datetime.timedelta(days=1)
+                elif batch_start_time >= run_at:
+                    stop_at = stop_at + datetime.timedelta(days=1)
+            if run_at <= batch_start_time <= (stop_at - increment):
+                break
+            batch_start_time = batch_start_time + increment
+        batches.append(batch_start_time)
+        batch_start_time = batch_start_time + increment
+    return batches
+
+
+def exponential_increase(
+    count: int,
+    batch_count: int,
+    increase_factor: float = 0.2,
+) -> list[int]:
+    """
+    Apportion a count (positive integer) of things into a number of
+    batches given by batch_count.  Returns a list of integers, batch_count
+    in length, where each item is the number of things to be processed in
+    that batch.
+
+    The apportionment of things to process per batch follows an exponential
+    increase given by the `increase_factor variable`.  The function will
+    ensure that the sum of integers returned always matches the `batch_count`
+    supplied by the caller.  Each batch returned will contain at least one
+    item, provided that the count is greater than the batch count, at the
+    expense of the apportionment curve, so if `count` is equal or slightly
+    higher than `batch_count`, the returned batch sizes will be mostly ones
+    with the small excess loaded to the end of the returned list.
+    """
+    try:
+        assert increase_factor > 0.0, "increase_factor must be a positive float"
+        assert count > 0, "count must be a positive integer"
+        assert batch_count > 0, "batch_count must be a positive integer"
+    except AssertionError as e:
+        raise ValueError(str(e))
+
+    batches: list[int] = [0 for _ in range(batch_count)]
+    remaining = count
+    for n, b in enumerate(batches):
+        if remaining > 0:
+            batches[n] = 1
+            remaining = remaining - 1
+        else:
+            break
+    if remaining == 0:
+        return batches
+
+    remaining_batches: list[float] = [1 + increase_factor]
+    while len(remaining_batches) < batch_count:
+        remaining_batches.append(remaining_batches[-1] * (1 + increase_factor))
+    scalefactor = sum(remaining_batches)
+    scaled = [b / scalefactor for b in remaining_batches]
+    rounded = [round(b * (count - sum(batches))) for b in scaled]
+
+    # Due to inevitable imprecision when rounded, we must fudge some values.
+    while sum(rounded) > count - len(batches):
+        for n, b in enumerate(rounded):
+            if b == 0:
+                continue
+            if sum(rounded) == count:
+                break
+            rounded[n] = rounded[n] - 1
+    while sum(rounded) < count - len(batches):
+        rounded[-1] = rounded[-1] + 1
+
+    while len(rounded) < len(batches):
+        rounded.insert(0, 0)
+    return [a + b for a, b in zip(batches, rounded)]
+
+
+def boundary_node_batch_create(
+    nodes: list[str], batch_count: int, increase_factor: float = 0.2
+) -> list[list[str]]:
+    """
+    Creates a list of batches from the provided node list.
+
+    The size of each batch follows an exponential distribution, with.
+    one caveat: each batch will have at least one node, provided that
+    there are sufficient nodes to apportion to each batch.
+    """
+    batch_sizes = exponential_increase(
+        len(nodes), batch_count, increase_factor=increase_factor
+    )
+    assert sum(batch_sizes) == len(nodes), (batch_sizes, nodes)
+    nodes = list(nodes)
+    batches: list[list[str]] = []
+    for sz in batch_sizes:
+        batches.append([])
+        while sz:
+            batches[-1].append(nodes.pop(0))
+            sz = sz - 1
+    assert not nodes, "nodes remaining after apportionment: %s" % nodes
+    return batches
+
+
+if __name__ == "__main__":
+    import pprint
+
+    pprint.pprint(
+        boundary_node_batch_timetable(
+            {
+                "nodes": ["abc"],
+                "start_day": "Monday",
+                "resume_at": "9:00",
+                "suspend_at": "18:00",
+                "minimum_minutes_per_batch": 60,
+            },
+            20,
+        )
+    )

--- a/shared/dfinity/ic_os_rollout.py
+++ b/shared/dfinity/ic_os_rollout.py
@@ -12,7 +12,7 @@ from dfinity.ic_types import (
     SubnetRolloutInstanceWithRevision,
 )
 from dfinity.rollout_types import (
-    BoundaryNodeRolloutPlanSpec,
+    ApiBoundaryNodeRolloutPlanSpec,
     SubnetNameOrNumber,
     SubnetNameOrNumberWithRevision,
     SubnetNumberWithRevision,
@@ -62,8 +62,8 @@ PLAN_FORM = """
            type="text"
            required="" rows="24">{value}</textarea>
 """
-# Corresponds to type BoundaryNodeRolloutPlanSpec.
-DEFAULT_BOUNDARY_NODE_ROLLOUT_PLANS: dict[str, str] = {
+# Corresponds to type ApiBoundaryNodeRolloutPlanSpec.
+DEFAULT_API_BOUNDARY_NODE_ROLLOUT_PLANS: dict[str, str] = {
     "mainnet": """
 # See documentation at the end of this configuration block.
 nodes:
@@ -95,7 +95,7 @@ minimum_minutes_per_batch: 60
     + (
         "# "
         + "# ".join(
-            textwrap.dedent(cast(str, BoundaryNodeRolloutPlanSpec.__doc__))
+            textwrap.dedent(cast(str, ApiBoundaryNodeRolloutPlanSpec.__doc__))
             .strip()
             .splitlines(True)
         )
@@ -303,17 +303,17 @@ def rollout_planner(
 
             if str(batch_index) in batches:
                 raise ValueError(
-                    f"batch {batch_index+1} requested by {date_and_time} has"
+                    f"batch {batch_index + 1} requested by {date_and_time} has"
                     f" already been assigned to a prior batch"
                 )
             if batch_index >= MAX_BATCHES:
                 raise ValueError(
-                    f"batch {batch_index+1} requested by {date_and_time} exceeds"
+                    f"batch {batch_index + 1} requested by {date_and_time} exceeds"
                     f" the maximum batch count of {MAX_BATCHES}"
                 )
             if batch_index < current_batch_index:
                 raise ValueError(
-                    f"batch {batch_index+1} requested by {date_and_time} is"
+                    f"batch {batch_index + 1} requested by {date_and_time} is"
                     f" lower than already-assigned batch {current_batch_index}"
                 )
 
@@ -368,7 +368,7 @@ def rollout_planner(
                 if bsn is not None:
                     raise ValueError(
                         f"subnet number {principal} requested by {date_and_time} is"
-                        f" already being rolled out as part of batch {bsn+1}"
+                        f" already being rolled out as part of batch {bsn + 1}"
                     )
                 batch_index_for_subnet[subnet_number] = batch_index
                 git_revision = subnet.get("git_revision")
@@ -417,8 +417,8 @@ def check_plan(plan: SubnetRolloutPlanWithRevision) -> None:
             )
 
 
-def boundary_node_batch_timetable(
-    spec: BoundaryNodeRolloutPlanSpec,
+def api_boundary_node_batch_timetable(
+    spec: ApiBoundaryNodeRolloutPlanSpec,
     batch_count: int,
     now: datetime.datetime | None = None,
 ) -> list[datetime.datetime]:
@@ -563,7 +563,7 @@ def exponential_increase(
     return [a + b for a, b in zip(batches, rounded)]
 
 
-def boundary_node_batch_create(
+def api_boundary_node_batch_create(
     nodes: list[str], batch_count: int, increase_factor: float = 0.2
 ) -> list[list[str]]:
     """
@@ -592,7 +592,7 @@ if __name__ == "__main__":
     import pprint
 
     pprint.pprint(
-        boundary_node_batch_timetable(
+        api_boundary_node_batch_timetable(
             {
                 "nodes": ["abc"],
                 "start_day": "Monday",

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -167,6 +167,11 @@ class ProposalTopic(Enum):
     ## Proposals related to rental of subnets (Utopia).
     ## TODO: verify the int corresponds to the proto.
     TOPIC_SUBNET_RENTAL = 16
+    # All proposals to manage protocol canisters, which are considered part of the
+    # ICP protocol and are essential for its proper functioning.
+    TOPIC_PROTOCOL_CANISTER_MANAGEMENT = 17
+    ## SNS management.
+    TOPIC_SERVICE_NERVOUS_SYSTEM_MANAGEMENT = 18
 
 
 class AbbrevProposal(TypedDict):
@@ -183,9 +188,53 @@ class AbbrevProposal(TypedDict):
                 '[b3b00ba59c366384e3e0cd53a69457e9053ec987](https:##dashboard.internetcomputer.org/release/b3b00ba59c366384e3e0cd53a69457e9053ec987)\n',
     'title': 'Update subnet 4zbus to replica version b3b00ba5',
     'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
+
+    could also be
+
+    {'proposal_id': 102768,
+    'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
+                'node_ids': ['4zbus-z2bmt-ilreg-'
+                    'xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe']},
+    'proposer': '80',
+    'status': 'EXECUTED',
+    'summary': 'Update 9 API boundary node(s) to '
+                'f8131bfbc2d339716a9cff06e04de49a68e5a80b '
+                '\n'nMotivation...',
+    'title': 'Update 9 API boundary node(s) to f8131bf',
+    'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
     """
 
     payload: dict[str, str]
+    proposal_id: int
+    proposer: int
+    status: ProposalStatus
+    summary: str
+    title: str
+    topic: ProposalTopic
+
+
+class AbbrevSubnetUpdateProposalPayload(TypedDict):
+    replica_version_id: str
+    subnet_id: str
+
+
+class AbbrevSubnetUpdateProposal(TypedDict):
+    """
+    {'proposal_id': 102768,
+    'payload': {'replica_version_id': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
+                'subnet_id': ('4zbus-z2bmt-ilreg-'
+                    'xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe')},
+    'proposer': '80',
+    'status': 'EXECUTED',
+    'summary': 'Update subnet '
+                '4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe '
+                'to replica version '
+                '[b3b00ba59c366384e3e0cd53a69457e9053ec987](https:##dashboard.internetcomputer.org/release/b3b00ba59c366384e3e0cd53a69457e9053ec987)\n',
+    'title': 'Update subnet 4zbus to replica version b3b00ba5',
+    'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
+    """
+
+    payload: AbbrevSubnetUpdateProposalPayload
     proposal_id: int
     proposer: int
     status: ProposalStatus

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -254,10 +254,10 @@ class AbbrevBoundaryNodesUpdateProposal(TypedDict):
                 'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
     'proposer': '80',
     'status': 'EXECUTED',
-    'summary': 'Update 9 API boundary node(s) to '
+    'summary': 'Update 1 API boundary node(s) to '
                 'f8131bfbc2d339716a9cff06e04de49a68e5a80b '
                 '\n'nMotivation...',
-    'title': 'Update 9 API boundary node(s) to f8131bf',
+    'title': 'Update 1 API boundary node(s) to f8131bf',
     'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
     """
 

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -241,3 +241,32 @@ class AbbrevSubnetUpdateProposal(TypedDict):
     summary: str
     title: str
     topic: ProposalTopic
+
+
+class AbbrevBoundaryNodesUpdateProposalPayload(TypedDict):
+    version: str
+    boundary_node_ids: str
+
+
+class AbbrevBoundaryNodesUpdateProposal(TypedDict):
+    """
+    {'proposal_id': 102768,
+    'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
+                'node_ids': ['4zbus-z2bmt-ilreg-'
+                    'xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe']},
+    'proposer': '80',
+    'status': 'EXECUTED',
+    'summary': 'Update 9 API boundary node(s) to '
+                'f8131bfbc2d339716a9cff06e04de49a68e5a80b '
+                '\n'nMotivation...',
+    'title': 'Update 9 API boundary node(s) to f8131bf',
+    'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
+    """
+
+    payload: AbbrevBoundaryNodesUpdateProposalPayload
+    proposal_id: int
+    proposer: int
+    status: ProposalStatus
+    summary: str
+    title: str
+    topic: ProposalTopic

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -193,8 +193,7 @@ class AbbrevProposal(TypedDict):
 
     {'proposal_id': 102768,
     'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
-                'node_ids': ['4zbus-z2bmt-ilreg-'
-                    'xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe']},
+                'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
     'proposer': '80',
     'status': 'EXECUTED',
     'summary': 'Update 9 API boundary node(s) to '

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -196,7 +196,7 @@ class AbbrevProposal(TypedDict):
                 'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
     'proposer': '80',
     'status': 'EXECUTED',
-    'summary': 'Update 9 API boundary node(s) to '
+    'summary': 'Update 1 API boundary node(s) to '
                 'f8131bfbc2d339716a9cff06e04de49a68e5a80b '
                 '\n'nMotivation...',
     'title': 'Update 1 API boundary node(s) to f8131bf',

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -199,7 +199,7 @@ class AbbrevProposal(TypedDict):
     'summary': 'Update 9 API boundary node(s) to '
                 'f8131bfbc2d339716a9cff06e04de49a68e5a80b '
                 '\n'nMotivation...',
-    'title': 'Update 9 API boundary node(s) to f8131bf',
+    'title': 'Update 1 API boundary node(s) to f8131bf',
     'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
     """
 

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -244,12 +244,12 @@ class AbbrevSubnetUpdateProposal(TypedDict):
     topic: ProposalTopic
 
 
-class AbbrevBoundaryNodesUpdateProposalPayload(TypedDict):
+class AbbrevApiBoundaryNodesUpdateProposalPayload(TypedDict):
     version: str
-    boundary_node_ids: str
+    api_boundary_node_ids: str
 
 
-class AbbrevBoundaryNodesUpdateProposal(TypedDict):
+class AbbrevApiBoundaryNodesUpdateProposal(TypedDict):
     """
     {'proposal_id': 102768,
     'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
@@ -265,7 +265,7 @@ class AbbrevBoundaryNodesUpdateProposal(TypedDict):
     'topic': 'TOPIC_IC_OS_VERSION_DEPLOYMENT'}
     """
 
-    payload: AbbrevBoundaryNodesUpdateProposalPayload
+    payload: AbbrevApiBoundaryNodesUpdateProposalPayload
     proposal_id: int
     proposer: int
     status: ProposalStatus

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -193,7 +193,9 @@ class AbbrevProposal(TypedDict):
 
     {'proposal_id': 102768,
     'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
-                'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
+                'node_ids': [
+                '4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae'
+                ]},
     'proposer': '80',
     'status': 'EXECUTED',
     'summary': 'Update 1 API boundary node(s) to '
@@ -251,7 +253,9 @@ class AbbrevBoundaryNodesUpdateProposal(TypedDict):
     """
     {'proposal_id': 102768,
     'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
-                'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
+                'node_ids': [
+                '4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae'
+                ]},
     'proposer': '80',
     'status': 'EXECUTED',
     'summary': 'Update 1 API boundary node(s) to '

--- a/shared/dfinity/ic_types.py
+++ b/shared/dfinity/ic_types.py
@@ -251,8 +251,7 @@ class AbbrevBoundaryNodesUpdateProposal(TypedDict):
     """
     {'proposal_id': 102768,
     'payload': {'version': 'b3b00ba59c366384e3e0cd53a69457e9053ec987',
-                'node_ids': ['4zbus-z2bmt-ilreg-'
-                    'xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe']},
+                'node_ids': ['4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae']},
     'proposer': '80',
     'status': 'EXECUTED',
     'summary': 'Update 9 API boundary node(s) to '

--- a/shared/dfinity/rollout_types.py
+++ b/shared/dfinity/rollout_types.py
@@ -92,7 +92,7 @@ SubnetRolloutPlanSpec = dict[
 ]
 
 
-class BoundaryNodeRolloutPlanSpec(TypedDict):
+class ApiBoundaryNodeRolloutPlanSpec(TypedDict):
     """
     Represents the shape of the rollout plan for boundary nodes input into Airflow
     by the operator.
@@ -124,7 +124,7 @@ class BoundaryNodeRolloutPlanSpec(TypedDict):
     minimum_minutes_per_batch: int
 
 
-def yaml_to_BoundaryNodeRolloutPlanSpec(s: str) -> BoundaryNodeRolloutPlanSpec:
+def yaml_to_ApiBoundaryNodeRolloutPlanSpec(s: str) -> ApiBoundaryNodeRolloutPlanSpec:
     try:
         d = yaml.safe_load(s)
     except Exception as e:
@@ -134,18 +134,18 @@ def yaml_to_BoundaryNodeRolloutPlanSpec(s: str) -> BoundaryNodeRolloutPlanSpec:
         assert "nodes" in d, "expected a nodes key"
         assert "resume_at" in d, "expected a resume_at key"
         assert "suspend_at" in d, "expected a suspend_at key"
-        assert (
-            "minimum_minutes_per_batch" in d
-        ), "expected a minimum_minutes_per_batch key"
+        assert "minimum_minutes_per_batch" in d, (
+            "expected a minimum_minutes_per_batch key"
+        )
         assert d["nodes"], "nodes cannot be empty"
         for node in d["nodes"]:
             assert isinstance(node, str), "node principal %r is not a string" % node
-        assert isinstance(d["resume_at"], str) or isinstance(
-            d["resume_at"], int
-        ), "resume_at must be an HH:MM string or a number of minutes"
-        assert isinstance(d["suspend_at"], str) or isinstance(
-            d["suspend_at"], int
-        ), "suspend_at must be an HH:MM string or a number of minutes"
+        assert isinstance(d["resume_at"], str) or isinstance(d["resume_at"], int), (
+            "resume_at must be an HH:MM string or a number of minutes"
+        )
+        assert isinstance(d["suspend_at"], str) or isinstance(d["suspend_at"], int), (
+            "suspend_at must be an HH:MM string or a number of minutes"
+        )
         assert (
             isinstance(d["minimum_minutes_per_batch"], int)
             and d["minimum_minutes_per_batch"] > 0
@@ -160,7 +160,7 @@ def yaml_to_BoundaryNodeRolloutPlanSpec(s: str) -> BoundaryNodeRolloutPlanSpec:
                 datetime.datetime.strptime(d["start_day"], "%A next week")
             except ValueError:
                 raise ValueError("invalid start_day value: %s" % d["start_day"]) from e
-    return cast(BoundaryNodeRolloutPlanSpec, d)
+    return cast(ApiBoundaryNodeRolloutPlanSpec, d)
 
 
 class ProposalInfo(TypedDict):

--- a/shared/dfinity/rollout_types.py
+++ b/shared/dfinity/rollout_types.py
@@ -49,7 +49,39 @@ class SubnetOrderSpec(TypedDict):
     batch: int | None
 
 
-RolloutPlanSpec = dict[
+SubnetRolloutPlanSpec_doc: str = """\
+Represents the rollout plan for subnet rollouts.
+
+Remarks:
+* All times are expressed in the UTC time zone.
+* Days refer to dates relative to your current work week
+  if starting a rollout during a workday, or next week if
+  the rollout is started during a weekend.
+* A day name with " next week" added at the end means
+  "add one week to this day".
+* Each date/time can specify a simple list of subnets,
+  or can specify a dict with two keys:
+  * batch: an optional integer 1-30 with the batch number
+           you want to assign to this batch.
+  * subnets: a list of subnets.
+* A subnet may be specified:
+  * as an integer number from 0 to the maximum subnet number,
+  * as a full or abbreviated subnet principal ID,
+  * as a dictionary of {
+       subnet: ID or principal
+       git_revision: revision to deploy to this subnet
+    }
+    with this form being able to override the Git revision
+    that will be targeted to that specific subnet.
+    Example of a batch specified this way:
+      Monday next week:
+        7:00:
+          batch: 30
+          subnets:
+          - subnet: tdb26
+            git_revision: 0123456789012345678901234567890123456789
+"""
+SubnetRolloutPlanSpec = dict[
     str,
     dict[
         str | int,

--- a/shared/dfinity/rollout_types.py
+++ b/shared/dfinity/rollout_types.py
@@ -1,5 +1,7 @@
 import datetime
-from typing import TypedDict
+from typing import NotRequired, TypedDict, cast
+
+import yaml
 
 GitCommit = str
 FeatureName = str
@@ -88,3 +90,80 @@ SubnetRolloutPlanSpec = dict[
         list[SubnetNameOrNumber | SubnetNameOrNumberWithRevision] | SubnetOrderSpec,
     ],
 ]
+
+
+class BoundaryNodeRolloutPlanSpec(TypedDict):
+    """
+    Represents the shape of the rollout plan for boundary nodes input into Airflow
+    by the operator.
+
+    All keys are required except for start_day.
+
+    Remarks:
+    * The nodes key contains a list of all boundary nodes to be
+      rolled out to.  These will be batched (in the given order) into
+      batches of one or more, to fit a total maximum of 20 batches.
+      The largest batches will occur at the end.
+    * The minimum_minutes_per_batch key indicates how fast we can go.
+      The default 60 minutes ensures batches are spaced a minimum of
+      60 minutes apart.
+    * The start_day key indicates the weekday (in English) when the
+      first batch of the rollout should start being rolled out.
+      If left unspecified, it corresponds to today.
+    * Batches are rolled out between the times specified in the
+      resume_at and the suspend_at keys (in HH:MM format).  The time
+      window between resume_at and suspend_at must be large enough
+      to fit the minimum_minutes_per_batch value.
+    * All times are UTC.
+    """
+
+    nodes: list[str]
+    start_day: NotRequired[str]
+    resume_at: str
+    suspend_at: str
+    minimum_minutes_per_batch: int
+
+
+def yaml_to_BoundaryNodeRolloutPlanSpec(s: str) -> BoundaryNodeRolloutPlanSpec:
+    try:
+        d = yaml.safe_load(s)
+    except Exception as e:
+        raise ValueError(str(e)) from e
+    try:
+        assert isinstance(d, dict), "expected a dictionary of keys and values"
+        assert "nodes" in d, "expected a nodes key"
+        assert "resume_at" in d, "expected a resume_at key"
+        assert "suspend_at" in d, "expected a suspend_at key"
+        assert (
+            "minimum_minutes_per_batch" in d
+        ), "expected a minimum_minutes_per_batch key"
+        assert d["nodes"], "nodes cannot be empty"
+        for node in d["nodes"]:
+            assert isinstance(node, str), "node principal %r is not a string" % node
+        assert isinstance(d["resume_at"], str) or isinstance(
+            d["resume_at"], int
+        ), "resume_at must be an HH:MM string or a number of minutes"
+        assert isinstance(d["suspend_at"], str) or isinstance(
+            d["suspend_at"], int
+        ), "suspend_at must be an HH:MM string or a number of minutes"
+        assert (
+            isinstance(d["minimum_minutes_per_batch"], int)
+            and d["minimum_minutes_per_batch"] > 0
+        ), "minimum_minutes_per_batch must be a positive integer"
+    except AssertionError as e:
+        raise ValueError(str(e)) from e
+    if "start_day" in d:
+        try:
+            datetime.datetime.strptime(d["start_day"], "%A")
+        except ValueError as e:
+            try:
+                datetime.datetime.strptime(d["start_day"], "%A next week")
+            except ValueError:
+                raise ValueError("invalid start_day value: %s" % d["start_day"]) from e
+    return cast(BoundaryNodeRolloutPlanSpec, d)
+
+
+class ProposalInfo(TypedDict):
+    proposal_id: int
+    proposal_url: str
+    needs_vote: bool

--- a/tests/test_ic_os_rollout.py
+++ b/tests/test_ic_os_rollout.py
@@ -3,14 +3,14 @@ import typing
 import unittest
 
 from dfinity.ic_os_rollout import (
-    boundary_node_batch_create,
-    boundary_node_batch_timetable,
+    api_boundary_node_batch_create,
+    api_boundary_node_batch_timetable,
     exponential_increase,
     next_day_of_the_week,
 )
 
 
-class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
+class TestApiBoundaryNodeRolloutPlanSpec(unittest.TestCase):
     def test_various_days(self) -> None:
         """Tests that a valid rollout plan spec works."""
         now = datetime.datetime(2025, 6, 12, 11, 59, 10)  # This is a Thursday
@@ -37,7 +37,7 @@ def fmtdate(d: datetime.datetime, day: bool = False) -> str:
     return d.strftime("%A %H:%M")
 
 
-class TestBoundaryNodeBatchTimetable(unittest.TestCase):
+class TestApiBoundaryNodeBatchTimetable(unittest.TestCase):
     maxDiff = None
 
     def test_simple_case(self) -> None:
@@ -71,7 +71,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Saturday 09:00",
             "Saturday 10:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 20, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 20, now=now)]
         self.assertListEqual(exp, res)
 
     def test_tight_night_case(self) -> None:
@@ -105,7 +105,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Saturday 21:00",
             "Saturday 22:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 20, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 20, now=now)]
         self.assertListEqual(exp, res)
 
     def test_night_case(self) -> None:
@@ -127,7 +127,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Friday 23:00",
             "Saturday 00:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 8, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 8, now=now)]
         self.assertListEqual(exp, res)
 
     def test_barely_fits_in_window(self) -> None:
@@ -144,7 +144,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Friday 21:00",
             "Saturday 21:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 3, now=now)]
         self.assertListEqual(exp, res)
 
     def test_does_not_fit_in_window(self) -> None:
@@ -157,7 +157,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "minimum_minutes_per_batch": 121,
         }
         self.assertRaises(
-            ValueError, lambda: boundary_node_batch_timetable(plan, 3, now=now)
+            ValueError, lambda: api_boundary_node_batch_timetable(plan, 3, now=now)
         )
 
     def test_absent_start_day(self) -> None:
@@ -173,7 +173,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Thursday 21:00",
             "Friday 21:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 3, now=now)]
         self.assertListEqual(exp, res)
 
     def test_starts_tomorrow(self) -> None:
@@ -190,7 +190,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
             "Friday 21:00",
             "Saturday 21:00",
         ]
-        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        res = [fmtdate(d) for d in api_boundary_node_batch_timetable(plan, 3, now=now)]
         self.assertListEqual(exp, res)
 
     def test_starts_next_week_tomorrow(self) -> None:
@@ -212,7 +212,7 @@ class TestBoundaryNodeBatchTimetable(unittest.TestCase):
         ]
         res = [
             fmtdate(d, day=True)
-            for d in boundary_node_batch_timetable(plan, 3, now=now)
+            for d in api_boundary_node_batch_timetable(plan, 3, now=now)
         ]
         self.assertListEqual(exp, res)
 
@@ -249,7 +249,7 @@ class TestExponentialIncrease(unittest.TestCase):
         )
 
 
-class TestBoundaryNodeBatchCreate(unittest.TestCase):
+class TestApiBoundaryNodeBatchCreate(unittest.TestCase):
     def expect(
         self,
         expected: list[str],
@@ -261,7 +261,7 @@ class TestBoundaryNodeBatchCreate(unittest.TestCase):
             expected,
             [
                 "".join(x)
-                for x in boundary_node_batch_create(nodes, batch_count, **kwargs)
+                for x in api_boundary_node_batch_create(nodes, batch_count, **kwargs)
             ],
         )
 

--- a/tests/test_ic_os_rollout.py
+++ b/tests/test_ic_os_rollout.py
@@ -1,0 +1,283 @@
+import datetime
+import typing
+import unittest
+
+from dfinity.ic_os_rollout import (
+    boundary_node_batch_create,
+    boundary_node_batch_timetable,
+    exponential_increase,
+    next_day_of_the_week,
+)
+
+
+class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
+    def test_various_days(self) -> None:
+        """Tests that a valid rollout plan spec works."""
+        now = datetime.datetime(2025, 6, 12, 11, 59, 10)  # This is a Thursday
+        for inp, exp in [
+            ("Thursday", 12),
+            ("Friday", 13),
+            ("Saturday", 14),
+            ("Sunday", 15),
+            ("Monday", 16),
+            ("Tuesday", 17),
+            ("Wednesday", 18),
+            ("Thursday next week", 19),
+        ]:
+            res = next_day_of_the_week(inp, now=now).day
+            assert res == exp, f"inp: res != exp ({inp}: {res} != {exp})"
+
+    def test_invalid_day(self) -> None:
+        self.assertRaises(ValueError, lambda: next_day_of_the_week("Everyday"))
+
+
+def fmtdate(d: datetime.datetime, day: bool = False) -> str:
+    if day:
+        return d.strftime("%A %d %H:%M")
+    return d.strftime("%A %H:%M")
+
+
+class TestBoundaryNodeBatchTimetable(unittest.TestCase):
+    maxDiff = None
+
+    def test_simple_case(self) -> None:
+        now = datetime.datetime(2025, 6, 12, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "start_day": "Thursday",
+            "resume_at": "9:00",
+            "suspend_at": "18:00",
+            "minimum_minutes_per_batch": 60,
+        }
+        exp = [
+            "Thursday 09:00",
+            "Thursday 10:00",
+            "Thursday 11:00",
+            "Thursday 12:00",
+            "Thursday 13:00",
+            "Thursday 14:00",
+            "Thursday 15:00",
+            "Thursday 16:00",
+            "Thursday 17:00",
+            "Friday 09:00",
+            "Friday 10:00",
+            "Friday 11:00",
+            "Friday 12:00",
+            "Friday 13:00",
+            "Friday 14:00",
+            "Friday 15:00",
+            "Friday 16:00",
+            "Friday 17:00",
+            "Saturday 09:00",
+            "Saturday 10:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 20, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_tight_night_case(self) -> None:
+        now = datetime.datetime(2025, 6, 12, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "start_day": "Thursday",
+            "resume_at": "21:00",
+            "suspend_at": "6:59",
+            "minimum_minutes_per_batch": 60,
+        }
+        exp = [
+            "Thursday 21:00",
+            "Thursday 22:00",
+            "Thursday 23:00",
+            "Friday 00:00",
+            "Friday 01:00",
+            "Friday 02:00",
+            "Friday 03:00",
+            "Friday 04:00",
+            "Friday 05:00",
+            "Friday 21:00",
+            "Friday 22:00",
+            "Friday 23:00",
+            "Saturday 00:00",
+            "Saturday 01:00",
+            "Saturday 02:00",
+            "Saturday 03:00",
+            "Saturday 04:00",
+            "Saturday 05:00",
+            "Saturday 21:00",
+            "Saturday 22:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 20, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_night_case(self) -> None:
+        now = datetime.datetime(2025, 6, 12, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "start_day": "Thursday",
+            "resume_at": "21:00",
+            "suspend_at": "1:00",
+            "minimum_minutes_per_batch": 60,
+        }
+        exp = [
+            "Thursday 21:00",
+            "Thursday 22:00",
+            "Thursday 23:00",
+            "Friday 00:00",
+            "Friday 21:00",
+            "Friday 22:00",
+            "Friday 23:00",
+            "Saturday 00:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 8, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_barely_fits_in_window(self) -> None:
+        now = datetime.datetime(2025, 6, 12, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "start_day": "Thursday",
+            "resume_at": "21:00",
+            "suspend_at": "23:00",
+            "minimum_minutes_per_batch": 120,
+        }
+        exp = [
+            "Thursday 21:00",
+            "Friday 21:00",
+            "Saturday 21:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_does_not_fit_in_window(self) -> None:
+        now = datetime.datetime(2025, 6, 12, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "start_day": "Thursday",
+            "resume_at": "21:00",
+            "suspend_at": "23:00",
+            "minimum_minutes_per_batch": 121,
+        }
+        self.assertRaises(
+            ValueError, lambda: boundary_node_batch_timetable(plan, 3, now=now)
+        )
+
+    def test_absent_start_day(self) -> None:
+        now = datetime.datetime(2025, 6, 11, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "resume_at": "21:00",
+            "suspend_at": "23:00",
+            "minimum_minutes_per_batch": 120,
+        }
+        exp = [
+            "Wednesday 21:00",
+            "Thursday 21:00",
+            "Friday 21:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_starts_tomorrow(self) -> None:
+        now = datetime.datetime(2025, 6, 11, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "resume_at": "21:00",
+            "start_day": "Thursday",
+            "suspend_at": "23:00",
+            "minimum_minutes_per_batch": 120,
+        }
+        exp = [
+            "Thursday 21:00",
+            "Friday 21:00",
+            "Saturday 21:00",
+        ]
+        res = [fmtdate(d) for d in boundary_node_batch_timetable(plan, 3, now=now)]
+        self.assertListEqual(exp, res)
+
+    def test_starts_next_week_tomorrow(self) -> None:
+        """
+        Test that a plan computed Wed 11th for Thu next week starts the 19th.
+        """
+        now = datetime.datetime(2025, 6, 11, 14, 33, 16)
+        plan = {
+            "nodes": ["abc"],
+            "resume_at": "21:00",
+            "start_day": "Thursday next week",
+            "suspend_at": "23:00",
+            "minimum_minutes_per_batch": 120,
+        }
+        exp = [
+            "Thursday 19 21:00",
+            "Friday 20 21:00",
+            "Saturday 21 21:00",
+        ]
+        res = [
+            fmtdate(d, day=True)
+            for d in boundary_node_batch_timetable(plan, 3, now=now)
+        ]
+        self.assertListEqual(exp, res)
+
+
+class TestExponentialIncrease(unittest.TestCase):
+    def expect(
+        self, expected: str, count: int, batch_count: int, **kwargs: typing.Any
+    ) -> None:
+        self.assertEqual(
+            expected,
+            " ".join(
+                str(s) for s in exponential_increase(count, batch_count, **kwargs)
+            ),
+        )
+
+    def test_basic(self) -> None:
+        self.expect("1 1 1 1 1", count=5, batch_count=5)
+
+    def test_basic_increase(self) -> None:
+        self.expect("2 2 2 2 2", count=10, batch_count=5)
+
+    def test_basic_big_increase(self) -> None:
+        self.expect("3 3 4 4 6", count=20, batch_count=5)
+
+    def test_count_lower_than_batch_count(self) -> None:
+        self.expect("1 1 1 0 0", count=3, batch_count=5)
+
+    def test_large(self) -> None:
+        self.expect("7 8 10 11 14", count=50, batch_count=5)
+
+    def test_sharper_knee(self) -> None:
+        self.expect(
+            "1 1 1 1 2 3 4 6 9 22", count=50, batch_count=10, increase_factor=0.5
+        )
+
+
+class TestBoundaryNodeBatchCreate(unittest.TestCase):
+    def expect(
+        self,
+        expected: list[str],
+        nodes: list[str],
+        batch_count: int,
+        **kwargs: typing.Any,
+    ) -> None:
+        self.assertListEqual(
+            expected,
+            [
+                "".join(x)
+                for x in boundary_node_batch_create(nodes, batch_count, **kwargs)
+            ],
+        )
+
+    def test_basic(self) -> None:
+        self.expect(["a", "bc"], list("abc"), 2)
+
+    def test_twenty_items_in_twenty_batches(self) -> None:
+        self.expect(
+            list("abcdefghijklmnopqrst"),
+            list("abcdefghijklmnopqrst"),
+            20,
+        )
+
+    def test_twenty_six_items_in_twenty_batches(self) -> None:
+        self.expect(
+            list("abcdefghijklmnop") + ["qr", "st", "uv", "wxyz"],
+            list("abcdefghijklmnopqrstuvwxyz"),
+            20,
+        )

--- a/tests/test_ic_os_rollout_operators.py
+++ b/tests/test_ic_os_rollout_operators.py
@@ -2,15 +2,20 @@ import contextlib
 import unittest
 
 import mock
-from dfinity.ic_types import IC_NETWORKS, AbbrevProposal, ProposalStatus, ProposalTopic
-from operators.ic_os_rollout import CreateProposalIdempotently
+from dfinity.ic_types import (
+    IC_NETWORKS,
+    AbbrevProposal,
+    ProposalStatus,
+    ProposalTopic,
+)
+from operators.ic_os_rollout import CreateSubnetUpdateProposalIdempotently
 
 
 class TestOperators(unittest.TestCase):
     def test_instantiation(self) -> None:
         sid = "qn2sv-gibnj-5jrdq-3irkq-ozzdo-ri5dn-dynlb-xgk6d-kiq7w-cvop5-uae"
         gitr = "a1f503d20b7846375c74ce5f7d0f8f6620ab7511"
-        CreateProposalIdempotently(
+        CreateSubnetUpdateProposalIdempotently(
             task_id="xxx",
             subnet_id=sid,
             git_revision=gitr,
@@ -22,11 +27,11 @@ class TestOperators(unittest.TestCase):
 class TestCreateProposal(unittest.TestCase):
     network = IC_NETWORKS["mainnet"]
 
-    def _exercise(self) -> CreateProposalIdempotently:
+    def _exercise(self) -> CreateSubnetUpdateProposalIdempotently:
         def fake_xcom_push(key, value, context=None):  # type:ignore
             return
 
-        k = CreateProposalIdempotently(
+        k = CreateSubnetUpdateProposalIdempotently(
             task_id="x",
             subnet_id="yinp6-35cfo-wgcd2",
             git_revision="d5eb7683e144acb0f8850fedb29011f34bfbe4ac",
@@ -66,9 +71,7 @@ class TestCreateProposal(unittest.TestCase):
             "dfinity.prom_api.query_prometheus_servers"
         ) as n, mock.patch(
             "dfinity.dre.AuthenticatedDRE.propose_to_update_subnet_replica_version"
-        ) as p, mock.patch(
-            "airflow.models.variable.Variable.get"
-        ) as v:
+        ) as p, mock.patch("airflow.models.variable.Variable.get") as v:
             n.return_value = [{"value": 13}]
             v.return_value = "FAKE CERT"
             yield m, p

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -4,8 +4,8 @@ from datetime import timezone as tz
 
 import yaml
 from dfinity.ic_os_rollout import (
-    RolloutPlan,
-    RolloutPlanWithRevision,
+    SubnetRolloutPlan,
+    SubnetRolloutPlanWithRevision,
     assign_default_revision,
     check_plan,
     rollout_planner,
@@ -38,7 +38,7 @@ class TestWeekPlanner(unittest.TestCase):
 class TestRolloutPlanner(unittest.TestCase):
     def transform_actual(
         self,
-        inp: RolloutPlan,
+        inp: SubnetRolloutPlan,
     ) -> list[tuple[int, datetime.datetime, int]]:
         """
         Convert RolloutPlan into simple list of batch index, date/time, subnet num.
@@ -54,7 +54,7 @@ class TestRolloutPlanner(unittest.TestCase):
 
     def transform_actual_with_git_revision(
         self,
-        inp: RolloutPlan,
+        inp: SubnetRolloutPlan,
     ) -> list[tuple[int, datetime.datetime, int, str]]:
         """
         Convert RolloutPlan into simple list of batch index, date/time, subnet num.
@@ -379,8 +379,7 @@ Monday:
 
 
 class TestPlanChecker(unittest.TestCase):
-
-    def _formulate_plan(self, plan_draft: str) -> RolloutPlanWithRevision:
+    def _formulate_plan(self, plan_draft: str) -> SubnetRolloutPlanWithRevision:
         plan = yaml.safe_load(plan_draft)
 
         def lister() -> list[str]:

--- a/tests/test_rollout_types.py
+++ b/tests/test_rollout_types.py
@@ -4,7 +4,7 @@ import unittest
 import dfinity.rollout_types as rollout_types
 
 
-class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
+class TestApiBoundaryNodeRolloutPlanSpec(unittest.TestCase):
     def test_valid(self) -> None:
         """Tests that a valid rollout plan spec works."""
         inp = textwrap.dedent("""\
@@ -15,7 +15,7 @@ class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
         suspend_at: 18:59
         minimum_minutes_per_batch: 60
         """)
-        rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+        rollout_types.yaml_to_ApiBoundaryNodeRolloutPlanSpec(inp)
 
     def test_bad_weekday(self) -> None:
         inp = textwrap.dedent("""\
@@ -27,7 +27,8 @@ class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
         minimum_minutes_per_batch: 60
         """)
         self.assertRaises(
-            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+            ValueError,
+            lambda: rollout_types.yaml_to_ApiBoundaryNodeRolloutPlanSpec(inp),
         )
 
     def test_no_nodes(self) -> None:
@@ -39,7 +40,8 @@ class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
         minimum_minutes_per_batch: 60
         """)
         self.assertRaises(
-            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+            ValueError,
+            lambda: rollout_types.yaml_to_ApiBoundaryNodeRolloutPlanSpec(inp),
         )
 
     def test_zero_minimum_minutes(self) -> None:
@@ -51,7 +53,8 @@ class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
         minimum_minutes_per_batch: 0
         """)
         self.assertRaises(
-            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+            ValueError,
+            lambda: rollout_types.yaml_to_ApiBoundaryNodeRolloutPlanSpec(inp),
         )
 
     def test_wrong_resume_at_time(self) -> None:
@@ -63,5 +66,6 @@ class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
         minimum_minutes_per_batch: 60
         """)
         self.assertRaises(
-            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+            ValueError,
+            lambda: rollout_types.yaml_to_ApiBoundaryNodeRolloutPlanSpec(inp),
         )

--- a/tests/test_rollout_types.py
+++ b/tests/test_rollout_types.py
@@ -1,0 +1,67 @@
+import textwrap
+import unittest
+
+import dfinity.rollout_types as rollout_types
+
+
+class TestBoundaryNodeRolloutPlanSpec(unittest.TestCase):
+    def test_valid(self) -> None:
+        """Tests that a valid rollout plan spec works."""
+        inp = textwrap.dedent("""\
+        nodes:
+        - abc
+        start_day: Wednesday
+        resume_at: 9:00
+        suspend_at: 18:59
+        minimum_minutes_per_batch: 60
+        """)
+        rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+
+    def test_bad_weekday(self) -> None:
+        inp = textwrap.dedent("""\
+        nodes:
+        - abc
+        start_day: Wednsesday
+        resume_at: 9:00
+        suspend_at: 18:59
+        minimum_minutes_per_batch: 60
+        """)
+        self.assertRaises(
+            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+        )
+
+    def test_no_nodes(self) -> None:
+        inp = textwrap.dedent("""\
+        nodes: []
+        start_day: Wednsesday
+        resume_at: 9:00
+        suspend_at: 18:59
+        minimum_minutes_per_batch: 60
+        """)
+        self.assertRaises(
+            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+        )
+
+    def test_zero_minimum_minutes(self) -> None:
+        inp = textwrap.dedent("""\
+        nodes: [abc]
+        start_day: Wednsesday
+        resume_at: 9:00
+        suspend_at: 18:59
+        minimum_minutes_per_batch: 0
+        """)
+        self.assertRaises(
+            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+        )
+
+    def test_wrong_resume_at_time(self) -> None:
+        inp = textwrap.dedent("""\
+        nodes: [abc]
+        start_day: Wednsesday
+        resume_at: 5.5
+        suspend_at: 18:59
+        minimum_minutes_per_batch: 60
+        """)
+        self.assertRaises(
+            ValueError, lambda: rollout_types.yaml_to_BoundaryNodeRolloutPlanSpec(inp)
+        )

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -25,7 +25,6 @@ def db():
 
 
 class TestSchedule(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         db()
@@ -46,7 +45,9 @@ class TestSchedule(unittest.TestCase):
                     description="Git revision",
                 ),
                 "plan": Param(
-                    default=ic_os_rollout.DEFAULT_PLANS["mainnet"].strip(),
+                    default=ic_os_rollout.DEFAULT_SUBNET_ROLLOUT_PLANS[
+                        "mainnet"
+                    ].strip(),
                     type="string",
                     title="Rollout plan",
                     description="YAML-formatted string describing the rollout schedule",


### PR DESCRIPTION
This work comprises the following parts (as a chain of commits):

* Code quality improvements setting the stage for the feature being added here.
* The main feature being added, which is a flow that implements API boundary nodes rollout as per https://dfinity.atlassian.net/browse/DRE-407 .

Notes:

* To determine if a batch of nodes has upgraded, we issue this Prometheus query:

```
    joined = "|".join(boundary_node_ids)
    query = (
        "sum(ic_orchestrator_info{"
        + f'ic_node=~"{joined}"'
        + "}) by (ic_active_version, ic_subnet)"
    )
```

* To determine if a batch of nodes is all healthy, we do this:

```
    bns = "|".join(boundary_node_ids)
    query = """
        sum_over_time(
            ALERTS{
                ic_node=~"%(bns)s",
                severity="page"
            }[15m]
        )""" % (
        {
            "bns": bns,
        }
    )
```

* The current number of boundary nodes is 20, so we start with 20 batches.  As the number grows, we have the flexibility of decreasing how long we wait between upgrades (currently one hour -- see variable `DEFAULT_BOUNDARY_NODE_ROLLOUT_PLANS` in diff) or we can just add more, and the system will attempt to distribute boundary nodes with an exponential-ish distribution, pushing the majority of nodes to be updated as part of the last batches (as is typical for a progressive rollout).

Here is a visual of the work DAG implemented by this feature:

![image](https://github.com/user-attachments/assets/a768c280-bd3f-4f1d-ad32-00c78e1a42ba)