### PR TITLE
Refactor rollout plan dispatcher flow to include GuestOS and API boundary nodes

### DIFF
--- a/dags/rollout_ic_os_to_api_boundary_nodes.py
+++ b/dags/rollout_ic_os_to_api_boundary_nodes.py
@@ -11,7 +11,7 @@ import operators.ic_os_rollout as ic_os_rollout
 import pendulum
 import sensors.ic_os_rollout as ic_os_sensor
 from dfinity.ic_os_rollout import (
-    DEFAULT_API_BOUNDARY_NODE_ROLLOUT_PLANS,
+    DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS,
     PLAN_FORM,
     api_boundary_node_batch_create,
     api_boundary_node_batch_timetable,
@@ -59,7 +59,7 @@ for network_name, network in ic_types.IC_NETWORKS.items():
                 " the version must have been elected before but the rollout will check",
             ),
             "plan": Param(
-                default=DEFAULT_API_BOUNDARY_NODE_ROLLOUT_PLANS[network_name].strip(),
+                default=DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS[network_name].strip(),
                 type="string",
                 title="Rollout plan",
                 description="A YAML-formatted string describing the rollout schedule",

--- a/dags/rollout_ic_os_to_subnets.py
+++ b/dags/rollout_ic_os_to_subnets.py
@@ -11,7 +11,7 @@ import operators.ic_os_rollout as ic_os_rollout
 import pendulum
 import sensors.ic_os_rollout as ic_os_sensor
 from dfinity.ic_os_rollout import (
-    DEFAULT_SUBNET_ROLLOUT_PLANS,
+    DEFAULT_GUESTOS_ROLLOUT_PLANS,
     MAX_BATCHES,
     PLAN_FORM,
     SubnetIdWithRevision,
@@ -47,7 +47,7 @@ for network_name, network in IC_NETWORKS.items():
                 " the version must have been elected before but the rollout will check",
             ),
             "plan": Param(
-                default=DEFAULT_SUBNET_ROLLOUT_PLANS[network_name].strip(),
+                default=DEFAULT_GUESTOS_ROLLOUT_PLANS[network_name].strip(),
                 type="string",
                 title="Rollout plan",
                 description="A YAML-formatted string describing the rollout schedule",
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     try:
         plan = sys.argv[2]
     except Exception:
-        plan = DEFAULT_SUBNET_ROLLOUT_PLANS["mainnet"]
+        plan = DEFAULT_GUESTOS_ROLLOUT_PLANS["mainnet"]
     dag = DAGS["mainnet"]
     dag.test(
         run_conf={

--- a/rollout-dashboard/frontend/tsconfig.json
+++ b/rollout-dashboard/frontend/tsconfig.json
@@ -14,8 +14,20 @@
     "allowJs": true,
     "checkJs": true,
     "isolatedModules": true,
-    "moduleDetection": "force"
+    "moduleDetection": "force",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.svelte"
+  ],
+  "exclude": [
+    "dist/**/*"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/rollout-dashboard/frontend/tsconfig.node.json
+++ b/rollout-dashboard/frontend/tsconfig.node.json
@@ -6,7 +6,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "noEmit": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts"
+  ]
 }

--- a/shared/dfinity/ic_os_rollout.py
+++ b/shared/dfinity/ic_os_rollout.py
@@ -26,7 +26,7 @@ SLACK_CONNECTION_ID = "slack.ic_os_rollout"
 DR_DRE_SLACK_ID = "S05GPUNS7EX"
 MAX_BATCHES: int = 30
 
-DEFAULT_SUBNET_ROLLOUT_PLANS: dict[str, str] = {
+DEFAULT_GUESTOS_ROLLOUT_PLANS: dict[str, str] = {
     "mainnet": """
 # See documentation at the end of this configuration block.
 Monday:
@@ -63,7 +63,7 @@ PLAN_FORM = """
            required="" rows="24">{value}</textarea>
 """
 # Corresponds to type ApiBoundaryNodeRolloutPlanSpec.
-DEFAULT_API_BOUNDARY_NODE_ROLLOUT_PLANS: dict[str, str] = {
+DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS: dict[str, str] = {
     "mainnet": """
 # See documentation at the end of this configuration block.
 nodes:


### PR DESCRIPTION
Updated the code to use `DEFAULT_GUESTOS_ROLLOUT_PLANS` and `DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS`. Renamed parameters and triggered tasks accordingly. Added support for custom HTML forms for rollout plans.

This finishes https://dfinity.atlassian.net/browse/DRE-407 .