### PR TITLE
Improve the boundary node rollout to permit manual intervention.

### DIFF
--- a/dags/auto_compute_rollout.py
+++ b/dags/auto_compute_rollout.py
@@ -147,13 +147,13 @@ for network_name, network in IC_NETWORKS.items():
                     task_id="start_guestos_rollout",
                     trigger_dag_id=f"rollout_ic_os_to_{network_name}_subnets",
                     plan_task_id="auto_compute_rollout",
-                    simulate_rollout="{{ params.simulate }}",
+                    simulate_rollout="{{ params.simulate }}",  # type: ignore
                 ),
                 auto_rollout.TriggerAPIBoundaryNodesRollout(
                     task_id="start_api_boundary_nodes_rollout",
                     trigger_dag_id=f"rollout_ic_os_to_{network_name}_api_boundary_nodes",
                     plan_task_id="auto_compute_rollout",
-                    simulate_rollout="{{ params.simulate }}",
+                    simulate_rollout="{{ params.simulate }}",  # type: ignore
                 ),
             )
         )

--- a/dags/rollout_ic_os_to_api_boundary_nodes.py
+++ b/dags/rollout_ic_os_to_api_boundary_nodes.py
@@ -203,23 +203,48 @@ for network_name, network in ic_types.IC_NETWORKS.items():
             @task_group(group_id=f"batch_{batch_index + 1}")
             def batch(batch_index: int) -> None:
                 should_run = prepare(batch_index)  # type: ignore
-                nodes_to_rollout = wait_until_start_time(batch_index)  # type: ignore
-                chain(should_run, nodes_to_rollout)
-                proposed = create_proposal_if_none_exists(nodes_to_rollout)  # type: ignore
+                wait = ic_os_sensor.CustomDateTimeSensorAsync(
+                    task_id="wait_until_start_time",
+                    target_time="""{{
+                            ti.xcom_pull(task_ids='schedule')[%d][0] | string
+                        }}"""
+                    % batch_index,
+                )
+                chain(should_run, wait)
+                proposed = create_proposal_if_none_exists(
+                    nodes="""{{
+                        ti.xcom_pull(task_ids='schedule')[%d][1]
+                    }}"""  # type: ignore
+                    % batch_index
+                )
+                chain(wait, proposed)
                 announced = ic_os_rollout.RequestProposalVote(
                     task_id="request_proposal_vote",
                     source_task_id=f"batch_{batch_index + 1}"
                     ".create_proposal_if_none_exists",
                     retries=retries,
                 )
-                accepted = wait_until_proposal_is_accepted(  # type: ignore
-                    nodes=nodes_to_rollout,  # type: ignore
+                accepted = wait_until_proposal_is_accepted(
+                    nodes="""{{
+                        ti.xcom_pull(task_ids='schedule')[%d][1]
+                    }}"""
+                    % batch_index,  # type: ignore
                     proposal_info=proposed,  # type: ignore
                 )
                 chain(proposed, announced)
-                adopted = wait_for_revision_adoption(nodes=nodes_to_rollout)  # type: ignore
+                adopted = wait_for_revision_adoption(  # type: ignore
+                    nodes="""{{
+                        ti.xcom_pull(task_ids='schedule')[%d][1]
+                    }}"""  # type: ignore
+                    % batch_index
+                )
                 chain(accepted, adopted)
-                healthy = wait_until_nodes_healthy(nodes_to_rollout)  # type: ignore
+                healthy = wait_until_nodes_healthy(  # type: ignore
+                    nodes="""{{
+                        ti.xcom_pull(task_ids='schedule')[%d][1]
+                    }}"""  # type: ignore
+                    % batch_index
+                )
                 chain(adopted, healthy)
                 join = EmptyOperator(
                     task_id="join",


### PR DESCRIPTION
Due to the way tasks were chained, it was previously not possible to accelerate tasks by marking them as complete.

This PR fixes that.  It's going to be a rare time when we need to do this, but when we do, it's good to have the ability.

This was tested locally using Airflow.   It works.