### PR TITLE
Fix data_interval_start to data_interval_end.

### DIFF
--- a/dags/target_topology.py
+++ b/dags/target_topology.py
@@ -81,14 +81,14 @@ with DAG(
             topology_file="{{ params.topology_file }}",
             node_pipeline="{{ params.node_pipeline }}",
             drive_subfolder="""{{
-                params.folder_name or data_interval_start.strftime('%Y-%m-%d')
+                params.folder_name or data_interval_end.strftime('%Y-%m-%d')
             }}""",
             task_id="run_topology_tool",
         )
         >> SendReport(
             scenario="{{ params.scenario }}",
             drive_subfolder="""{{
-                params.folder_name or data_interval_start.strftime('%Y-%m-%d')
+                params.folder_name or data_interval_end.strftime('%Y-%m-%d')
             }}""",
         )
     )

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -7,25 +7,45 @@ import datetime
 import operators.test_operator as test_operator
 import pendulum
 
+import airflow.operators.python as python_operator
 from airflow import DAG
 from airflow.decorators import task
 from airflow.sensors.time_delta import TimeDeltaSensorAsync
 
 with DAG(
     dag_id="test_dag",
-    schedule=None,
-    start_date=pendulum.datetime(2020, 1, 1, tz="UTC"),
-    catchup=False,
+    schedule=None,  # "@daily",
+    start_date=pendulum.datetime(2025, 7, 5, tz="UTC"),
+    catchup=True,
     dagrun_timeout=datetime.timedelta(days=14),
     tags=["testing"],
 ) as dag:
+
+    class TemplatedTaskArgs:
+        template_fields = ["string"]
+
+        def __init__(self, string: str) -> None:
+            self.string = string
+
+    def print_data(string: TemplatedTaskArgs) -> None:
+        print(string.string)
 
     @task
     def finish() -> None:
         print("Finished!")
 
     (
-        test_operator.TestTask(
+        python_operator.PythonOperator(
+            task_id="start",
+            python_callable=print_data,
+            op_args=[
+                TemplatedTaskArgs(
+                    "ds {{ ds }} distart {{ data_interval_start }}"
+                    " diend {{ data_interval_end }} logical_date {{ logical_date }}"
+                )
+            ],
+        )
+        >> test_operator.TestTask(
             task_id="task_1",
         )
         >> test_operator.TestTask(


### PR DESCRIPTION
Updated the data interval from start to end in the topology (and the test) DAG.

Quick explanation:

* For manual DAGs, the logical date is whatever date/time it was dispatched on.
* For automatic DAGs, the logical date and start date is exactly one day before when the DAG got dispatched.
* For both manual and automatic DAGs, the *end date* is the date at which the DAG was dispatched.

So the correct date to use as a folder by default is exactly the *end date*.