### PR TITLE
Capitalize batch state in rollouts.

### DIFF
--- a/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesBatch.svelte
+++ b/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesBatch.svelte
@@ -7,7 +7,7 @@
         apiBoundaryNodesBatchRolloutStateComment,
         apiBoundaryNodesBatchRolloutStateIcon,
     } from "./types";
-    import { selectTextOnFocus } from "./lib";
+    import { cap, selectTextOnFocus } from "./lib";
     export let batch_num: String;
     export let batch: ApiBoundaryNodesBatch;
     export let git_revision: string;
@@ -23,7 +23,7 @@
                     target="_blank"
                     class="api_boundary_node_batch_state"
                     data-sveltekit-preload-data="off"
-                    title={apiBoundaryNodesBatchRolloutStateComment(batch)}
+                    title={cap(apiBoundaryNodesBatchRolloutStateComment(batch))}
                 >
                     <div class="api_boundary_node_batch_state_icon">
                         {apiBoundaryNodesBatchRolloutStateIcon(batch)}

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -36,7 +36,7 @@ export function subnetStateIcon(subnet: Subnet): String {
 export function subnetStateComment(subnet: Subnet): string {
     let s = SubnetRolloutState[subnet.state].name;
     if (subnet.comment) {
-        s = s + ": " + subnet.comment
+        s = s + " • " + subnet.comment
     }
     return s
 }
@@ -135,7 +135,7 @@ export function apiBoundaryNodesBatchRolloutStateIcon(batch: ApiBoundaryNodesBat
 export function apiBoundaryNodesBatchRolloutStateComment(subnet: ApiBoundaryNodesBatch): string {
     let s = ApiBoundaryNodesBatchRolloutState[subnet.state].name;
     if (subnet.comment) {
-        s = s + ": " + subnet.comment
+        s = s + " • " + subnet.comment
     }
     return s
 }


### PR DESCRIPTION
Fixes tooltip with state not showing the state in first letter capital. This was a regression from when the dashboard gained the capability to show API boundary node rollouts.