### PR TITLE
Rename task_id from 'wait_until_nodes_healthy' to 'wait_for_revision_to_be_elected'.

### DIFF
--- a/dags/rollout_ic_os_to_nodes.py
+++ b/dags/rollout_ic_os_to_nodes.py
@@ -276,7 +276,7 @@ for network_name, network in IC_NETWORKS.items():
         )
 
         wait_for_election = python_sensor.PythonSensor(
-            task_id="wait_until_nodes_healthy",
+            task_id="wait_for_revision_to_be_elected",
             python_callable=hostos_sensors.has_network_adopted_hostos_revision,
             poke_interval=300,
             timeout=86400 * 7,


### PR DESCRIPTION
The task ID in the PythonSensor has been renamed to better reflect its purpose, which is now to wait for a specific revision to be elected.

- Updated `task_id` from 'wait_until_nodes_healthy' to 'wait_for_revision_to_be_elected'.