### PR TITLE
Cosmetic fixes to rollout dashboard:

### DIFF
--- a/rollout-dashboard/frontend/src/App.svelte
+++ b/rollout-dashboard/frontend/src/App.svelte
@@ -96,7 +96,7 @@
   {#if $view.error === "loading"}
     <div
       class="flex items-center justify-center w-56 h-56 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
-      style="align-self: center"
+      style="margin-left: auto; margin-right: auto;"
     >
       <div role="status">
         <svg

--- a/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesBatch.svelte
+++ b/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesBatch.svelte
@@ -37,7 +37,7 @@
             </li>
         </ul>
     {/each}
-    <div class="start_time text-gray-500">
+    <div class="time text-gray-500">
         Planned <Time
             live
             relative
@@ -46,7 +46,7 @@
         />
     </div>
     {#if batch.actual_start_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Started <Time
                 live
                 relative
@@ -56,7 +56,7 @@
         </div>
     {/if}
     {#if batch.end_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Finished <Time
                 live
                 relative
@@ -107,7 +107,8 @@
         text-decoration-style: dotted;
         text-decoration-color: #e4e4e4;
     }
-    .start_time {
+    .time {
         text-align: right;
+        white-space: nowrap; /* prevent breaking spaces */
     }
 </style>

--- a/rollout-dashboard/frontend/src/lib/HostOSBatch.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatch.svelte
@@ -25,23 +25,23 @@
             {hostOsBatchStateIcon(batch)}
         </div></a
     >
-    {#if batch.actual_nodes !== null && batch.actual_nodes.length != batch.planned_nodes.length}
-        <div class="node_count">
-            {batch.actual_nodes.length} nodes targeted
-        </div>
-        <div class="node_count">
+    {#if batch.actual_nodes !== null && JSON.stringify(batch.actual_nodes) != JSON.stringify(batch.planned_nodes)}<!-- planned and actual are different -->
+        <div class="nodes">
             {batch.planned_nodes.length} nodes planned
         </div>
-    {:else if batch.actual_nodes !== null && batch.actual_nodes.length > 0}
-        <div class="node_count">
+        <div class="nodes">
             {batch.actual_nodes.length} nodes targeted
         </div>
-    {:else}
-        <div class="node_count">
+    {:else if batch.actual_nodes !== null && batch.actual_nodes.length > 0}<!-- planned and actual are same nodes -->
+        <div class="nodes">
+            {batch.actual_nodes.length} nodes targeted
+        </div>
+    {:else}<!-- no actual nodes yet -->
+        <div class="nodes">
             {batch.planned_nodes.length} nodes planned
         </div>
     {/if}
-    <div class="start_time text-gray-500">
+    <div class="time text-gray-500">
         Planned <Time
             live
             relative
@@ -50,7 +50,7 @@
         />
     </div>
     {#if batch.actual_start_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Started <Time
                 live
                 relative
@@ -60,7 +60,7 @@
         </div>
     {/if}
     {#if batch.end_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Finished <Time
                 live
                 relative
@@ -77,14 +77,15 @@
         padding: 0.6em;
         flex-grow: 1;
     }
-    li.batch .hostos_node_batch_state div {
+    li.batch a.hostos_node_batch_state div {
         min-width: 1.8em;
         float: left;
         margin-top: -2px;
         text-align: left;
     }
-    .start_time,
-    .node_count {
+    .time,
+    .nodes {
         text-align: right;
+        white-space: nowrap; /* prevent breaking spaces */
     }
 </style>

--- a/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
@@ -252,6 +252,10 @@
         text-align: center;
         writing-mode: vertical-lr;
         text-orientation: mixed;
+        padding-top: 1em; /* add padding to the pills on the right side of each stage */
+        padding-bottom: 1em;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
     }
     div.stage-name.stage-canary {
         background-color: #e1e0d2;

--- a/rollout-dashboard/frontend/src/lib/SubnetBatch.svelte
+++ b/rollout-dashboard/frontend/src/lib/SubnetBatch.svelte
@@ -59,7 +59,7 @@
             </li>
         </ul>
     {/each}
-    <div class="start_time text-gray-500">
+    <div class="time text-gray-500">
         Planned <Time
             live
             relative
@@ -68,7 +68,7 @@
         />
     </div>
     {#if batch.actual_start_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Started <Time
                 live
                 relative
@@ -78,7 +78,7 @@
         </div>
     {/if}
     {#if batch.end_time}
-        <div class="start_time text-gray-500">
+        <div class="time text-gray-500">
             Finished <Time
                 live
                 relative
@@ -151,7 +151,8 @@
         margin-left: -1em;
         margin-top: 0.35em;
     }
-    .start_time {
+    .time {
         text-align: right;
+        text-align: nowrap; /* prevent breaking spaces */
     }
 </style>


### PR DESCRIPTION
* Prevent text wrap in batch tile.
* If nodes are different, even if they are the same count, show a note to that effect.
* Pills that display the name of each HostOS rollout stage required padding.
* Center loading spinner.  It used to be centered but when it moved to the header, CSS cascading broke that.