### PR TITLE
Fix election check for HostOS rollout.

### DIFF
--- a/plugins/sensors/hostos_rollout.py
+++ b/plugins/sensors/hostos_rollout.py
@@ -113,3 +113,22 @@ def are_hostos_nodes_healthy(
 
     print("There are no more alerts on HostOS nodes.")
     return True
+
+
+if __name__ == "__main__":
+    network = ic_types.ICNetwork(
+        "https://ic0.app/",
+        "https://dashboard.internetcomputer.org/proposal",
+        "https://dashboard.internetcomputer.org/release",
+        [
+            "https://victoria.mainnet.dfinity.network/select/0/prometheus/api/v1/query",
+        ],
+        80,
+        "dfinity.ic_admin.mainnet.proposer_key_file",
+    )
+    params: DagParams = {
+        "simulate": False,
+        "git_revision": "143a635e2af0f574e1ea0f795f8754dfbd86c0c0",
+        "plan": "",
+    }
+    has_network_adopted_hostos_revision(network, params)


### PR DESCRIPTION
The `--json` argument to dre get elected hostos revisions has (unexpectedly) no effect; we still get revisions as a newline-separated list.  Decode that instead.

Sample error this PR fixes:

```
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 465, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 432, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 400, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sensors/base.py", line 264, in execute
    raise e
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sensors/base.py", line 246, in execute
    poke_return = self.poke(context)
                  ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sensors/python.py", line 76, in poke
    return_value = self.python_callable(*self.op_args, **self.op_kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/plugins/sensors/hostos_rollout.py", line 19, in has_network_adopted_hostos_revision
    if dre.DRE(network, SubprocessHook()).is_hostos_version_blessed(git_revision):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/plugins/dfinity/dre.py", line 441, in is_hostos_version_blessed
    x.lower() for x in self.get_elected_hostos_versions()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/plugins/dfinity/dre.py", line 432, in get_elected_hostos_versions
    return cast(list[str], json.loads(r.output))
                           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
```