### PR TITLE
Add a new canary step that upgrades more unassigned nodes owned by non-DFINITY providers

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -87,6 +87,12 @@ stages:
       status: Healthy
       nodes_per_group: 5
   - selectors:
+    - assignment: unassigned
+      owner: others
+      group_by: datacenter
+      status: Healthy
+      nodes_per_group: 1
+  - selectors:
     - assignment: assigned
       owner: DFINITY
       status: Healthy


### PR DESCRIPTION
Ref: https://dfinity.slack.com/archives/C026JQ1B2AF/p1753188942620629?thread_ts=1752061810.851159&cid=C026JQ1B2AF