### PR TITLE
fix: update static directory path

### DIFF
--- a/rollout-dashboard/Dockerfile
+++ b/rollout-dashboard/Dockerfile
@@ -21,7 +21,7 @@ RUN npm run build
 FROM docker.io/debian:bookworm
 WORKDIR /
 COPY --from=rust /usr/src/rollout-dashboard/rollout-dashboard /rollout-dashboard
-COPY --from=node /workdir/dist/client /workdir/static
+COPY --from=node /workdir/dist/client /static
 RUN apt-get update && apt-get upgrade -y && apt install -y openssl ca-certificates
 
 EXPOSE 4174


### PR DESCRIPTION
Updated the path to the static directory from `/workdir/static` to `/static`.

This unbreaks the dashboard.