### PR TITLE
Various fixes to HostOS rollout.

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -77,15 +77,10 @@ DEFAULT_HOSTOS_ROLLOUT_PLANS: dict[str, str] = {
 stages:
   canary:
   - selectors:
-      join:
-      - assignment: unassigned
-        owner: DFINITY
-        status: Healthy
-        nodes_per_group: 1
-      - assignment: API boundary
-        owner: DFINITY
-        status: Healthy
-        nodes_per_group: 1
+      assignment: unassigned
+      owner: DFINITY
+      status: Healthy
+      nodes_per_group: 1
   - selectors:
       assignment: unassigned
       owner: DFINITY
@@ -103,11 +98,16 @@ stages:
       status: Healthy
       nodes_per_group: 10%
   - selectors:
-      assignment: assigned
-      owner: others
-      group_by: subnet
-      status: Healthy
-      nodes_per_group: 1
+      join:
+      - assignment: assigned
+        owner: others
+        group_by: subnet
+        status: Healthy
+        nodes_per_group: 1
+      - assignment: API boundary
+        owner: DFINITY
+        status: Healthy
+        nodes_per_group: 1
   main:
     selectors:
       join:
@@ -132,6 +132,6 @@ allowed_days:
 - Thursday
 resume_at: 7:00
 suspend_at: 15:00
-minimum_minutes_per_batch: 120
+minimum_minutes_per_batch: 90
 """.strip()
 }

--- a/rollout-dashboard/frontend/package-lock.json
+++ b/rollout-dashboard/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend-only-svelte",
       "version": "0.0.0",
       "devDependencies": {
-        "@flowbite-svelte-plugins/datatable": "^0.4.0",
         "@humanspeak/svelte-markdown": "^0.8.8",
         "@roxi/routify": "^3.0.0-next.292",
         "@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -20,7 +19,6 @@
         "flowbite": "^2.5.2",
         "flowbite-svelte": "^1.10.20",
         "flowbite-svelte-icons": "^2.2.1",
-        "simple-datatables": "^10.0.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "svelte-copy": "^2.0.0",
@@ -473,21 +471,21 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
-      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
       }
     },
@@ -497,28 +495,15 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "dev": true
     },
-    "node_modules/@flowbite-svelte-plugins/datatable": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@flowbite-svelte-plugins/datatable/-/datatable-0.4.0.tgz",
-      "integrity": "sha512-mGNDi2TkyeHDouKUpRv/LkA5R/JyLfE75qRBfvKwTM3HlurbGgmXOrvdFyjcSGuD+EAVY6VWpuh/XS4hi9rP1w==",
-      "dev": true,
-      "dependencies": {
-        "simple-datatables": "^10.0.0"
-      },
-      "peerDependencies": {
-        "svelte": "^5.0.0",
-        "tailwindcss": "^4.1.4"
-      }
-    },
     "node_modules/@humanspeak/svelte-markdown": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@humanspeak/svelte-markdown/-/svelte-markdown-0.8.8.tgz",
-      "integrity": "sha512-9KQyyDWE3TCfx14T+eRAmlUiiCqs/39wKtmT/koQM3w1lB21Py4gjpvE34tUJK6BXmbVZ1Sq1fvopa0gVOGxjQ==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@humanspeak/svelte-markdown/-/svelte-markdown-0.8.9.tgz",
+      "integrity": "sha512-/MP8CXs7Xm0ufX+Bf5mwYVesUhgPCijUN330EadsDXKW1rpmRnCBoEf6ycMX5CuBGIK5kz45jhLimFNgKGJPZQ==",
       "dev": true,
       "dependencies": {
         "github-slugger": "^2.0.0",
         "htmlparser2": "^10.0.0",
-        "marked": "^16.0.0"
+        "marked": "^16.1.1"
       },
       "funding": {
         "type": "github",
@@ -632,9 +617,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
       "cpu": [
         "arm"
       ],
@@ -645,9 +630,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +643,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
       "cpu": [
         "arm64"
       ],
@@ -671,9 +656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
       "cpu": [
         "x64"
       ],
@@ -684,9 +669,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
       "cpu": [
         "arm64"
       ],
@@ -697,9 +682,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
       "cpu": [
         "x64"
       ],
@@ -710,9 +695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
       "cpu": [
         "arm"
       ],
@@ -723,9 +708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
       "cpu": [
         "arm"
       ],
@@ -736,9 +721,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
       "cpu": [
         "arm64"
       ],
@@ -749,9 +734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
       "cpu": [
         "arm64"
       ],
@@ -762,9 +747,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
       "cpu": [
         "loong64"
       ],
@@ -774,10 +759,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
       "cpu": [
         "ppc64"
       ],
@@ -788,9 +773,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
       "cpu": [
         "riscv64"
       ],
@@ -801,9 +786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
       "cpu": [
         "riscv64"
       ],
@@ -814,9 +799,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
       "cpu": [
         "s390x"
       ],
@@ -827,9 +812,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
       "cpu": [
         "x64"
       ],
@@ -840,9 +825,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
       "cpu": [
         "x64"
       ],
@@ -853,9 +838,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
       "cpu": [
         "arm64"
       ],
@@ -866,9 +851,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
       "cpu": [
         "ia32"
       ],
@@ -879,9 +864,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
       "cpu": [
         "x64"
       ],
@@ -892,9 +877,9 @@
       ]
     },
     "node_modules/@roxi/routify": {
-      "version": "3.0.0-next.293",
-      "resolved": "https://registry.npmjs.org/@roxi/routify/-/routify-3.0.0-next.293.tgz",
-      "integrity": "sha512-hF3LT8bTh6/o9djgggkJlVVjK9pBy9Hq8R+gLi2+qK4FUoHdqZtx1NAzb98g8B8SAwfYxYr8bhSch51QiAeheA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@roxi/routify/-/routify-3.5.2.tgz",
+      "integrity": "sha512-A6N/t0WDExw/FiJFvHePLlg8+EAHGfKlkWmWiyTOih3My+cB8qoYGaxwCImZellKJmUHs6gdNabk3Fs86aaEOw==",
       "dev": true,
       "dependencies": {
         "cachewrap": "^0.0.1",
@@ -1476,9 +1461,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {
@@ -1698,12 +1683,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff-dom/-/diff-dom-5.2.0.tgz",
-      "integrity": "sha512-+FEFvDJljxPBz9ddkxCpn7I/5SFFYYfvqcS63zE+Aw+3TgTyHAI1RGXEBGLfrkbVQTYCSpvc0nxNNMyNBA60tQ==",
-      "dev": true
-    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -1787,9 +1766,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.191",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
-      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
+      "version": "1.5.194",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
+      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
       "dev": true
     },
     "node_modules/encoding-sniffer": {
@@ -1969,9 +1948,9 @@
       }
     },
     "node_modules/flowbite-svelte": {
-      "version": "1.10.20",
-      "resolved": "https://registry.npmjs.org/flowbite-svelte/-/flowbite-svelte-1.10.20.tgz",
-      "integrity": "sha512-xAoLfTskPliCZgXZUFh8Gqg4yLav/Qas4XRPnFVMynUpA65ASulj9W+VAbqN5q//y4JP0jKQ24rCjefViZrAQQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/flowbite-svelte/-/flowbite-svelte-1.11.2.tgz",
+      "integrity": "sha512-thpD1xUx+VTo+Sv/kixe69MIEBzY13kZsJrK2B3hYSraMsEWC+e99v8PsUtXpdJB3FqgIrOA8nIx6Yuh8LNXZQ==",
       "dev": true,
       "dependencies": {
         "@floating-ui/dom": "^1.7.2",
@@ -2452,9 +2431,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
-      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -2775,9 +2754,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
+      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -2790,26 +2769,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.46.2",
+        "@rollup/rollup-android-arm64": "4.46.2",
+        "@rollup/rollup-darwin-arm64": "4.46.2",
+        "@rollup/rollup-darwin-x64": "4.46.2",
+        "@rollup/rollup-freebsd-arm64": "4.46.2",
+        "@rollup/rollup-freebsd-x64": "4.46.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
+        "@rollup/rollup-linux-arm64-musl": "4.46.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-musl": "4.46.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
+        "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -2840,16 +2819,6 @@
         "compute-scroll-into-view": "^3.0.2"
       }
     },
-    "node_modules/simple-datatables": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/simple-datatables/-/simple-datatables-10.0.0.tgz",
-      "integrity": "sha512-Pqzld1ixWz2/dbA3ZB/3m78elfolzbiC0+aBuugj+bF70Yk35J0p8qwrOpaAfSe/8II9WV+nKJ5CYDOeJVx5mw==",
-      "dev": true,
-      "dependencies": {
-        "dayjs": "^1.11.10",
-        "diff-dom": "^5.1.3"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -2878,9 +2847,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.36.16",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.36.16.tgz",
-      "integrity": "sha512-C7HnyISfvZEofs7T4p7+bmjrbQlhd6lZfgV2tLYg6Eb3nUFM/Zu9dGlSg+GWbUBU/WPw6zDPOFNZAx9qXsoCkg==",
+      "version": "5.37.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.37.3.tgz",
+      "integrity": "sha512-7t/ejshehHd+95z3Z7ebS7wsqHDQxi/8nBTuTRwpMgNegfRBfuitCSKTUDKIBOExqfT2+DhQ2VLG8Xn+cBXoaQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -2903,9 +2872,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.0.tgz",
-      "integrity": "sha512-Iz8dFXzBNAM7XlEIsUjUGQhbEE+Pvv9odb9+0+ITTgFWZBGeJRRYqHUUglwe2EkLD5LIsQaAc4IUJyvtKuOO5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.1.tgz",
+      "integrity": "sha512-lkh8gff5gpHLjxIV+IaApMxQhTGnir2pNUAqcNgeKkvK5bT/30Ey/nzBxNLDlkztCH4dP7PixkMt9SWEKFPBWg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -3034,9 +3003,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3047,9 +3016,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-      "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
+      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
       "dev": true,
       "engines": {
         "node": ">=20.18.1"
@@ -3224,20 +3193,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/zimmerframe": {

--- a/rollout-dashboard/frontend/package.json
+++ b/rollout-dashboard/frontend/package.json
@@ -12,7 +12,6 @@
     "check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@flowbite-svelte-plugins/datatable": "^0.4.0",
     "@humanspeak/svelte-markdown": "^0.8.8",
     "@roxi/routify": "^3.0.0-next.292",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -24,7 +23,6 @@
     "flowbite": "^2.5.2",
     "flowbite-svelte": "^1.10.20",
     "flowbite-svelte-icons": "^2.2.1",
-    "simple-datatables": "^10.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "svelte-copy": "^2.0.0",

--- a/rollout-dashboard/frontend/src/app.css
+++ b/rollout-dashboard/frontend/src/app.css
@@ -72,30 +72,13 @@ div.note a {
 
 /* end my stuff */
 
-/* datatables from flowbite */
+/* oneliner no-wrap tables from flowbite */
 
-@source "../node_modules/simple-datatables/dist";
-@source "../node_modules/@flowbite-svelte-plugins/datatable/dist";
-
-@import 'simple-datatables';
-
-.datatable-pagination .datatable-active a,
-.datatable-pagination .datatable-active a:focus,
-.datatable-pagination .datatable-active a:hover,
-.datatable-pagination .datatable-active button,
-.datatable-pagination .datatable-active button:focus,
-.datatable-pagination .datatable-active button:hover {
-  background-color: #ffe4de;
-  cursor: default;
+td.oneliner {
+  white-space: collapse !important;
 }
 
-.datatable-wrapper .datatable-table tbody tr.selected {
-  background-color: #fff1ee !important;
-}
-
-/* datatables from flowbite */
-
-.datatable-table td > .oneliner {
+td.oneliner > * {
   text-overflow: ellipsis;
   overflow: hidden;
   display: block;

--- a/rollout-dashboard/frontend/src/app.d.ts
+++ b/rollout-dashboard/frontend/src/app.d.ts
@@ -2,20 +2,4 @@ declare global {
     namespace App { }
 }
 
-declare module "simple-datatables" {
-    export { DataTable } from "simple-datatables/dist/dts/datatable";
-    export { convertCSV, convertJSON } from "simple-datatables/dist/dts/convert";
-    export { exportCSV, exportJSON, exportSQL, exportTXT } from "simple-datatables/dist/dts/export";
-    export { createElement, isJson, isObject } from "simple-datatables/dist/dts/helpers";
-    export { makeEditable } from "simple-datatables/dist/dts/editing";
-    export { addColumnFilter } from "simple-datatables/dist/dts/column_filter";
-
-    export type { DataTableOptions, DataTableConfiguration, ColumnOption, cellType, inputCellType, dataRowType, inputRowType, headerCellType, inputHeaderCellType, TableDataType, DataOption, renderType, nodeType, elementNodeType, textNodeType, cellDataType } from "simple-datatables/dist/dts/datatable";
-
-    export interface SelectableDataRow {
-        selected?: boolean;
-        [key: string]: any;
-    }
-}
-
 export { };

--- a/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
@@ -4,11 +4,12 @@
         type HostOsBatchResponse,
         formatSelectors,
     } from "./types";
-    import { Table } from "@flowbite-svelte-plugins/datatable";
     import {
         Table as RegularTable,
+        TableBody,
         TableBodyCell,
         TableBodyRow,
+        TableHead,
         TableHeadCell,
     } from "flowbite-svelte";
     import { Tabs, TabItem } from "flowbite-svelte";
@@ -19,21 +20,6 @@
         dag_run_id: string;
         batch: HostOsBatchResponse;
     }
-
-    let { dag_run_id, batch }: Props = $props();
-
-    let planned_items = batch.planned_nodes.map((val) => ({
-        Node: val.node_id,
-        Provider: val.node_provider_id,
-        DC: val.dc_id,
-        Assignment:
-            val.assignment === null
-                ? "—"
-                : val.assignment === "API boundary"
-                  ? "API boundary"
-                  : val.assignment,
-        Status: val.status,
-    }));
 
     function getUpgradeStatus(node_id: string): string {
         if (batch.upgraded_nodes !== null) {
@@ -59,7 +45,33 @@
         }
     }
 
-    let actual_items =
+    function reducer(akku: Record<string, number>, val: string) {
+        let old_count = akku[val];
+        if (old_count === undefined) {
+            akku[val] = 1;
+        } else {
+            akku[val] = old_count + 1;
+        }
+        return akku;
+    }
+
+    let { dag_run_id, batch }: Props = $props();
+
+    let planned_items = $derived(
+        batch.planned_nodes.map((val) => ({
+            Node: val.node_id,
+            Provider: val.node_provider_id,
+            DC: val.dc_id,
+            Assignment:
+                val.assignment === null
+                    ? "—"
+                    : val.assignment === "API boundary"
+                      ? "API boundary"
+                      : val.assignment,
+            Status: val.status,
+        })),
+    );
+    let actual_items = $derived(
         batch.actual_nodes !== null
             ? batch.actual_nodes.map((val) => ({
                   Node: val.node_id,
@@ -74,53 +86,48 @@
                   "Upgraded?": getUpgradeStatus(val.node_id),
                   "Alerting?": getAlertStatus(val.node_id),
               }))
-            : null;
+            : null,
+    );
 
-    function reducer(akku: Record<string, number>, val: string) {
-        let old_count = akku[val];
-        if (old_count === undefined) {
-            akku[val] = 1;
-        } else {
-            akku[val] = old_count + 1;
-        }
-        return akku;
-    }
-
-    let upgraded_nodes_summary =
+    let upgraded_nodes_summary = $derived(
         batch.upgraded_nodes === null
             ? null
             : Object.entries(batch.upgraded_nodes)
                   .map(([k, v]) => v)
-                  .reduce(reducer, {});
+                  .reduce(reducer, {}),
+    );
 
-    let alerting_nodes_summary =
+    let alerting_nodes_summary = $derived(
         batch.alerting_nodes === null
             ? null
             : Object.entries(batch.alerting_nodes)
                   .map(([k, v]) => v)
-                  .reduce(reducer, {});
+                  .reduce(reducer, {}),
+    );
 
     let options = {
+        paging: false,
+        perPage: 500,
         columns: [
             {
                 select: [0],
                 type: "string",
                 render: function (cellData: string, td: Node) {
-                    return `<a class="oneliner text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/nodes/${cellData}">${cellData}</div>`;
+                    return `<a class="text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/nodes/${cellData}">${cellData}</div>`;
                 },
             },
             {
                 select: [1],
                 type: "string",
                 render: function (cellData: string, td: Node) {
-                    return `<a class="oneliner text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/providers/${cellData}">${cellData}</div>`;
+                    return `<a class="text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/providers/${cellData}">${cellData}</div>`;
                 },
             },
             {
                 select: [2],
                 type: "string",
                 render: function (cellData: string, td: Node) {
-                    return `<a class="oneliner text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/centers/${cellData}">${cellData}</div>`;
+                    return `<a class="text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/centers/${cellData}">${cellData}</div>`;
                 },
             },
             {
@@ -128,12 +135,11 @@
                 type: "string",
                 render: function (cellData: string, td: Node) {
                     if (cellData != "—" && cellData != "API boundary") {
-                        return `<a class="oneliner text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/subnets/${cellData}">${cellData.split("-")[0]}</div>`;
+                        return `<a class="text-secondary-600" target="_blank" href="https://dashboard.internetcomputer.org/network/subnets/${cellData}">${cellData.split("-")[0]}</div>`;
                     }
                 },
             },
         ],
-        perPage: 20,
     };
 </script>
 
@@ -236,15 +242,158 @@
         </TabItem>
         {#if actual_items !== null}
             <TabItem title="Actual nodes">
-                <Table items={actual_items} dataTableOptions={options} />
-            </TabItem>
-            <TabItem title="Planned nodes">
-                <Table items={planned_items} dataTableOptions={options} />
-            </TabItem>
-        {:else}
-            <TabItem title="Planned nodes">
-                <Table items={planned_items} dataTableOptions={options} />
+                <div
+                    class="flex items-center p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
+                    role="alert"
+                >
+                    <svg
+                        class="shrink-0 inline w-4 h-4 me-3"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                    >
+                        <path
+                            d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"
+                        />
+                    </svg>
+                    <span class="sr-only">Info</span>
+                    <div>
+                        These are the nodes selected at the start of the batch
+                        just prior to submitting the upgrade proposal. They may
+                        differ from the planned nodes, originally selected at
+                        the beginning of the rollout.
+                    </div>
+                </div>
+                <RegularTable striped={true}>
+                    <TableHead>
+                        <TableHeadCell>Node</TableHeadCell>
+                        <TableHeadCell>Provider</TableHeadCell>
+                        <TableHeadCell>DC</TableHeadCell>
+                        <TableHeadCell>Upgraded?</TableHeadCell>
+                        <TableHeadCell>Alerting?</TableHeadCell>
+                    </TableHead>
+                    <TableBody>
+                        {#each actual_items as node}
+                            <TableBodyRow>
+                                <TableBodyCell class="oneliner"
+                                    ><a
+                                        class="text-secondary-600"
+                                        target="_blank"
+                                        href="https://dashboard.internetcomputer.org/network/nodes/{node[
+                                            'Node'
+                                        ]}">{node["Node"]}</a
+                                    ></TableBodyCell
+                                >
+                                <TableBodyCell class="oneliner"
+                                    ><a
+                                        class="text-secondary-600"
+                                        target="_blank"
+                                        href="https://dashboard.internetcomputer.org/network/providers/{node[
+                                            'Provider'
+                                        ]}">{node["Provider"]}</a
+                                    ></TableBodyCell
+                                >
+                                <TableBodyCell class="oneliner"
+                                    ><a
+                                        class=" text-secondary-600"
+                                        target="_blank"
+                                        href="https://dashboard.internetcomputer.org/network/centers/{node[
+                                            'DC'
+                                        ]}">{node["DC"]}</a
+                                    ></TableBodyCell
+                                >
+                                <TableBodyCell
+                                    >{node["Upgraded?"]}</TableBodyCell
+                                >
+                                <TableBodyCell
+                                    >{node["Alerting?"]}</TableBodyCell
+                                >
+                            </TableBodyRow>
+                        {/each}
+                    </TableBody>
+                </RegularTable>
             </TabItem>
         {/if}
+        <TabItem title="Planned nodes">
+            <div
+                class="flex items-center p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
+                role="alert"
+            >
+                <svg
+                    class="shrink-0 inline w-4 h-4 me-3"
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                >
+                    <path
+                        d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"
+                    />
+                </svg>
+                <span class="sr-only">Info</span>
+                <div>
+                    These are the nodes originally planned to be rolled out at
+                    the beginning of the rollout. They may differ from the nodes
+                    actually targeted once this batch has begun to do work. The
+                    status per node shown here corresponds to the status of the
+                    node at the beginning of the rollout.
+                </div>
+            </div>
+            <RegularTable striped={true}>
+                <TableHead>
+                    <TableHeadCell>Node</TableHeadCell>
+                    <TableHeadCell>Provider</TableHeadCell>
+                    <TableHeadCell>DC</TableHeadCell>
+                    <TableHeadCell>Assignment</TableHeadCell>
+                    <TableHeadCell>Status</TableHeadCell>
+                </TableHead>
+                <TableBody>
+                    {#each planned_items as node}
+                        <TableBodyRow>
+                            <TableBodyCell class="oneliner"
+                                ><a
+                                    class="text-secondary-600"
+                                    target="_blank"
+                                    href="https://dashboard.internetcomputer.org/network/nodes/{node[
+                                        'Node'
+                                    ]}">{node["Node"]}</a
+                                ></TableBodyCell
+                            >
+                            <TableBodyCell class="oneliner"
+                                ><a
+                                    class="text-secondary-600"
+                                    target="_blank"
+                                    href="https://dashboard.internetcomputer.org/network/providers/{node[
+                                        'Provider'
+                                    ]}">{node["Provider"]}</a
+                                ></TableBodyCell
+                            >
+                            <TableBodyCell class="oneliner"
+                                ><a
+                                    class=" text-secondary-600"
+                                    target="_blank"
+                                    href="https://dashboard.internetcomputer.org/network/centers/{node[
+                                        'DC'
+                                    ]}">{node["DC"]}</a
+                                ></TableBodyCell
+                            >
+                            <TableBodyCell
+                                >{#if node["Assignment"] != "—" && node["Assignment"] != "API boundary"}<a
+                                        class="oneliner text-secondary-600"
+                                        target="_blank"
+                                        href="https://dashboard.internetcomputer.org/network/subnets/${node[
+                                            'Assignment'
+                                        ]}">{node["Assignment"].split("-")}</a
+                                    >{:else}{node["Assignment"].split(
+                                        "-",
+                                    )}{/if}</TableBodyCell
+                            >
+                            <TableBodyCell>{node["Status"]}</TableBodyCell>
+                        </TableBodyRow>
+                    {/each}
+                </TableBody>
+            </RegularTable>
+        </TabItem>
     </Tabs>
 </div>

--- a/rollout-dashboard/frontend/src/lib/stores.ts
+++ b/rollout-dashboard/frontend/src/lib/stores.ts
@@ -7,10 +7,7 @@ export type FullState = {
     rollout_engine_states: RolloutEngineStates;
 }
 
-const API_URL = import.meta.env.BACKEND_API_PATH || "/api/v2";
-const UNSTABLE_API_URL =
-    import.meta.env.BACKEND_API_PATH_UNSTABLE || "/api/unstable";
-
+const API_URL = "/api/v2";
 
 const url = API_URL + "/sse"
 var evtSource: null | EventSource = null;

--- a/tests/test_hostos_rollout.py
+++ b/tests/test_hostos_rollout.py
@@ -106,7 +106,7 @@ def test_default_plan(registry: dre.RegistrySnapshot) -> None:
         + [r for r in res["unassigned"]]
         + [r for r in res["stragglers"]]
     )
-    assert batches[-1]["start_at"] == datetime.datetime(2025, 7, 28, 13, 0)
+    assert batches[-1]["start_at"] == datetime.datetime(2025, 7, 23, 8, 30)
 
 
 def test_schedule_bombs_with_too_many_nodes(


### PR DESCRIPTION
* Reduce future rollouts' time per batch to 90 minutes.
* Move API boundary node canary (prod machine) to latest canary batch.
* Eliminate datatables from HostOS detail view -- it caused bad flickering, did not update reactively, and had poor styling.
* Update NPM dependencies of frontend.
* Make detail tables in HostOS detail view reactive to status updates.
* Add informational preface explaining node selection in HostOS detail view.
