### PR TITLE
feat: Add HostOS versions dropdown item

### DIFF
--- a/rollout-dashboard/frontend/src/routes/index.svelte
+++ b/rollout-dashboard/frontend/src/routes/index.svelte
@@ -85,7 +85,13 @@
                     <DropdownItem
                         ><a
                             href="https://grafana.mainnet.dfinity.network/d/release/release?orgId=1&from=now-7d&to=now&var-ic=mercury&var-ic_subnet=$__all&refresh=30s"
-                            target="_blank">Mainnet versions</a
+                            target="_blank">Mainnet GuestOS versions</a
+                        ></DropdownItem
+                    >
+                    <DropdownItem
+                        ><a
+                            href="https://grafana.mainnet.dfinity.network/d/hostos-versions/hostos-versions"
+                            target="_blank">Mainnet HostOS versions</a
                         ></DropdownItem
                     >
                     <DropdownItem


### PR DESCRIPTION
Added a new dropdown item to display Mainnet HostOS versions on the dashboard.

- Updated the existing 'Mainnet versions' dropdown item to be more specific, now referred to as 'Mainnet GuestOS versions'.
- Added a new dropdown item for accessing 'Mainnet HostOS versions' through a Grafana link.

Dashboard has been brought to modernity in this PR: https://github.com/dfinity-ops/k8s/pull/1709