### PR TITLE
Simplify the API regarding HostOS batch summaries (used on the main screen)

### DIFF
--- a/rollout-dashboard/frontend/src/lib/HostOSBatch.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatch.svelte
@@ -44,19 +44,19 @@
                         <span
                             class="tooltip"
                             title={formatSelectors(batch.selectors)}
-                            >{batch.planned_nodes.length} nodes planned</span
+                            >{batch.planned_nodes} nodes planned</span
                         >
                     </div>
                     <div class="nodes">
-                        {batch.actual_nodes.length} nodes targeted
+                        {batch.actual_nodes} nodes targeted
                     </div>
-                {:else if batch.actual_nodes !== null && batch.actual_nodes.length > 0}
+                {:else if batch.actual_nodes !== null && batch.actual_nodes > 0}
                     <div class="nodes">
                         <!-- planned and actual are same nodes -->
                         <span
                             class="tooltip"
                             title={formatSelectors(batch.selectors)}
-                            >{batch.actual_nodes.length} nodes targeted</span
+                            >{batch.actual_nodes} nodes targeted</span
                         >
                     </div>
                 {:else}
@@ -65,7 +65,7 @@
                         <span
                             class="tooltip"
                             title={formatSelectors(batch.selectors)}
-                            >{batch.planned_nodes.length} nodes planned</span
+                            >{batch.planned_nodes} nodes planned</span
                         >
                     </div>
                 {/if}

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -231,13 +231,13 @@ const HostOsBatchState = {
     skipped: { icon: "⏩", name: "skipped" },
     unknown: { icon: "❓", name: "does not appear in Airflow" },
 };
-export function hostOsBatchStateName(batch: HostOsBatch): String {
+export function hostOsBatchStateName(batch: HostOsBatch | HostOsBatchResponse): String {
     return HostOsBatchState[batch.state].name;
 }
-export function hostOsBatchStateIcon(batch: HostOsBatch): String {
+export function hostOsBatchStateIcon(batch: HostOsBatch | HostOsBatchResponse): String {
     return HostOsBatchState[batch.state].icon;
 }
-export function hostOsBatchStateComment(subnet: HostOsBatch): string {
+export function hostOsBatchStateComment(subnet: HostOsBatch | HostOsBatchResponse): string {
     let s = HostOsBatchState[subnet.state].name;
     if (subnet.comment) {
         s = s + " • " + subnet.comment
@@ -348,8 +348,8 @@ export type HostOsBatch = {
     state: keyof typeof HostOsBatchState;
     comment: String;
     display_url: string;
-    planned_nodes: HostOsNode[];
-    actual_nodes: HostOsNode[] | null;
+    planned_nodes: number;
+    actual_nodes: number | null;
     selectors: HostOsNodeSelectors | null;
 };
 

--- a/rollout-dashboard/server/src/types.rs
+++ b/rollout-dashboard/server/src/types.rs
@@ -660,14 +660,14 @@ pub mod v2 {
             /// Links to the specific task within Airflow that this batch is currently performing; else it contains an empty string.
             pub display_url: String,
             /// A count of the nodes planned to be upgraded as part of this batch.
-            pub planned_nodes: Vec<Node>,
+            pub planned_nodes: usize,
             /// A list of selectors used to select which nodes to target for upgrade.
             /// This is None if the selectors are not yet known.
             pub selectors: Option<NodeSelectors>,
             /// A count of the nodes that actually were or are upgraded as part of this batch.
             /// Usually updated after collect_nodes has executed and has obtained a list of nodes.
             /// If that phase of the batch has yet to take place, this is usually null.
-            pub actual_nodes: Option<Vec<Node>>,
+            pub actual_nodes: Option<usize>,
         }
 
         impl From<&BatchResponse> for Batch {
@@ -679,17 +679,9 @@ pub mod v2 {
                     state: other.state.clone(),
                     comment: other.comment.clone(),
                     display_url: other.display_url.clone(),
-                    planned_nodes: other
-                        .planned_nodes
-                        .clone()
-                        .into_iter()
-                        .map(|n| n.into())
-                        .collect(),
+                    planned_nodes: other.planned_nodes.len(),
                     selectors: other.selectors.clone(),
-                    actual_nodes: other
-                        .actual_nodes
-                        .clone()
-                        .map(|ns| ns.into_iter().map(|n| n.into()).collect()),
+                    actual_nodes: other.actual_nodes.clone().map(|ns| ns.len()),
                 }
             }
         }


### PR DESCRIPTION
This changes the API to return node counts rather than node lists, slashing in half the amount of data sent with each update.