### PR TITLE
Support for exclusion in HostOS rollout plans.

### DIFF
--- a/rollout-dashboard/frontend/src/lib/Alert.svelte
+++ b/rollout-dashboard/frontend/src/lib/Alert.svelte
@@ -13,7 +13,7 @@
 
 {#if type === "info"}
     <div
-        class="flex items-center p-4 text-sm text-blue-800 border border-blue-300 rounded-lg bg-blue-50 dark:bg-blue-800 dark:text-blue-400 dark:border-blue-600"
+        class="flex items-center p-4 mb-2 mt-2 text-sm text-blue-800 border border-blue-300 rounded-lg bg-blue-50 dark:bg-blue-800 dark:text-blue-400 dark:border-blue-600"
         role="alert"
     >
         <InfoCircleOutline class="shrink-0 h-6 w-6 me-3" />
@@ -22,7 +22,7 @@
     </div>
 {:else if type === "black-info"}
     <div
-        class="flex items-center p-4 text-sm text-gray-800 border border-gray-300 rounded-lg bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600"
+        class="flex items-center p-4 mb-2 mt-2 text-sm text-gray-800 border border-gray-300 rounded-lg bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600"
         role="alert"
     >
         <InfoCircleOutline class="shrink-0 h-6 w-6 me-3" />
@@ -31,7 +31,7 @@
     </div>
 {:else if type === "warning"}
     <div
-        class="flex items-center p-4 text-sm text-yellow-800 border border-yellow-300 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 dark:border-yellow-600"
+        class="flex items-center p-4 mb-2 mt-2 text-sm text-yellow-800 border border-yellow-300 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 dark:border-yellow-600"
         role="alert"
     >
         <CircleMinusOutline class="shrink-0 h-6 w-6 me-3" />
@@ -42,7 +42,7 @@
     </div>
 {:else}
     <div
-        class="flex items-center p-4 text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 dark:border-red-800"
+        class="flex items-center p-4 mb-2 mt-2 text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 dark:border-red-800"
         role="alert"
     >
         <CloseCircleOutline class="shrink-0 h-6 w-6 me-3" />

--- a/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
@@ -328,9 +328,10 @@
                                 >{#if node["Assignment"] != "—" && node["Assignment"] != "API boundary"}<a
                                         class="oneliner text-secondary-600"
                                         target="_blank"
-                                        href="https://dashboard.internetcomputer.org/network/subnets/${node[
+                                        href="https://dashboard.internetcomputer.org/network/subnets/{node[
                                             'Assignment'
-                                        ]}">{node["Assignment"].split("-")}</a
+                                        ]}"
+                                        >{node["Assignment"].split("-")[0]}</a
                                     >{:else}{node["Assignment"].split(
                                         "-",
                                     )}{/if}</TableBodyCell

--- a/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
@@ -17,6 +17,7 @@
     import { cap } from "./lib";
     import InfoBlock from "./InfoBlock.svelte";
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
+    import Selectors from "./Selectors.svelte";
 
     interface Props {
         dag_run_id: string;
@@ -114,21 +115,26 @@
             <RegularTable striped={true}>
                 <TableBodyRow
                     ><TableHeadCell>Part of rollout</TableHeadCell
-                    ><TableBodyCell>{dag_run_id}</TableBodyCell></TableBodyRow
+                    ><TableBodyCell style="white-space: normal"
+                        >{dag_run_id}</TableBodyCell
+                    ></TableBodyRow
                 >
                 <TableBodyRow
                     ><TableHeadCell>Stage</TableHeadCell><TableBodyCell
+                        style="white-space: normal"
                         >{cap(batch.stage)}</TableBodyCell
                     ></TableBodyRow
                 >
                 <TableBodyRow
                     ><TableHeadCell>Planned at</TableHeadCell><TableBodyCell
+                        style="white-space: normal"
                         >{batch.planned_start_time.toString()}</TableBodyCell
                     ></TableBodyRow
                 >
                 {#if batch.actual_start_time !== null}
                     <TableBodyRow
                         ><TableHeadCell>Started at</TableHeadCell><TableBodyCell
+                            style="white-space: normal"
                             >{batch.actual_start_time.toString()}</TableBodyCell
                         ></TableBodyRow
                     >
@@ -136,12 +142,14 @@
                 {#if batch.end_time !== null}
                     <TableBodyRow
                         ><TableHeadCell>Started at</TableHeadCell><TableBodyCell
+                            style="white-space: normal"
                             >{batch.end_time.toString()}</TableBodyCell
                         ></TableBodyRow
                     >
                 {/if}
                 <TableBodyRow
                     ><TableHeadCell>State</TableHeadCell><TableBodyCell
+                        style="white-space: normal"
                         >{#if batch.display_url}<a
                                 rel="external"
                                 title="Open Airflow logs for the most recently updated task"
@@ -162,25 +170,30 @@
                 {#if batch.comment !== null && batch.comment !== ""}
                     <TableBodyRow
                         ><TableHeadCell>Comment</TableHeadCell><TableBodyCell
+                            style="white-space: normal"
                             >{batch.comment}</TableBodyCell
                         ></TableBodyRow
                     >
                 {/if}
                 <TableBodyRow
                     ><TableHeadCell>Selectors</TableHeadCell>
-                    <TableBodyCell
-                        >{formatSelectors(batch.selectors)}
+                    <TableBodyCell style="white-space: normal">
+                        <div
+                            style="display: flex; flex-grow: 0; justify-content: flex-start;"
+                        >
+                            <Selectors selectors={batch.selectors} />
+                        </div>
                     </TableBodyCell>
                 </TableBodyRow>
                 <TableBodyRow
                     ><TableHeadCell>Targets</TableHeadCell>
                     {#if actual_items !== null}
-                        <TableBodyCell
+                        <TableBodyCell style="white-space: normal"
                             >{planned_items.length} nodes planned, {actual_items.length}
                             actually targeted</TableBodyCell
                         >
                     {:else}
-                        <TableBodyCell
+                        <TableBodyCell style="white-space: normal"
                             >{planned_items.length} nodes planned</TableBodyCell
                         >
                     {/if}</TableBodyRow
@@ -188,7 +201,7 @@
                 {#if upgraded_nodes_summary}
                     <TableBodyRow
                         ><TableHeadCell>Upgrade status</TableHeadCell
-                        ><TableBodyCell
+                        ><TableBodyCell style="white-space: normal"
                             >{Object.entries(upgraded_nodes_summary)
                                 .map(([k, v]) => `${v} nodes ${k}`)
                                 .join(", ")}</TableBodyCell
@@ -198,7 +211,7 @@
                 {#if alerting_nodes_summary}
                     <TableBodyRow
                         ><TableHeadCell>Health status</TableHeadCell
-                        ><TableBodyCell
+                        ><TableBodyCell style="white-space: normal"
                             >{Object.entries(alerting_nodes_summary)
                                 .map(([k, v]) => `${v} nodes ${k}`)
                                 .join(", ")}</TableBodyCell

--- a/rollout-dashboard/frontend/src/lib/Selectors.svelte
+++ b/rollout-dashboard/frontend/src/lib/Selectors.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+    import { formatSpecifier, type HostOsNodeSelectors } from "./types";
+    import Selectors from "./Selectors.svelte";
+
+    interface Props {
+        selectors: HostOsNodeSelectors | null;
+    }
+
+    let { selectors }: Props = $props();
+</script>
+
+{#if selectors === null}
+    Selectors not known
+{:else if "intersect" in selectors}
+    {#if selectors.intersect.length === 0}
+        <div class="specifier">All remaining nodes</div>
+    {:else if selectors.intersect.length === 1}
+        <Selectors selectors={selectors.intersect[0]} />
+    {:else}
+        <div class="intersect">
+            {#each Object.entries(selectors.intersect) as [index, selector]}
+                {#if index !== "0"}<div
+                        class="operator"
+                        title="intersected with"
+                    >
+                        ⋂
+                    </div>{/if}
+                <Selectors selectors={selector} />
+            {/each}
+        </div>
+    {/if}
+{:else if "join" in selectors}
+    {#if selectors.join.length === 0}
+        <div class="specifier">No nodes</div>
+    {:else if selectors.join.length === 1}
+        <Selectors selectors={selectors.join[0]} />
+    {:else}
+        <div class="join">
+            {#each Object.entries(selectors.join) as [index, selector]}
+                {#if index !== "0"}<div class="operator">⋃</div>{/if}
+                <Selectors selectors={selector} />
+            {/each}
+        </div>
+    {/if}
+{:else if "not" in selectors}
+    <div class="complement">
+        <div class="specifier">remaining candidates</div>
+        <div class="operator">∖</div>
+        <Selectors selectors={selectors.not} />
+    </div>
+{:else}
+    <div class="specifier">{formatSpecifier(selectors)}</div>
+{/if}
+
+<style>
+    div {
+        display: flex;
+        text-align: center;
+        justify-content: center;
+        align-self: center;
+        padding: 0.5em;
+        border-radius: 1.5em;
+        border: 1px solid transparent;
+        flex-wrap: wrap;
+        gap: 1em;
+        flex-direction: column;
+    }
+    .intersect {
+        background-color: rgb(233, 220, 243);
+    }
+    .join {
+        background-color: rgb(209, 221, 236);
+    }
+    .complement {
+        background-color: rgb(248, 187, 187);
+    }
+    .specifier {
+        border-style: dashed;
+        border-color: rgb(21, 51, 9);
+        padding-top: 0.5em;
+        padding-bottom: 0.5em;
+        background-color: white;
+    }
+    .operator {
+        padding: 0em;
+        font-size: 150%;
+        font-weight: bold;
+        line-height: 0.5em;
+    }
+    /* .complement > * {
+        background-color: transparent;
+        border-style: none;
+        padding: 0em;
+    } */
+</style>

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -273,7 +273,7 @@ export type HostOsNodeComplement = {
 
 export type HostOsNodeSelectors = HostOsNodeAggregator | HostOsNodeFilter | HostOsNodeComplement | HostOsNodeSpecifier;
 
-function formatSpecifier(selector: HostOsNodeSpecifier): string {
+export function formatSpecifier(selector: HostOsNodeSpecifier): string {
     let health =
         selector.status === null
             ? " "

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -267,9 +267,13 @@ export type HostOsNodeFilter = {
     intersect: HostOsNodeSelectors[]
 }
 
-export type HostOsNodeSelectors = HostOsNodeAggregator | HostOsNodeFilter | HostOsNodeSpecifier;
+export type HostOsNodeComplement = {
+    not: HostOsNodeSelectors
+}
 
-function formatSelector(selector: HostOsNodeSpecifier): string {
+export type HostOsNodeSelectors = HostOsNodeAggregator | HostOsNodeFilter | HostOsNodeComplement | HostOsNodeSpecifier;
+
+function formatSpecifier(selector: HostOsNodeSpecifier): string {
     let health =
         selector.status === null
             ? " "
@@ -335,8 +339,12 @@ export function formatSelectors(selectors: HostOsNodeSelectors | null): string {
         } else {
             return "( " + (selectors as HostOsNodeAggregator).join.map((s) => formatSelectors(s)).join(" ∪ ") + " )"
         }
+    } else if ((selectors as HostOsNodeComplement).not !== undefined) {
+        {
+            return " — " + formatSelectors((selectors as HostOsNodeAggregator).join[0])
+        }
     }
-    return formatSelector((selectors as HostOsNodeSpecifier));
+    return formatSpecifier((selectors as HostOsNodeSpecifier));
 }
 
 

--- a/tests/test_hostos_rollout.py
+++ b/tests/test_hostos_rollout.py
@@ -175,3 +175,75 @@ def test_join_apibn_and_regular_assigned(
     assert len(sched["canary"][0]["nodes"]) == 2
     assert sched["canary"][0]["nodes"][0]["assignment"] == "API boundary"
     assert sched["canary"][0]["nodes"][1]["assignment"] != "API boundary"
+
+
+def test_nodes_dont_repeat_themselves(
+    mocker: Any, registry: dre.RegistrySnapshot
+) -> None:
+    "Schedule should bomb if one stage tries to upgrade too many nodes."
+    """Tests that the default rollout plan spec works."""
+    spec = textwrap.dedent("""\
+        stages:
+          canary:
+          - selectors:
+              join:
+              - assignment: API boundary
+                nodes_per_group: 1
+              - assignment: API boundary
+                nodes_per_group: 1
+        resume_at: 7:00
+        suspend_at: 15:00
+        minimum_minutes_per_batch: 30
+        """)
+    params: DagParams = {"simulate": True, "plan": spec, "git_revision": "0"}
+    mocker.patch("dfinity.dre.DRE.get_registry", return_value=registry)
+    sched = schedule(IC_NETWORKS["mainnet"], params)
+    assert len(sched["canary"][0]["nodes"]) == 2
+    assert (
+        sched["canary"][0]["nodes"][0]["node_id"]
+        != sched["canary"][0]["nodes"][1]["node_id"]
+    )
+
+
+def test_exclude_hk_nodes(mocker: Any, registry: dre.RegistrySnapshot) -> None:
+    "Schedule should bomb if one stage tries to upgrade too many nodes."
+    """Tests that the default rollout plan spec works."""
+    spec_without_exclusion = textwrap.dedent("""\
+        stages:
+          canary:
+          - selectors:
+                assignment: unassigned
+                nodes_per_group: 120
+        resume_at: 7:00
+        suspend_at: 15:00
+        minimum_minutes_per_batch: 30
+        """)
+    spec_with_exclusion = textwrap.dedent("""\
+        stages:
+          canary:
+          - selectors:
+              intersect:
+              - assignment: unassigned
+                nodes_per_group: 120
+              - not:
+                  datacenter: hk4
+        resume_at: 7:00
+        suspend_at: 15:00
+        minimum_minutes_per_batch: 30
+        """)
+    mocker.patch("dfinity.dre.DRE.get_registry", return_value=registry)
+    sched_without_exclusion = schedule(
+        IC_NETWORKS["mainnet"],
+        {"simulate": True, "plan": spec_without_exclusion, "git_revision": "0"},
+    )
+    sched_with_exclusion = schedule(
+        IC_NETWORKS["mainnet"],
+        {"simulate": True, "plan": spec_with_exclusion, "git_revision": "0"},
+    )
+    assert any(
+        n["dc_id"] == "hk4" for n in sched_without_exclusion["canary"][0]["nodes"]
+    )
+    assert len(sched_with_exclusion["canary"][0]["nodes"])
+    assert not any(
+        n["dc_id"] == "hk4" for n in sched_with_exclusion["canary"][0]["nodes"]
+    )


### PR DESCRIPTION
This allows us to support node selection predicates like `1 node per subnet except for nodes in datacenter hk4`.

All layers of the stack (rollout, dashboard backend and frontend) have gained this support.  Here is how a demo rollout using this feature looks like:

<img width="812" height="184" alt="image" src="https://github.com/user-attachments/assets/1fe0704c-8bcc-4463-a76d-6a9df95b1421" />
