### PR TITLE
Rollouts now show paused state within the rollout rectangle.

### DIFF
--- a/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesRollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/ApiBoundaryNodesRollout.svelte
@@ -14,11 +14,13 @@
     import BlackInfoBlock from "./BlackInfoBlock.svelte";
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
     import ClipboardIcon from "./ClipboardIcon.svelte";
+    import InfoBlock from "./InfoBlock.svelte";
     interface Props {
         rollout: ApiBoundaryNodesRollout;
+        paused: boolean;
     }
 
-    let { rollout }: Props = $props();
+    let { rollout, paused }: Props = $props();
 
     let rolloutClass: String = activeClass(rollout.state);
     let git_revision: string = rollout.conf.git_revision.toString();
@@ -67,6 +69,13 @@
         <div class="note space-y-4">
             <SvelteMarkdown source={rollout.note.toString()} />
         </div>
+    {/if}
+    {#if paused}
+        <InfoBlock>
+            <span class="font-medium">This rollout has its engine paused.</span>
+            Rollouts of this type have been paused by DRE. Use the
+            <i>Help</i> link below if you want to inquire why.
+        </InfoBlock>
     {/if}
     <div class="rollout_info space-y-4 text-gray-500">
         Git revision:

--- a/rollout-dashboard/frontend/src/lib/GuestOSRollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/GuestOSRollout.svelte
@@ -11,11 +11,13 @@
     import SubnetBatch from "./SubnetBatch.svelte";
     import BlackInfoBlock from "./BlackInfoBlock.svelte";
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
+    import InfoBlock from "./InfoBlock.svelte";
     interface Props {
         rollout: GuestOsRollout;
+        paused: boolean;
     }
 
-    let { rollout }: Props = $props();
+    let { rollout, paused }: Props = $props();
 
     let rolloutClass: String = activeClass(rollout.state);
 </script>
@@ -63,6 +65,13 @@
         <div class="note space-y-4">
             <SvelteMarkdown source={rollout.note.toString()} />
         </div>
+    {/if}
+    {#if paused}
+        <InfoBlock>
+            <span class="font-medium">This rollout has its engine paused.</span>
+            Rollouts of this type have been paused by DRE. Use the
+            <i>Help</i> link below if you want to inquire why.
+        </InfoBlock>
     {/if}
     {#if rollout.batches && Object.keys(rollout.batches).length > 0}
         <ul>

--- a/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
@@ -15,11 +15,13 @@
     import BlackInfoBlock from "./BlackInfoBlock.svelte";
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
     import ClipboardIcon from "./ClipboardIcon.svelte";
+    import InfoBlock from "./InfoBlock.svelte";
     interface Props {
         rollout: HostOsRollout;
+        paused: boolean;
     }
 
-    let { rollout }: Props = $props();
+    let { rollout, paused }: Props = $props();
 
     let rolloutClass: String = activeClass(rollout.state);
     let git_revision: string = rollout.conf.git_revision.toString();
@@ -72,6 +74,13 @@
         <div class="note space-y-4">
             <SvelteMarkdown source={rollout.note.toString()} />
         </div>
+    {/if}
+    {#if paused}
+        <InfoBlock>
+            <span class="font-medium">This rollout has its engine paused.</span>
+            Rollouts of this type have been paused by DRE. Use the
+            <i>Help</i> link below if you want to inquire why.
+        </InfoBlock>
     {/if}
     <div class="rollout_info space-y-4 text-gray-500">
         Git revision:

--- a/rollout-dashboard/frontend/src/routes/index.svelte
+++ b/rollout-dashboard/frontend/src/routes/index.svelte
@@ -209,27 +209,32 @@
                 DRE.
             </WarningBlock>
         {/if}
-
-        {#if state === "paused"}
-            <InfoBlock>
-                <span class="font-medium"
-                    >{rolloutKindName(kind)} engine paused.</span
-                >
-                {rolloutKindName(kind)} has been paused by DRE. Use the
-                <i>Help</i> link below if you want to inquire why.
-            </InfoBlock>
-        {/if}
     {/each}
 </div>
 
 {#each $view.rollouts as rollout}
     {#if (visibleStates.includes("active") && rollout.state !== "complete" && rollout.state !== "failed") || (visibleStates.includes("complete") && rollout.state === "complete") || (visibleStates.includes("failed") && rollout.state === "failed")}
         {#if rollout.kind === "rollout_ic_os_to_mainnet_subnets" && visibleKinds.includes("rollout_ic_os_to_mainnet_subnets")}
-            <GuestOSRollout {rollout} />
+            <GuestOSRollout
+                {rollout}
+                paused={$view.rollout_engine_states[
+                    "rollout_ic_os_to_mainnet_subnets"
+                ] === "paused"}
+            />
         {:else if rollout.kind === "rollout_ic_os_to_mainnet_api_boundary_nodes" && visibleKinds.includes("rollout_ic_os_to_mainnet_api_boundary_nodes")}
-            <ApiBoundaryNodesRollout {rollout} />
+            <ApiBoundaryNodesRollout
+                {rollout}
+                paused={$view.rollout_engine_states[
+                    "rollout_ic_os_to_mainnet_api_boundary_nodes"
+                ] === "paused"}
+            />
         {:else if rollout.kind === "rollout_ic_os_to_mainnet_nodes" && visibleKinds.includes("rollout_ic_os_to_mainnet_nodes")}
-            <HostOsRollout {rollout} />
+            <HostOsRollout
+                {rollout}
+                paused={$view.rollout_engine_states[
+                    "rollout_ic_os_to_mainnet_nodes"
+                ] === "paused"}
+            />
         {/if}
     {/if}
 {/each}


### PR DESCRIPTION
Before, we used to show the paused state at the top.  This did not make much sense, because the association between the infobox and the actual rollout is visually not noticeable.

Now we show the paused infobox within the rectangle of the rollout it affects.  Here is a visual of how that looks like:

<img width="1244" height="487" alt="image" src="https://github.com/user-attachments/assets/193814c0-3808-41c8-b344-5b53c381d35a" />


A bunch of imports no longer needed have been removed.