### PR TITLE
Fix: Update static content path in Dockerfile

### DIFF
--- a/rollout-dashboard/Dockerfile
+++ b/rollout-dashboard/Dockerfile
@@ -21,7 +21,7 @@ RUN npm run build
 FROM quay.io/fedora/fedora-minimal:42
 WORKDIR /
 COPY --from=rust /usr/src/rollout-dashboard/rollout-dashboard /rollout-dashboard
-COPY --from=node /workdir/dist/client /static
+COPY --from=node /workdir/dist /static
 
 EXPOSE 4174
 ENV FRONTEND_STATIC_DIR=static


### PR DESCRIPTION
Resolved an issue where the static content path was incorrect, causing frontend resources to load improperly.

**Changes:**
- Corrected the path from `/workdir/dist/client` to `/workdir/dist` in the `COPY` command for static files.