### PR TITLE
Gate unstable API behind variable, and provide XCom retrieval unstable API endpoint.

### DIFF
--- a/rollout-dashboard/server/src/airflow_client.rs
+++ b/rollout-dashboard/server/src/airflow_client.rs
@@ -221,7 +221,7 @@ impl Pageable for DagRunsResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct XComEntryResponse {
     #[allow(dead_code)]
     pub key: String,
@@ -1293,7 +1293,7 @@ impl AirflowClient {
         .await
     }
 
-    /// Return mapped tasks of a task instance in a DAG run.
+    /// Return XCom entry of a (possibly mapped) task instance in a DAG run.
     pub async fn xcom_entry(
         &self,
         dag_id: &str,

--- a/rollout-dashboard/server/src/live_state/task_sorter.rs
+++ b/rollout-dashboard/server/src/live_state/task_sorter.rs
@@ -88,9 +88,7 @@ impl TaskInstanceTopologicalSorter {
                 })
             }) {
                 Ok(pos) => {
-                    panic!(
-                        "Task instance {taskid} {mapindex:?} cannot be already in pos {pos}"
-                    )
+                    panic!("Task instance {taskid} {mapindex:?} cannot be already in pos {pos}")
                 } // element already in vector @ `pos`
                 Err(pos) => tasklist.insert(pos, rctaskinstance),
             }

--- a/rollout-dashboard/server/src/types.rs
+++ b/rollout-dashboard/server/src/types.rs
@@ -1383,6 +1383,7 @@ pub mod v2 {
 pub mod unstable {
     pub use crate::airflow_client::DagRunsResponseItem;
     pub use crate::airflow_client::TaskInstancesResponseItem;
+    pub use crate::airflow_client::XComEntryResponse;
     use chrono::{DateTime, Utc};
     use serde::Serialize;
 


### PR DESCRIPTION


With the feature gate behind a variable which defaults to false, we prevent anyone from retrieving any arbitrary XCom (task instance return value) from the unstable API endpoint, including anything potentially sensitive.