### PR TITLE
Fix corner case that would cause the dashboard to eat a ton of memory.

### DIFF
--- a/rollout-dashboard/frontend/src/App.svelte
+++ b/rollout-dashboard/frontend/src/App.svelte
@@ -15,6 +15,8 @@
   import HostOsBatchDetail from "./lib/HostOSBatchDetail.svelte";
   import { writable, type Writable } from "svelte/store";
   import NotFound from "./lib/NotFound.svelte";
+  import { rollouts_view_with_cancellation } from "./lib/stores";
+  import { onDestroy } from "svelte";
 
   type index_route = { name: "index" };
   type not_found = { name: "NotFound" };
@@ -71,17 +73,23 @@
     // For me, this means if it's not part of my admin path
     // if (!url.startsWith("/admin")) return;
   });
+
+  let [rollouts_view, cancel] = rollouts_view_with_cancellation();
+  onDestroy(() => {
+    cancel();
+  });
 </script>
 
 <div>
   {#key $selectedRoute}
     {#if $selectedRoute.name === "index"}
-      <Index />
+      <Index {rollouts_view} />
     {:else if $selectedRoute.name === "HostOsBatchDetail"}
       <HostOsBatchDetail
         dag_run_id={$selectedRoute.dag_run_id}
         stage_name={$selectedRoute.stage_name}
         batch_number={$selectedRoute.batch_number}
+        {rollouts_view}
       />
     {:else}
       <NotFound />

--- a/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSBatchDetail.svelte
@@ -21,17 +21,15 @@
     import InfoBlock from "./InfoBlock.svelte";
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
     import Selectors from "./Selectors.svelte";
-    import {
-        batch_view_with_cancellation,
-        rollouts_view_with_cancellation,
-    } from "./stores";
+    import { batch_view_with_cancellation, type FullState } from "./stores";
     import { onDestroy } from "svelte";
-    import { Dropdown, Heading, NavHamburger } from "flowbite-svelte";
+    import { Heading, NavHamburger } from "flowbite-svelte";
     import { Navbar, NavLi, NavUl, NavBrand } from "flowbite-svelte";
     import { AngleLeftOutline, GridOutline } from "flowbite-svelte-icons";
     import LoadingBlock from "./LoadingBlock.svelte";
     import ErrorBlock from "./ErrorBlock.svelte";
     import HostOsRollout from "./HostOSRollout.svelte";
+    import type { Writable } from "svelte/store";
 
     function reducer(akku: Record<string, number>, val: string) {
         let old_count = akku[val];
@@ -47,9 +45,11 @@
         dag_run_id: string;
         stage_name: string;
         batch_number: number;
+        rollouts_view: Writable<FullState>;
     }
 
-    let { dag_run_id, stage_name, batch_number }: Props = $props();
+    let { dag_run_id, stage_name, batch_number, rollouts_view }: Props =
+        $props();
 
     let [batch, cancel] = batch_view_with_cancellation(
         dag_run_id,
@@ -57,11 +57,8 @@
         batch_number,
     );
 
-    let [view, cancel_rollouts_view] = rollouts_view_with_cancellation();
-
     onDestroy(() => {
         cancel();
-        cancel_rollouts_view();
     });
 
     function getUpgradeStatus(
@@ -179,13 +176,14 @@
 
             <Popover class="cursor-pointer w-4/5">
                 <div>
-                    {#each $view.rollouts as rollout}
+                    {#each $rollouts_view.rollouts as rollout}
                         {#if rollout.name == dag_run_id && rollout.kind === "rollout_ic_os_to_mainnet_nodes"}
                             <HostOsRollout
                                 {rollout}
-                                paused={$view.rollout_engine_states[
+                                paused={$rollouts_view.rollout_engine_states[
                                     "rollout_ic_os_to_mainnet_nodes"
                                 ] === "paused"}
+                                {rollouts_view}
                             />
                         {/if}
                     {/each}

--- a/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
+++ b/rollout-dashboard/frontend/src/lib/HostOSRollout.svelte
@@ -16,12 +16,15 @@
     import ExternalLinkIcon from "./ExternalLinkIcon.svelte";
     import ClipboardIcon from "./ClipboardIcon.svelte";
     import InfoBlock from "./InfoBlock.svelte";
+    import type { Writable } from "svelte/store";
+    import type { FullState } from "./stores";
     interface Props {
         rollout: HostOsRollout;
         paused: boolean;
+        rollouts_view: Writable<FullState>;
     }
 
-    let { rollout, paused }: Props = $props();
+    let { rollout, paused, rollouts_view }: Props = $props();
 
     let rolloutClass: String = activeClass(rollout.state);
     let git_revision: string = rollout.conf.git_revision.toString();

--- a/rollout-dashboard/frontend/src/lib/index.svelte
+++ b/rollout-dashboard/frontend/src/lib/index.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-    import {
-        rollouts_view_with_cancellation,
-        type FullState,
-    } from "../lib/stores.js";
+    import { type FullState } from "../lib/stores.js";
     import {
         rolloutKindName,
         getRolloutEngineStates,

--- a/rollout-dashboard/frontend/src/lib/index.svelte
+++ b/rollout-dashboard/frontend/src/lib/index.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-    import { rollouts_view_with_cancellation } from "../lib/stores.js";
+    import {
+        rollouts_view_with_cancellation,
+        type FullState,
+    } from "../lib/stores.js";
     import {
         rolloutKindName,
         getRolloutEngineStates,
@@ -30,8 +33,12 @@
     import LoadingBlock from "../lib/LoadingBlock.svelte";
     import WarningBlock from "../lib/WarningBlock.svelte";
     import ExternalLinkIcon from "../lib/ExternalLinkIcon.svelte";
+    import type { Writable } from "svelte/store";
 
-    let [view, cancel] = rollouts_view_with_cancellation();
+    interface Props {
+        rollouts_view: Writable<FullState>;
+    }
+    let { rollouts_view }: Props = $props();
 
     let stateChoices: CheckboxItem[] = [
         { value: "active", label: "Active" },
@@ -74,7 +81,6 @@
         }
     });
     onDestroy(() => {
-        cancel();
         let savedFilters = {
             visibleStates: visibleStates,
             visibleKinds: visibleKinds,
@@ -162,17 +168,17 @@
         </NavUl>
     </Navbar>
 
-    {#if $view.error && $view.error !== "loading"}
+    {#if $rollouts_view.error && $rollouts_view.error !== "loading"}
         <ErrorBlock>
             <span class="font-medium">Cannot retrieve rollout data:</span>
-            {$view.error}
+            {$rollouts_view.error}
         </ErrorBlock>
     {/if}
 
-    {#if $view.error === "loading"}
+    {#if $rollouts_view.error === "loading"}
         <LoadingBlock />
     {/if}
-    {#each getRolloutEngineStates($view.rollout_engine_states) as [kind, state]}
+    {#each getRolloutEngineStates($rollouts_view.rollout_engine_states) as [kind, state]}
         {#if state === "missing"}
             <WarningBlock>
                 <span class="font-medium"
@@ -209,28 +215,29 @@
     {/each}
 </div>
 
-{#each $view.rollouts as rollout}
+{#each $rollouts_view.rollouts as rollout}
     {#if (visibleStates.includes("active") && rollout.state !== "complete" && rollout.state !== "failed") || (visibleStates.includes("complete") && rollout.state === "complete") || (visibleStates.includes("failed") && rollout.state === "failed")}
         {#if rollout.kind === "rollout_ic_os_to_mainnet_subnets" && visibleKinds.includes("rollout_ic_os_to_mainnet_subnets")}
             <GuestOSRollout
                 {rollout}
-                paused={$view.rollout_engine_states[
+                paused={$rollouts_view.rollout_engine_states[
                     "rollout_ic_os_to_mainnet_subnets"
                 ] === "paused"}
             />
         {:else if rollout.kind === "rollout_ic_os_to_mainnet_api_boundary_nodes" && visibleKinds.includes("rollout_ic_os_to_mainnet_api_boundary_nodes")}
             <ApiBoundaryNodesRollout
                 {rollout}
-                paused={$view.rollout_engine_states[
+                paused={$rollouts_view.rollout_engine_states[
                     "rollout_ic_os_to_mainnet_api_boundary_nodes"
                 ] === "paused"}
             />
         {:else if rollout.kind === "rollout_ic_os_to_mainnet_nodes" && visibleKinds.includes("rollout_ic_os_to_mainnet_nodes")}
             <HostOsRollout
                 {rollout}
-                paused={$view.rollout_engine_states[
+                paused={$rollouts_view.rollout_engine_states[
                     "rollout_ic_os_to_mainnet_nodes"
                 ] === "paused"}
+                {rollouts_view}
             />
         {/if}
     {/if}


### PR DESCRIPTION
During reconnection events, we were firing twice the reconnection attempts, causing an exponential increase in memory and an eventual hang of the dashboard.

Fix this.

This goes atop the following PR: https://github.com/dfinity/dre-airflow/pull/178