### PR TITLE
Refine HostOS rollout batch filtering.

### DIFF
--- a/rollout-dashboard/server/src/live_state/hostos_rollout.rs
+++ b/rollout-dashboard/server/src/live_state/hostos_rollout.rs
@@ -646,8 +646,22 @@ impl Parser {
         ) -> IndexMap<NonZero<usize>, BatchResponse> {
             m.into_iter()
                 .filter(|(_, v)| {
-                    !v.planned_nodes.is_empty()
-                        || !v.actual_nodes.clone().unwrap_or_default().is_empty()
+                    !(
+                        // We drop the batch if it has no planned nodes
+                        // AND (
+                        //   it is either known that there are no actual nodes,
+                        //   OR
+                        //   no nodes have been assigned to the task yet
+                        // )
+                        //
+                        // Basically if a batch has no planned work, and has
+                        // has not yet done any actual work yet, it is dropped.
+                        // If it has planned work, it is kept, even if it did
+                        // later do no actual work.  If it did not plan any work
+                        // but in the end did actual work, it is kept.
+                        v.planned_nodes.is_empty()
+                            && v.actual_nodes.as_ref().is_none_or(|nodes| nodes.is_empty())
+                    )
                 })
                 .collect()
         }


### PR DESCRIPTION
The filtering logic for HostOS rollouts is updated to exclude batches that have no planned nodes *and* no actual nodes, since those batches are skipped by definition.  This removes clutter from the screen, and also allows the batch detail view to correctly show that the batch may not yet appear, or (in the case of completed rollouts) is simply nonexistent.