### PR TITLE
Generate a new container for Airflow with version 2.11.0.

### DIFF
--- a/airflow-customized/Dockerfile
+++ b/airflow-customized/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.9.1-python3.12
+FROM apache/airflow:2.11.0-python3.12
 
 LABEL org.opencontainers.image.source="https://github.com/dfinity/dre-airflow"
 


### PR DESCRIPTION
Part of https://dfinity.atlassian.net/browse/DRE-496 .

This shall not be rolled into production directly, but rather with an upcoming Helm chart change that leverages this container version.