### PR TITLE
Fix: Pass target_time correctly in CustomDateTimeSensorAsync

### DIFF
--- a/plugins/sensors/ic_os_rollout.py
+++ b/plugins/sensors/ic_os_rollout.py
@@ -72,7 +72,7 @@ class CustomDateTimeSensorAsync(DateTimeSensorAsync):
     ) -> None:
         """Exists to work around inability to pass target_time as xcom arg."""
         self.simulate = simulate
-        DateTimeSensorAsync.__init__(self, **kwargs)
+        DateTimeSensorAsync.__init__(self, target_time=target_time, **kwargs)
 
         if isinstance(target_time, datetime.datetime):
             self.target_time = target_time.isoformat()


### PR DESCRIPTION
In the `CustomDateTimeSensorAsync` class, ensure that `target_time` is passed as an argument to the parent class constructor instead of relying on **kwargs. This change prevents issues where `target_time` might not be recognized if it's not explicitly specified.