### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/airflow-content-syncer-container.yaml
+++ b/.github/workflows/airflow-content-syncer-container.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # This image is based on ubuntu:20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create airflow-content-syncer container
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     # This image is based on ubuntu:20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create and publish airflow-content-syncer container
         with:

--- a/.github/workflows/airflow-content.yaml
+++ b/.github/workflows/airflow-content.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Test Airflow content
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Test
         uses: ./.github/workflows/test

--- a/.github/workflows/airflow-customized-container.yaml
+++ b/.github/workflows/airflow-customized-container.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # This image is based on ubuntu:20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create airflow-customized container
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     # This image is based on ubuntu:20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create and publish airflow-customized container
         with:

--- a/.github/workflows/rollout-dashboard.yaml
+++ b/.github/workflows/rollout-dashboard.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: Set month and year for cache key
         id: date
         run: echo "date=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Move backend files to source root
         run: mv -f rollout-dashboard/server/* .
       - name: Cache Cargo stuff once a month for faster execution
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           key: cargo-build-deps-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ steps.date.outputs.date }}
           path: |
@@ -41,11 +41,11 @@ jobs:
             target/debug/deps
             target/debug/.fingerprint
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
       - name: Security audit
-        uses: actions-rs/audit-check@v1
+        uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: cargo machete
@@ -54,11 +54,11 @@ jobs:
           which cargo-machete || cargo install cargo-machete
           cargo machete
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
       - name: cargo test
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: test
       - name: cargo doc
@@ -70,9 +70,9 @@ jobs:
     name: Test rollout dashboard frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20.x"
       - name: Move frontend files to source root
@@ -91,7 +91,7 @@ jobs:
     needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create rollout-dashboard container
         with:
@@ -103,7 +103,7 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/publish
         name: Create and publish rollout-dashboard container
         with:


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/cache@v3` -> `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `actions-rs/toolchain@v1` -> `actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7`
  - Version: v1.0.7 | Latest: v1.0.6 | Release age: 2207d
  - Commit: https://github.com/actions-rs/toolchain/commit/16499b5e05bf2e26879000db0c1d13f7e13fa3af

- `actions-rs/audit-check@v1` -> `actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0`
  - Version: v1.2.0 | Latest: v1.2.0 | Release age: 2163d
  - Commit: https://github.com/actions-rs/audit-check/commit/35b7b53b1e25b55642157ac01b4adceb5b9ebef3

- `actions-rs/cargo@v1` -> `actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3`
  - Version: v1.0.3 | Latest: v1.0.1 | Release age: 2398d
  - Commit: https://github.com/actions-rs/cargo/commit/844f36862e911db73fe0815f00a4a2602c279505

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020


### Files modified

- `.github/workflows/airflow-content-syncer-container.yaml`
- `.github/workflows/airflow-content.yaml`
- `.github/workflows/airflow-customized-container.yaml`
- `.github/workflows/rollout-dashboard.yaml`