### PR TITLE
Switch mainnet rollout plan sheet to in-org copy

### DIFF
--- a/dags/auto_compute_rollout.py
+++ b/dags/auto_compute_rollout.py
@@ -29,7 +29,7 @@ finally:
 
 
 DEFAULT_ROLLOUT_PLAN_SHEETS = {
-    "mainnet": "1ZcYB0gWjbgg7tFgy2Fhd3llzYlefJIb0Mik75UUrSXM",
+    "mainnet": "1c9GUWBGVGeg3-EmheQbvw9vPPXxQ7GqsNDjheI7UoCg",
 }
 
 if "2.9" in __version__:


### PR DESCRIPTION
## Summary

- The `auto_compute_rollout_to_mainnet` DAG has been failing `get_feature_rollout_plan` with `HTTP 403 PERMISSION_DENIED` from the Google Sheets API.
- Root cause: the configured sheet (`1ZcYB0gWjbgg7tFgy2Fhd3llzYlefJIb0Mik75UUrSXM`) sits outside the dfinity.org Workspace org, and DFINITY's Workspace policy blocks external sharing — so `airflow@airflow-422113.iam.gserviceaccount.com` cannot be added as a viewer ("Sorry, an item cannot be shared outside of DFINITY Foundation").
- Fix: point the default mainnet `release_feature_spreadsheet_id` at an in-org copy (`1c9GUWBGVGeg3-EmheQbvw9vPPXxQ7GqsNDjheI7UoCg`) that already has the service account shared as Viewer.