### PR TITLE
Exclude type4 (cloud engine) nodes from HostOS rollouts

### DIFF
--- a/plugins/operators/hostos_rollout.py
+++ b/plugins/operators/hostos_rollout.py
@@ -44,7 +44,16 @@ DFINITY: NodeProviderId = (
     "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe"
 )
 
+# Node reward types whose nodes must never be part of a HostOS rollout.
+# Currently used to exclude type4 nodes.
+EXCLUDED_NODE_REWARD_TYPE_PREFIXES: tuple[str, ...] = ("type4",)
+
 LOGGER = logging.getLogger(__name__)
+
+
+def _is_excluded_node_type(n: dre.RegistryNode) -> bool:
+    """Return True if the node should be globally excluded from HostOS rollouts."""
+    return n["node_reward_type"].startswith(EXCLUDED_NODE_REWARD_TYPE_PREFIXES)
 
 
 class DagParams(typing.TypedDict):
@@ -241,9 +250,13 @@ def compute_actual_plan_for_batch(
     possibility that nodes may have changed assignment in the meantime, or
     may have changed health status.
     """
-    # Exclude all upgraded nodes already.
+    # Exclude all upgraded nodes already, plus any nodes whose reward type
+    # is globally opted out of HostOS rollouts (see
+    # EXCLUDED_NODE_REWARD_TYPE_PREFIXES).
     remaining_nodes = [
-        n for n in registry["nodes"] if n["hostos_version_id"] != git_revision
+        n
+        for n in registry["nodes"]
+        if n["hostos_version_id"] != git_revision and not _is_excluded_node_type(n)
     ]
     dcs_owned_by_dfinity = set(
         d["dc_id"]
@@ -296,9 +309,13 @@ def compute_provisional_node_batches(
     expects the specific selectors for the single batch that will do the work,
     and does not iteratively reduce the number of nodes available.
     """
-    # Exclude all upgraded nodes already.
+    # Exclude all upgraded nodes already, plus any nodes whose reward type
+    # is globally opted out of HostOS rollouts (see
+    # EXCLUDED_NODE_REWARD_TYPE_PREFIXES).
     remaining_nodes = [
-        n for n in registry["nodes"] if n["hostos_version_id"] != git_revision
+        n
+        for n in registry["nodes"]
+        if n["hostos_version_id"] != git_revision and not _is_excluded_node_type(n)
     ]
     dcs_owned_by_dfinity = set(
         d["dc_id"]

--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -65,7 +65,7 @@ class RegistryNode(TypedDict):
     dc_id: rollout_types.DCId
     node_provider_id: rollout_types.NodeProviderId
     status: rollout_types.NodeStatus
-    #  "node_type": "type1.1"
+    node_reward_type: rollout_types.NodeRewardType
 
 
 class RegistrySubnet(TypedDict):

--- a/shared/dfinity/rollout_types.py
+++ b/shared/dfinity/rollout_types.py
@@ -12,6 +12,7 @@ type NodeProviderId = str
 type DCId = str
 type NodeStatus = Literal["Healthy"] | Literal["Degraded"] | Literal["Down"]
 type HostOsVersion = str
+type NodeRewardType = str
 
 type DaysOfWeek = (
     Literal["Monday"]

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -36,7 +36,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5alj6-ij6fd-4efxw-chag5-7a327-7uvyj-lhait-ojze2-gxxtr-mgfkf-rae": {
           "node_id": "5alj6-ij6fd-4efxw-chag5-7a327-7uvyj-lhait-ojze2-gxxtr-mgfkf-rae",
@@ -56,7 +56,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "64fwz-oyjy7-3r6wn-n5bhn-534fp-bjw2l-b5gel-gdrt4-egsun-6tkiw-cae": {
           "node_id": "64fwz-oyjy7-3r6wn-n5bhn-534fp-bjw2l-b5gel-gdrt4-egsun-6tkiw-cae",
@@ -76,7 +76,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6wnv3-oxkmg-rtcgq-slqsn-5xlwu-7a27t-524pa-st7b3-epsck-tixsa-uqe": {
           "node_id": "6wnv3-oxkmg-rtcgq-slqsn-5xlwu-7a27t-524pa-st7b3-epsck-tixsa-uqe",
@@ -96,7 +96,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "bkg32-x7k7j-t66jk-b4wqq-vul5w-qdtrw-5uefo-yuknb-fe54a-tp4lu-iae": {
           "node_id": "bkg32-x7k7j-t66jk-b4wqq-vul5w-qdtrw-5uefo-yuknb-fe54a-tp4lu-iae",
@@ -116,7 +116,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "buqsd-72zlu-hbgr2-hzjnr-mgvyj-6ldtg-2hdsd-igtpb-q7p2l-4j43v-5ae": {
           "node_id": "buqsd-72zlu-hbgr2-hzjnr-mgvyj-6ldtg-2hdsd-igtpb-q7p2l-4j43v-5ae",
@@ -136,7 +136,7 @@
           "dc_id": "st1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fh6lp-xtfi2-7aa22-dsx64-hs42f-hc2a2-wfqsu-5rvnk-7wcf7-yu6cm-kae": {
           "node_id": "fh6lp-xtfi2-7aa22-dsx64-hs42f-hc2a2-wfqsu-5rvnk-7wcf7-yu6cm-kae",
@@ -156,7 +156,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "gsvxv-tou7p-drlxw-rnldp-m7z3n-e42j4-nrsp4-dzsfc-7wuqr-2qwpf-pae": {
           "node_id": "gsvxv-tou7p-drlxw-rnldp-m7z3n-e42j4-nrsp4-dzsfc-7wuqr-2qwpf-pae",
@@ -176,7 +176,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "m34r6-l2rj7-deohw-yrkjp-sretm-6tadf-xnwqy-3flhm-nqj4r-wwcoh-eae": {
           "node_id": "m34r6-l2rj7-deohw-yrkjp-sretm-6tadf-xnwqy-3flhm-nqj4r-wwcoh-eae",
@@ -202,7 +202,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ptzzn-jphjl-476ql-lgyrk-37oa6-zxhat-ynn4f-fm2ry-r3cmf-lx7e6-uae": {
           "node_id": "ptzzn-jphjl-476ql-lgyrk-37oa6-zxhat-ynn4f-fm2ry-r3cmf-lx7e6-uae",
@@ -222,7 +222,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ux7wu-iidyv-r5cth-tz6n5-4xryn-av37c-24lrk-ozfaq-7sjax-ohkd2-6ae": {
           "node_id": "ux7wu-iidyv-r5cth-tz6n5-4xryn-av37c-24lrk-ozfaq-7sjax-ohkd2-6ae",
@@ -242,7 +242,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vudfj-wtx2a-hrx3r-rzc5m-dbuc2-hl5m6-b2liw-pxjzj-ugiwp-62frd-cqe": {
           "node_id": "vudfj-wtx2a-hrx3r-rzc5m-dbuc2-hl5m6-b2liw-pxjzj-ugiwp-62frd-cqe",
@@ -262,7 +262,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zxxo4-abmdb-uj3ok-cbj4k-is36g-b5o2d-c6akl-vmgyu-d2wie-hgr3y-uae": {
           "node_id": "zxxo4-abmdb-uj3ok-cbj4k-is36g-b5o2d-c6akl-vmgyu-d2wie-hgr3y-uae",
@@ -282,7 +282,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -398,7 +398,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5u6dm-zixbp-mbblj-xc7en-hsc7i-upw4t-3dzyb-63tfg-h3f5p-3q3b5-4qe": {
           "node_id": "5u6dm-zixbp-mbblj-xc7en-hsc7i-upw4t-3dzyb-63tfg-h3f5p-3q3b5-4qe",
@@ -418,7 +418,7 @@
           "dc_id": "sj2",
           "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7h3aw-y3ygk-37mdb-cbuj7-ric2q-b7pgf-xwspg-bxzq5-cxid3-lqqwi-nae": {
           "node_id": "7h3aw-y3ygk-37mdb-cbuj7-ric2q-b7pgf-xwspg-bxzq5-cxid3-lqqwi-nae",
@@ -438,7 +438,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "a6t2w-sxcps-qmgvc-vlitk-kvrsv-pqpl7-hylkb-urlhs-gove6-ehq7x-iae": {
           "node_id": "a6t2w-sxcps-qmgvc-vlitk-kvrsv-pqpl7-hylkb-urlhs-gove6-ehq7x-iae",
@@ -458,7 +458,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dofld-ghkjo-hynoo-myl2n-mgqql-vsbou-5sowc-bcwtw-u4sr7-4w4dy-nqe": {
           "node_id": "dofld-ghkjo-hynoo-myl2n-mgqql-vsbou-5sowc-bcwtw-u4sr7-4w4dy-nqe",
@@ -478,7 +478,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "hgbum-72ne6-onsua-rjul3-siwu5-da4zu-wkqro-rm4el-52osh-bhkgi-dqe": {
           "node_id": "hgbum-72ne6-onsua-rjul3-siwu5-da4zu-wkqro-rm4el-52osh-bhkgi-dqe",
@@ -498,7 +498,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "hm6f7-as4t3-33b2a-msirw-hhcc3-eq6yq-uoamo-eif7z-5d35z-u3pqd-yqe": {
           "node_id": "hm6f7-as4t3-33b2a-msirw-hhcc3-eq6yq-uoamo-eif7z-5d35z-u3pqd-yqe",
@@ -518,7 +518,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lmfy6-g2wta-3pp67-cjv5u-qws2j-kf3ci-tkze3-iqucl-mscsw-3u7bx-jae": {
           "node_id": "lmfy6-g2wta-3pp67-cjv5u-qws2j-kf3ci-tkze3-iqucl-mscsw-3u7bx-jae",
@@ -538,7 +538,7 @@
           "dc_id": "rg1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "lsew2-tmjjw-ytiyx-st6sx-qo2wi-cxu3e-sgidd-i34jd-okjsn-rtli5-cqe": {
           "node_id": "lsew2-tmjjw-ytiyx-st6sx-qo2wi-cxu3e-sgidd-i34jd-okjsn-rtli5-cqe",
@@ -558,7 +558,7 @@
           "dc_id": "bt1",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ocony-vhzun-3ygcw-3mck2-2knqd-d47bv-hi7jq-kbfc5-xf6ui-ou5c4-bqe": {
           "node_id": "ocony-vhzun-3ygcw-3mck2-2knqd-d47bv-hi7jq-kbfc5-xf6ui-ou5c4-bqe",
@@ -578,7 +578,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "qn5jg-h2if5-pw342-jegq5-fzrtg-n3gvv-e2xj5-47vpe-c7nyw-q6mwk-pqe": {
           "node_id": "qn5jg-h2if5-pw342-jegq5-fzrtg-n3gvv-e2xj5-47vpe-c7nyw-q6mwk-pqe",
@@ -598,7 +598,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "vte5d-zw5lg-axpbi-yrc6s-nm3mj-knu44-piwp3-ukrtj-xb4s5-mleiq-lae": {
           "node_id": "vte5d-zw5lg-axpbi-yrc6s-nm3mj-knu44-piwp3-ukrtj-xb4s5-mleiq-lae",
@@ -618,7 +618,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zjcl6-i6eie-fllmg-27ohu-lm4cy-4dax2-7ppcd-4mgig-rtfpz-typl6-yqe": {
           "node_id": "zjcl6-i6eie-fllmg-27ohu-lm4cy-4dax2-7ppcd-4mgig-rtfpz-typl6-yqe",
@@ -638,7 +638,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -699,7 +699,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe": {
           "node_id": "5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe",
@@ -719,7 +719,7 @@
           "dc_id": "si1",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "7f5c7-l7cuq-7jnfc-yexo3-bytd3-yf6xa-ctk76-wywln-jsy2n-ds2lp-tqe": {
           "node_id": "7f5c7-l7cuq-7jnfc-yexo3-bytd3-yf6xa-ctk76-wywln-jsy2n-ds2lp-tqe",
@@ -739,7 +739,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "b5pgw-6wtjo-dzwgu-zkfz6-3l5f3-cw6ka-y4crr-dikku-fkjbe-lfzki-qae": {
           "node_id": "b5pgw-6wtjo-dzwgu-zkfz6-3l5f3-cw6ka-y4crr-dikku-fkjbe-lfzki-qae",
@@ -759,7 +759,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "c3syk-l56ky-owcvg-y4ogf-3qfti-elv4e-2bqp7-k5v32-ibzm6-o4k6s-eqe": {
           "node_id": "c3syk-l56ky-owcvg-y4ogf-3qfti-elv4e-2bqp7-k5v32-ibzm6-o4k6s-eqe",
@@ -779,7 +779,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "hhixb-o5xrj-s5pty-esitz-m6s46-wgsez-c7thd-6h27w-7hikq-ae5n7-pae": {
           "node_id": "hhixb-o5xrj-s5pty-esitz-m6s46-wgsez-c7thd-6h27w-7hikq-ae5n7-pae",
@@ -799,7 +799,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lpkij-6jgir-sukcx-6kplx-qddla-ufncr-e3m2p-kikly-bcwzd-mtslj-4ae": {
           "node_id": "lpkij-6jgir-sukcx-6kplx-qddla-ufncr-e3m2p-kikly-bcwzd-mtslj-4ae",
@@ -819,7 +819,7 @@
           "dc_id": "kr2",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "m4e6a-3t7oi-ooshc-2b2vq-56xpu-pyo7q-qafn2-3sem2-cvtck-6xfqy-vae": {
           "node_id": "m4e6a-3t7oi-ooshc-2b2vq-56xpu-pyo7q-qafn2-3sem2-cvtck-6xfqy-vae",
@@ -839,7 +839,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ns7kv-kp2mu-mw7yi-krd4z-eqcvq-qeeej-mxtwb-c2ujq-xtq6x-orzoj-3qe": {
           "node_id": "ns7kv-kp2mu-mw7yi-krd4z-eqcvq-qeeej-mxtwb-c2ujq-xtq6x-orzoj-3qe",
@@ -859,7 +859,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "o42ny-ab3zt-iknyx-eo4ji-utgbe-xmae4-ybmwp-wdkzt-efffe-oq6nh-oae": {
           "node_id": "o42ny-ab3zt-iknyx-eo4ji-utgbe-xmae4-ybmwp-wdkzt-efffe-oq6nh-oae",
@@ -879,7 +879,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rfe2u-pdp5u-frzdb-r2ga3-5jept-24323-5pere-7lerg-toh4w-cwdsl-cqe": {
           "node_id": "rfe2u-pdp5u-frzdb-r2ga3-5jept-24323-5pere-7lerg-toh4w-cwdsl-cqe",
@@ -899,7 +899,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rwze6-4mvpx-o5pdv-3sujg-2szcx-223oi-f3jnl-jx27g-2qs22-dmt2j-jae": {
           "node_id": "rwze6-4mvpx-o5pdv-3sujg-2szcx-223oi-f3jnl-jx27g-2qs22-dmt2j-jae",
@@ -919,7 +919,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vw36t-lgksm-5cgtg-ait3y-sy25v-gdtsq-en6oe-md35y-a7cji-uiryt-3ae": {
           "node_id": "vw36t-lgksm-5cgtg-ait3y-sy25v-gdtsq-en6oe-md35y-a7cji-uiryt-3ae",
@@ -939,7 +939,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -1000,7 +1000,7 @@
           "dc_id": "at2",
           "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "46dgm-up32t-4urre-upnr3-p5o2g-kamxl-lm5wp-k3rhi-zo26u-bpiha-iae": {
           "node_id": "46dgm-up32t-4urre-upnr3-p5o2g-kamxl-lm5wp-k3rhi-zo26u-bpiha-iae",
@@ -1020,7 +1020,7 @@
           "dc_id": "to1",
           "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "b37zb-apiex-wwlpd-ccbxn-yes6n-q44fy-jtz3j-mjxrs-ecw7v-lzmut-oae": {
           "node_id": "b37zb-apiex-wwlpd-ccbxn-yes6n-q44fy-jtz3j-mjxrs-ecw7v-lzmut-oae",
@@ -1040,7 +1040,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "clpy5-qdkib-dop3e-vts5k-btmkp-qncpk-kn4jj-zfiiu-a6b4m-nscgs-fqe": {
           "node_id": "clpy5-qdkib-dop3e-vts5k-btmkp-qncpk-kn4jj-zfiiu-a6b4m-nscgs-fqe",
@@ -1060,7 +1060,7 @@
           "dc_id": "hk4",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "d4bgb-fhurc-bbdvo-ipdyx-mhb6t-ggr46-2qo42-tksma-svhyp-3ue4b-6qe": {
           "node_id": "d4bgb-fhurc-bbdvo-ipdyx-mhb6t-ggr46-2qo42-tksma-svhyp-3ue4b-6qe",
@@ -1080,7 +1080,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "e3l2o-4iy5c-43qaf-uvxbg-5slee-26j3w-iwdn3-ynwq3-z3ykg-kfzmo-pqe": {
           "node_id": "e3l2o-4iy5c-43qaf-uvxbg-5slee-26j3w-iwdn3-ynwq3-z3ykg-kfzmo-pqe",
@@ -1100,7 +1100,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "h57j6-72adp-jfeng-6xb5w-mqsgt-srmsc-gny3c-unzsx-fqrvu-ggao6-yae": {
           "node_id": "h57j6-72adp-jfeng-6xb5w-mqsgt-srmsc-gny3c-unzsx-fqrvu-ggao6-yae",
@@ -1120,7 +1120,7 @@
           "dc_id": "tv1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "hdkxy-jonbm-voico-5u7px-6vet6-6i7zx-xm65d-gdswt-2uvss-5o73g-aae": {
           "node_id": "hdkxy-jonbm-voico-5u7px-6vet6-6i7zx-xm65d-gdswt-2uvss-5o73g-aae",
@@ -1140,7 +1140,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "l4tph-sjzvn-2577n-igj5r-n2mwu-wqz5r-rabgw-xphul-dxpey-uwxnh-kae": {
           "node_id": "l4tph-sjzvn-2577n-igj5r-n2mwu-wqz5r-rabgw-xphul-dxpey-uwxnh-kae",
@@ -1160,7 +1160,7 @@
           "dc_id": "zh5",
           "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "m4mgu-gzf3s-4hwzh-7laf4-664rq-m6lu4-qs64b-yqrua-gfzdh-lmuf5-xqe": {
           "node_id": "m4mgu-gzf3s-4hwzh-7laf4-664rq-m6lu4-qs64b-yqrua-gfzdh-lmuf5-xqe",
@@ -1180,7 +1180,7 @@
           "dc_id": "se1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ncrki-fugy2-kmcnn-k3u67-ezjsz-6s76c-2iucl-xc63o-vn2lk-yebq4-jqe": {
           "node_id": "ncrki-fugy2-kmcnn-k3u67-ezjsz-6s76c-2iucl-xc63o-vn2lk-yebq4-jqe",
@@ -1200,7 +1200,7 @@
           "dc_id": "mb1",
           "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "swzzz-nct4o-kgh2s-fezeh-luamk-chexm-jsk4r-ks2qa-au63y-jtc7r-pae": {
           "node_id": "swzzz-nct4o-kgh2s-fezeh-luamk-chexm-jsk4r-ks2qa-au63y-jtc7r-pae",
@@ -1220,7 +1220,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xbsjm-f7kbx-wrerv-ponbs-e3kjp-pvt6d-lgjfv-kolpw-c4j3y-to5pe-7qe": {
           "node_id": "xbsjm-f7kbx-wrerv-ponbs-e3kjp-pvt6d-lgjfv-kolpw-c4j3y-to5pe-7qe",
@@ -1240,7 +1240,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -1301,7 +1301,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4nkoi-tdk2r-bfboy-5dokf-zc2tp-sokpx-hqfr5-6znc4-vqnxe-kr7ro-iqe": {
           "node_id": "4nkoi-tdk2r-bfboy-5dokf-zc2tp-sokpx-hqfr5-6znc4-vqnxe-kr7ro-iqe",
@@ -1321,7 +1321,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "5zqhj-66qn7-he3p5-76gnj-hlsvl-ajlt5-k356i-fgm4m-5it4c-6m5ag-7qe": {
           "node_id": "5zqhj-66qn7-he3p5-76gnj-hlsvl-ajlt5-k356i-fgm4m-5it4c-6m5ag-7qe",
@@ -1341,7 +1341,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "7agd5-pfc4g-rdozn-zajij-aax72-7jft2-rzw36-y3flc-xwt77-pjg5w-7qe": {
           "node_id": "7agd5-pfc4g-rdozn-zajij-aax72-7jft2-rzw36-y3flc-xwt77-pjg5w-7qe",
@@ -1361,7 +1361,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bqplp-iejs2-2awcz-oiy6u-62jzx-rzp66-z4eba-m6nan-dtljh-bb4pn-rae": {
           "node_id": "bqplp-iejs2-2awcz-oiy6u-62jzx-rzp66-z4eba-m6nan-dtljh-bb4pn-rae",
@@ -1381,7 +1381,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "cvic3-6mmjj-2zszr-mr727-im4l5-skwod-gzrg2-avd4i-bahw3-xyx3l-2ae": {
           "node_id": "cvic3-6mmjj-2zszr-mr727-im4l5-skwod-gzrg2-avd4i-bahw3-xyx3l-2ae",
@@ -1401,7 +1401,7 @@
           "dc_id": "at2",
           "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jvqnq-6jnty-tr3ml-izvma-e5w6e-s3rfx-w4wir-mwcsf-x5yok-nc4uz-6ae": {
           "node_id": "jvqnq-6jnty-tr3ml-izvma-e5w6e-s3rfx-w4wir-mwcsf-x5yok-nc4uz-6ae",
@@ -1421,7 +1421,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kdowl-chtwc-lkojq-lfb2l-p4w77-35pmk-3ixsh-hqhj3-uxi4k-jh7ge-mqe": {
           "node_id": "kdowl-chtwc-lkojq-lfb2l-p4w77-35pmk-3ixsh-hqhj3-uxi4k-jh7ge-mqe",
@@ -1441,7 +1441,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ktqjk-r6yho-cqgxd-qaqqn-yhxvl-ez6ax-jk3n4-bfa2f-vprkh-eigf5-5qe": {
           "node_id": "ktqjk-r6yho-cqgxd-qaqqn-yhxvl-ez6ax-jk3n4-bfa2f-vprkh-eigf5-5qe",
@@ -1461,7 +1461,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "najnj-to3ju-pl6pl-5yjlc-6vdqi-f7tht-qd7tt-fenyr-f3tjc-tfj37-uae": {
           "node_id": "najnj-to3ju-pl6pl-5yjlc-6vdqi-f7tht-qd7tt-fenyr-f3tjc-tfj37-uae",
@@ -1481,7 +1481,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "oiso5-hxkkc-elqlo-iyoqg-7oux4-5mscl-zkvoh-b2432-ohrir-b5fcm-gae": {
           "node_id": "oiso5-hxkkc-elqlo-iyoqg-7oux4-5mscl-zkvoh-b2432-ohrir-b5fcm-gae",
@@ -1501,7 +1501,7 @@
           "dc_id": "ma3",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ozim4-dez5l-gk24c-m7phw-e6i32-c7vxe-m6you-mkprj-moxq2-fhtyw-uae": {
           "node_id": "ozim4-dez5l-gk24c-m7phw-e6i32-c7vxe-m6you-mkprj-moxq2-fhtyw-uae",
@@ -1521,7 +1521,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qzvif-vpece-l4rga-6l6v7-tdegr-ycnty-p3zgo-qzghb-v5hmq-edjbv-lqe": {
           "node_id": "qzvif-vpece-l4rga-6l6v7-tdegr-ycnty-p3zgo-qzghb-v5hmq-edjbv-lqe",
@@ -1541,7 +1541,7 @@
           "dc_id": "wa3",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -1608,7 +1608,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cbtjz-aon2h-2hlj5-6sdzt-zrdfs-2tdhj-tzgpg-mwkod-ptfy4-hlqly-3qe": {
           "node_id": "cbtjz-aon2h-2hlj5-6sdzt-zrdfs-2tdhj-tzgpg-mwkod-ptfy4-hlqly-3qe",
@@ -1628,7 +1628,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "haeka-mchv4-zwg3j-d3sz2-k5z2x-ulfmb-kflyu-ezzlz-ckc3d-ako5j-uqe": {
           "node_id": "haeka-mchv4-zwg3j-d3sz2-k5z2x-ulfmb-kflyu-ezzlz-ckc3d-ako5j-uqe",
@@ -1654,7 +1654,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ihoip-fmbnl-mm4fa-pu7hu-2sbx2-mzl2f-tgzje-unnjg-bgcac-3apmo-gqe": {
           "node_id": "ihoip-fmbnl-mm4fa-pu7hu-2sbx2-mzl2f-tgzje-unnjg-bgcac-3apmo-gqe",
@@ -1674,7 +1674,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jtvnx-kem2o-icln6-b4oy6-n5ru5-dmksj-dfk5i-4ejvq-k3unp-47gjb-mae": {
           "node_id": "jtvnx-kem2o-icln6-b4oy6-n5ru5-dmksj-dfk5i-4ejvq-k3unp-47gjb-mae",
@@ -1694,7 +1694,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ocvcv-56eg5-gxibh-dcgpo-unhwq-4bwmo-x7q3h-stwf2-ycfex-gdr2a-kae": {
           "node_id": "ocvcv-56eg5-gxibh-dcgpo-unhwq-4bwmo-x7q3h-stwf2-ycfex-gdr2a-kae",
@@ -1714,7 +1714,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "oswv7-a355p-a5jlp-ko7pj-arrs2-rghho-dti4z-xgptn-szn55-jjr46-uqe": {
           "node_id": "oswv7-a355p-a5jlp-ko7pj-arrs2-rghho-dti4z-xgptn-szn55-jjr46-uqe",
@@ -1734,7 +1734,7 @@
           "dc_id": "ty3",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "srgrm-5pwg2-225hn-fxwdd-zphpu-wwxgu-uxako-avmlx-epw7e-zwkhf-sqe": {
           "node_id": "srgrm-5pwg2-225hn-fxwdd-zphpu-wwxgu-uxako-avmlx-epw7e-zwkhf-sqe",
@@ -1754,7 +1754,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ttjeo-6vece-x2hpb-lzmdg-b2fwl-7osa4-r5vb6-n4dyc-ocg5r-rztx2-eqe": {
           "node_id": "ttjeo-6vece-x2hpb-lzmdg-b2fwl-7osa4-r5vb6-n4dyc-ocg5r-rztx2-eqe",
@@ -1774,7 +1774,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "tu7cd-aljf3-56j73-xdusu-fyjps-sgkoi-5w3fx-p3vvd-tusca-w2vyl-bqe": {
           "node_id": "tu7cd-aljf3-56j73-xdusu-fyjps-sgkoi-5w3fx-p3vvd-tusca-w2vyl-bqe",
@@ -1794,7 +1794,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "uouxk-c246i-dgxzd-ql3a5-koofn-mclrv-toplo-bg76d-l4dzk-ngb3c-nae": {
           "node_id": "uouxk-c246i-dgxzd-ql3a5-koofn-mclrv-toplo-bg76d-l4dzk-ngb3c-nae",
@@ -1814,7 +1814,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "wq5v7-ngito-7ztqs-zlf2v-ibk6f-e54em-t3hou-x24kz-v5j77-6vo72-kqe": {
           "node_id": "wq5v7-ngito-7ztqs-zlf2v-ibk6f-e54em-t3hou-x24kz-v5j77-6vo72-kqe",
@@ -1834,7 +1834,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zos66-lmcn7-satbv-gcdzj-q3cdf-4n6zc-2hlei-gc453-uoh7r-4sj3w-vqe": {
           "node_id": "zos66-lmcn7-satbv-gcdzj-q3cdf-4n6zc-2hlei-gc453-uoh7r-4sj3w-vqe",
@@ -1854,7 +1854,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -1915,7 +1915,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4cldf-jb7ta-kvxlu-e6otc-fotnw-cgjot-vmo27-pt63w-btc7d-yo6dn-eae": {
           "node_id": "4cldf-jb7ta-kvxlu-e6otc-fotnw-cgjot-vmo27-pt63w-btc7d-yo6dn-eae",
@@ -1935,7 +1935,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4mm7j-dmeng-7ib4h-yvt3c-g5ed6-i5yar-rrc6w-rp7tk-ej3by-gilvv-kae": {
           "node_id": "4mm7j-dmeng-7ib4h-yvt3c-g5ed6-i5yar-rrc6w-rp7tk-ej3by-gilvv-kae",
@@ -1955,7 +1955,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "afjfz-erkja-k7euy-yjjrk-tsvsw-hfad7-allt6-4lb3e-kscys-7uyge-7ae": {
           "node_id": "afjfz-erkja-k7euy-yjjrk-tsvsw-hfad7-allt6-4lb3e-kscys-7uyge-7ae",
@@ -1975,7 +1975,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "efdju-ef2ce-a5jdn-obybl-x6ema-h5lwv-nc2sy-v4hvc-7nltm-aldtv-6ae": {
           "node_id": "efdju-ef2ce-a5jdn-obybl-x6ema-h5lwv-nc2sy-v4hvc-7nltm-aldtv-6ae",
@@ -1995,7 +1995,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jj7si-b7rs7-nq7sv-npame-aec3y-2anip-ol5s6-gxbh7-kjbg2-a5u6j-rae": {
           "node_id": "jj7si-b7rs7-nq7sv-npame-aec3y-2anip-ol5s6-gxbh7-kjbg2-a5u6j-rae",
@@ -2015,7 +2015,7 @@
           "dc_id": "ma1",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "n4d4s-hgx3a-nwox5-tmfqw-q2gu6-mlzhy-deyzq-zu6r7-wryv2-napyl-qae": {
           "node_id": "n4d4s-hgx3a-nwox5-tmfqw-q2gu6-mlzhy-deyzq-zu6r7-wryv2-napyl-qae",
@@ -2035,7 +2035,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "r4dbq-jplty-hxb2n-yx4pt-dm2vf-m73ro-sqgq7-onnzn-zenvp-dleaz-mae": {
           "node_id": "r4dbq-jplty-hxb2n-yx4pt-dm2vf-m73ro-sqgq7-onnzn-zenvp-dleaz-mae",
@@ -2055,7 +2055,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "rzm7j-37ied-ynlvt-zma7n-r4bjg-wxg2d-kr4me-ss4yr-3p5se-n4sry-wqe": {
           "node_id": "rzm7j-37ied-ynlvt-zma7n-r4bjg-wxg2d-kr4me-ss4yr-3p5se-n4sry-wqe",
@@ -2075,7 +2075,7 @@
           "dc_id": "zg1",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "td2et-sj5tw-njhtp-uw2ly-zwmwn-g4frd-off2d-5adoy-ybkoa-lj2ns-5ae": {
           "node_id": "td2et-sj5tw-njhtp-uw2ly-zwmwn-g4frd-off2d-5adoy-ybkoa-lj2ns-5ae",
@@ -2095,7 +2095,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "tgmtp-wy3f4-hqron-bnvc3-scclx-b7fgg-gdnc2-dwvks-dn6ao-gbqso-5ae": {
           "node_id": "tgmtp-wy3f4-hqron-bnvc3-scclx-b7fgg-gdnc2-dwvks-dn6ao-gbqso-5ae",
@@ -2115,7 +2115,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vuizy-nfm5v-rapnc-rijer-hijfx-bvjrz-ccxdd-kte3v-awbnq-bdm6m-6qe": {
           "node_id": "vuizy-nfm5v-rapnc-rijer-hijfx-bvjrz-ccxdd-kte3v-awbnq-bdm6m-6qe",
@@ -2135,7 +2135,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vwsvq-sp3z5-kjy66-srr2f-esws7-mzchn-oeqdb-n3qvz-wrzni-4pcsy-lae": {
           "node_id": "vwsvq-sp3z5-kjy66-srr2f-esws7-mzchn-oeqdb-n3qvz-wrzni-4pcsy-lae",
@@ -2155,7 +2155,7 @@
           "dc_id": "tv1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -2216,7 +2216,7 @@
           "dc_id": "ta2",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3yok3-yvswm-l4ior-bjh62-fsi73-vfqp3-77wji-coglq-l2bjw-rxrph-uqe": {
           "node_id": "3yok3-yvswm-l4ior-bjh62-fsi73-vfqp3-77wji-coglq-l2bjw-rxrph-uqe",
@@ -2236,7 +2236,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "7exbb-k4tu4-mw24y-3zylh-bopa5-fwdsc-f4a3z-45hh4-twpin-4zv4a-yae": {
           "node_id": "7exbb-k4tu4-mw24y-3zylh-bopa5-fwdsc-f4a3z-45hh4-twpin-4zv4a-yae",
@@ -2256,7 +2256,7 @@
           "dc_id": "ba1",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "a3xcb-ezfy5-yib3b-5bo75-5nok4-kaolh-a6akg-ilxck-qdbph-pwppb-dae": {
           "node_id": "a3xcb-ezfy5-yib3b-5bo75-5nok4-kaolh-a6akg-ilxck-qdbph-pwppb-dae",
@@ -2276,7 +2276,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "c4xi6-jnokz-uhpvd-lpwoe-hra3h-ph7ia-77clm-xfxf3-lskj2-4fohp-tqe": {
           "node_id": "c4xi6-jnokz-uhpvd-lpwoe-hra3h-ph7ia-77clm-xfxf3-lskj2-4fohp-tqe",
@@ -2302,7 +2302,7 @@
           "dc_id": "zg1",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dzol4-3eqco-5b5ag-ritui-tyl7u-i3iwz-ex2qo-cbfjx-5fmxw-yfgwo-tqe": {
           "node_id": "dzol4-3eqco-5b5ag-ritui-tyl7u-i3iwz-ex2qo-cbfjx-5fmxw-yfgwo-tqe",
@@ -2322,7 +2322,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "foa3b-mjkuu-3qlgu-6o64i-2omzt-x6suc-5gzcq-6j2gz-bftru-j5idg-gae": {
           "node_id": "foa3b-mjkuu-3qlgu-6o64i-2omzt-x6suc-5gzcq-6j2gz-bftru-j5idg-gae",
@@ -2342,7 +2342,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ldqxr-qdliy-howvj-2tamr-3fwul-liakv-7523k-tmhrz-5geyk-jlu7b-uae": {
           "node_id": "ldqxr-qdliy-howvj-2tamr-3fwul-liakv-7523k-tmhrz-5geyk-jlu7b-uae",
@@ -2362,7 +2362,7 @@
           "dc_id": "vl2",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "popmv-gccw7-zincv-gtcgo-jxfby-ar7zq-odvna-4jcs2-cnovy-qiha6-yae": {
           "node_id": "popmv-gccw7-zincv-gtcgo-jxfby-ar7zq-odvna-4jcs2-cnovy-qiha6-yae",
@@ -2382,7 +2382,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tsbrx-uiuyw-pf3h4-bx5i3-daxya-ygait-mnedj-kj574-vsw3u-fwuuz-5qe": {
           "node_id": "tsbrx-uiuyw-pf3h4-bx5i3-daxya-ygait-mnedj-kj574-vsw3u-fwuuz-5qe",
@@ -2402,7 +2402,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "w3phu-4ihah-tqdl6-n32hp-e5254-l6ybu-kvmmx-thj6t-q7z7k-swvi4-iqe": {
           "node_id": "w3phu-4ihah-tqdl6-n32hp-e5254-l6ybu-kvmmx-thj6t-q7z7k-swvi4-iqe",
@@ -2422,7 +2422,7 @@
           "dc_id": "zh3",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xzpf4-zeihc-upncx-zz65w-rep5j-xh2sy-yw6bg-qtgwu-5z3ez-er2gz-sae": {
           "node_id": "xzpf4-zeihc-upncx-zz65w-rep5j-xh2sy-yw6bg-qtgwu-5z3ez-er2gz-sae",
@@ -2442,7 +2442,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yf2ct-a2auf-nofdz-acf6v-ugwyb-k5f6j-5sr3y-7h3xi-svcdg-mhpgg-aae": {
           "node_id": "yf2ct-a2auf-nofdz-acf6v-ugwyb-k5f6j-5sr3y-7h3xi-svcdg-mhpgg-aae",
@@ -2462,7 +2462,7 @@
           "dc_id": "rg1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -2523,7 +2523,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5hni3-coaib-iuz4m-dxyvz-7bntg-hnwji-rghvw-sjvtj-nd2rd-jgjsn-jae": {
           "node_id": "5hni3-coaib-iuz4m-dxyvz-7bntg-hnwji-rghvw-sjvtj-nd2rd-jgjsn-jae",
@@ -2543,7 +2543,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "gyty5-impo7-5uugu-2ocbi-ekcg2-eloni-cj67g-vasbq-i4z74-2bhpw-7qe": {
           "node_id": "gyty5-impo7-5uugu-2ocbi-ekcg2-eloni-cj67g-vasbq-i4z74-2bhpw-7qe",
@@ -2563,7 +2563,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "i7zdo-qrk2t-phjla-2unbd-p76z5-eg2m3-yko4n-5dclc-rewwh-t33gv-wae": {
           "node_id": "i7zdo-qrk2t-phjla-2unbd-p76z5-eg2m3-yko4n-5dclc-rewwh-t33gv-wae",
@@ -2583,7 +2583,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jx6y5-u55cq-nwk3i-niahw-ogiah-vy46i-vq4oa-b7azf-27wgi-v7hhr-sqe": {
           "node_id": "jx6y5-u55cq-nwk3i-niahw-ogiah-vy46i-vq4oa-b7azf-27wgi-v7hhr-sqe",
@@ -2603,7 +2603,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kdldi-idcju-r7agw-nm3au-un5cc-2zxtu-mtnlv-tzvmt-c5alf-yjqld-cqe": {
           "node_id": "kdldi-idcju-r7agw-nm3au-un5cc-2zxtu-mtnlv-tzvmt-c5alf-yjqld-cqe",
@@ -2623,7 +2623,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lus5w-zk4cf-asgto-epkw2-ec2l4-djm6h-zywzq-qeg34-fxhf7-go6fb-jae": {
           "node_id": "lus5w-zk4cf-asgto-epkw2-ec2l4-djm6h-zywzq-qeg34-fxhf7-go6fb-jae",
@@ -2643,7 +2643,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "nj7re-dvkal-yq25a-opp2g-5y3qy-3ena4-opd5j-22uir-eaakx-ljk7k-6ae": {
           "node_id": "nj7re-dvkal-yq25a-opp2g-5y3qy-3ena4-opd5j-22uir-eaakx-ljk7k-6ae",
@@ -2669,7 +2669,7 @@
           "dc_id": "nd1",
           "node_provider_id": "pa5mu-yxsey-b4yrk-bodka-dhjnm-a3nx4-w2grw-3b766-ddr6e-nupu4-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "pvo54-4ykmv-7iumz-jxrld-qma55-wtgck-jmdui-r654s-bdjne-db7lf-kae": {
           "node_id": "pvo54-4ykmv-7iumz-jxrld-qma55-wtgck-jmdui-r654s-bdjne-db7lf-kae",
@@ -2689,7 +2689,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q3sji-7croe-uqcsz-rva4e-orlkf-c4y44-b2sl4-shnns-l57fz-fn2wa-xqe": {
           "node_id": "q3sji-7croe-uqcsz-rva4e-orlkf-c4y44-b2sl4-shnns-l57fz-fn2wa-xqe",
@@ -2709,7 +2709,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qbij2-wkp76-ewolj-xsyp5-flevz-5kvx2-4hvgg-q23hh-43hbe-bxntn-xqe": {
           "node_id": "qbij2-wkp76-ewolj-xsyp5-flevz-5kvx2-4hvgg-q23hh-43hbe-bxntn-xqe",
@@ -2729,7 +2729,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qhfut-l6rgw-kkbjn-iglum-tgn5d-pb36h-rlus5-f6uhu-fgv5g-5nqyc-nqe": {
           "node_id": "qhfut-l6rgw-kkbjn-iglum-tgn5d-pb36h-rlus5-f6uhu-fgv5g-5nqyc-nqe",
@@ -2749,7 +2749,7 @@
           "dc_id": "rg1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "xpit6-cyps4-ru26l-kw5rs-hbtll-yr7aw-ywa4o-2ibcf-zaich-qrzdq-3qe": {
           "node_id": "xpit6-cyps4-ru26l-kw5rs-hbtll-yr7aw-ywa4o-2ibcf-zaich-qrzdq-3qe",
@@ -2769,7 +2769,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -2830,7 +2830,7 @@
           "dc_id": "rg3",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "4lg7u-gpcph-smmt7-3c3mu-qyw6i-qlcvp-l2xws-piw34-vjd6x-665bt-lqe": {
           "node_id": "4lg7u-gpcph-smmt7-3c3mu-qyw6i-qlcvp-l2xws-piw34-vjd6x-665bt-lqe",
@@ -2850,7 +2850,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "62qwz-bp4wo-tdrcm-vincq-mdhz3-g6bfq-axwcr-vog76-fe4f3-lvepx-bae": {
           "node_id": "62qwz-bp4wo-tdrcm-vincq-mdhz3-g6bfq-axwcr-vog76-fe4f3-lvepx-bae",
@@ -2870,7 +2870,7 @@
           "dc_id": "at2",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6dmez-tuvfo-pxyw3-h3ds7-wie24-mpalp-fhjym-w7oh2-s2mqo-bsxkc-5ae": {
           "node_id": "6dmez-tuvfo-pxyw3-h3ds7-wie24-mpalp-fhjym-w7oh2-s2mqo-bsxkc-5ae",
@@ -2890,7 +2890,7 @@
           "dc_id": "ge1",
           "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dh4nc-xdofs-5bsqf-zny3q-zjfhj-sn76b-vizti-sjzmv-5jvqc-sjhv2-iae": {
           "node_id": "dh4nc-xdofs-5bsqf-zny3q-zjfhj-sn76b-vizti-sjzmv-5jvqc-sjhv2-iae",
@@ -2910,7 +2910,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "e5xk3-7dbi6-2zaxv-7ng3v-if5va-yktmq-roase-rqvx3-dii3z-2kh3r-vqe": {
           "node_id": "e5xk3-7dbi6-2zaxv-7ng3v-if5va-yktmq-roase-rqvx3-dii3z-2kh3r-vqe",
@@ -2936,7 +2936,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "gp2km-rzw5z-latpo-vp2m3-jdfqv-khn3m-i7l3z-nygeu-q2bfb-7aw5i-uqe": {
           "node_id": "gp2km-rzw5z-latpo-vp2m3-jdfqv-khn3m-i7l3z-nygeu-q2bfb-7aw5i-uqe",
@@ -2956,7 +2956,7 @@
           "dc_id": "lv1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "iqnlc-oy677-m524v-tisrn-3v44n-2eylu-bclq3-fqjtg-4ab7z-ycrie-mqe": {
           "node_id": "iqnlc-oy677-m524v-tisrn-3v44n-2eylu-bclq3-fqjtg-4ab7z-ycrie-mqe",
@@ -2976,7 +2976,7 @@
           "dc_id": "jb1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "izs3i-wcyvp-s47c2-enas5-77nmz-eib7t-3psjt-dsgr3-afgel-3hmkn-wqe": {
           "node_id": "izs3i-wcyvp-s47c2-enas5-77nmz-eib7t-3psjt-dsgr3-afgel-3hmkn-wqe",
@@ -2996,7 +2996,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mwrqx-e25kz-tchcz-quxpv-jhwdn-rwxeg-au4ci-xv5ko-s44pv-dmu6g-kqe": {
           "node_id": "mwrqx-e25kz-tchcz-quxpv-jhwdn-rwxeg-au4ci-xv5ko-s44pv-dmu6g-kqe",
@@ -3016,7 +3016,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "ng56n-tx2si-rxkmq-bkjnr-3fx6p-lw5pi-5pvsl-kdcg7-6ts24-m55dx-tqe": {
           "node_id": "ng56n-tx2si-rxkmq-bkjnr-3fx6p-lw5pi-5pvsl-kdcg7-6ts24-m55dx-tqe",
@@ -3036,7 +3036,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ofdd3-yoprc-tnvr7-tslrz-6rtn7-xofz6-kkoyi-ncfhd-aupek-kmtii-sae": {
           "node_id": "ofdd3-yoprc-tnvr7-tslrz-6rtn7-xofz6-kkoyi-ncfhd-aupek-kmtii-sae",
@@ -3056,7 +3056,7 @@
           "dc_id": "an1",
           "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "z5jll-2kgdy-vuzye-orvjn-u3uyz-2jrdt-5jxzj-hu5zv-pkts2-cvuhe-mqe": {
           "node_id": "z5jll-2kgdy-vuzye-orvjn-u3uyz-2jrdt-5jxzj-hu5zv-pkts2-cvuhe-mqe",
@@ -3082,7 +3082,7 @@
           "dc_id": "mb1",
           "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -3143,7 +3143,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "5hvab-67ek5-c7j2t-se7xt-zd3df-xjp6a-bnz76-kjx6e-bbx7e-rnwhz-nqe": {
           "node_id": "5hvab-67ek5-c7j2t-se7xt-zd3df-xjp6a-bnz76-kjx6e-bbx7e-rnwhz-nqe",
@@ -3169,7 +3169,7 @@
           "dc_id": "kr2",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "6t3hc-abwek-snx4i-s57g2-w7u2g-beaec-jsjgx-g47s7-zjeb2-cb5pu-yqe": {
           "node_id": "6t3hc-abwek-snx4i-s57g2-w7u2g-beaec-jsjgx-g47s7-zjeb2-cb5pu-yqe",
@@ -3189,7 +3189,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ami6p-hbo6h-zqoh2-lfqs7-44lch-tlkzt-skuxx-wyxs2-anezm-z2gxp-3ae": {
           "node_id": "ami6p-hbo6h-zqoh2-lfqs7-44lch-tlkzt-skuxx-wyxs2-anezm-z2gxp-3ae",
@@ -3209,7 +3209,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "cupz3-ehtqa-su3yl-2shoq-7yxw5-25uhz-g5kew-73dpi-w4gpu-hsmoi-vqe": {
           "node_id": "cupz3-ehtqa-su3yl-2shoq-7yxw5-25uhz-g5kew-73dpi-w4gpu-hsmoi-vqe",
@@ -3229,7 +3229,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "elons-ke2ex-4ykad-warsf-bi7zm-oskxc-un44b-phznq-sovqe-ko6u3-nqe": {
           "node_id": "elons-ke2ex-4ykad-warsf-bi7zm-oskxc-un44b-phznq-sovqe-ko6u3-nqe",
@@ -3249,7 +3249,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "g3ug2-wz6kb-unyk6-6mj4f-halk3-kkfvi-k33iz-fftob-qipom-t4kzr-qqe": {
           "node_id": "g3ug2-wz6kb-unyk6-6mj4f-halk3-kkfvi-k33iz-fftob-qipom-t4kzr-qqe",
@@ -3269,7 +3269,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "h3iv6-ezskc-3ij4j-zd3le-hld6d-hkuxx-dj6zq-w7rrd-gziap-a23ob-dqe": {
           "node_id": "h3iv6-ezskc-3ij4j-zd3le-hld6d-hkuxx-dj6zq-w7rrd-gziap-a23ob-dqe",
@@ -3289,7 +3289,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "i22yb-niksa-7n5xn-7i6ha-6duwj-kneqt-gikln-auy4j-tjk2b-lms5t-hae": {
           "node_id": "i22yb-niksa-7n5xn-7i6ha-6duwj-kneqt-gikln-auy4j-tjk2b-lms5t-hae",
@@ -3309,7 +3309,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "i4zve-soi3o-vqbql-gklv5-dbklt-g43ha-k3ju6-vdlrf-5t6lu-pyl3j-xqe": {
           "node_id": "i4zve-soi3o-vqbql-gklv5-dbklt-g43ha-k3ju6-vdlrf-5t6lu-pyl3j-xqe",
@@ -3329,7 +3329,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "k4ecc-uo6mt-3jzeo-axsrf-fm4s4-2v2fo-f2hai-nhbm7-ktblp-aixvz-iae": {
           "node_id": "k4ecc-uo6mt-3jzeo-axsrf-fm4s4-2v2fo-f2hai-nhbm7-ktblp-aixvz-iae",
@@ -3349,7 +3349,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "kno7y-tdoxx-da524-svbxm-wt7xn-nyit3-vtsd4-nimle-vahxa-q65e6-oqe": {
           "node_id": "kno7y-tdoxx-da524-svbxm-wt7xn-nyit3-vtsd4-nimle-vahxa-q65e6-oqe",
@@ -3369,7 +3369,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tun2n-sml7l-zb2qs-pytga-kx2qy-6gi7a-u6wzz-zu3ji-vnhql-7hzzd-uqe": {
           "node_id": "tun2n-sml7l-zb2qs-pytga-kx2qy-6gi7a-u6wzz-zu3ji-vnhql-7hzzd-uqe",
@@ -3389,7 +3389,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -3450,7 +3450,7 @@
           "dc_id": "ma3",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3fgii-zd73c-ftxy2-ypsbx-hnqf2-nzhc6-veurh-bru27-mz6bg-j62qd-xqe": {
           "node_id": "3fgii-zd73c-ftxy2-ypsbx-hnqf2-nzhc6-veurh-bru27-mz6bg-j62qd-xqe",
@@ -3470,7 +3470,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7vdar-a327j-byc4q-kacxg-ubasb-6dwe3-te272-frjgx-zeny2-xvj3j-5ae": {
           "node_id": "7vdar-a327j-byc4q-kacxg-ubasb-6dwe3-te272-frjgx-zeny2-xvj3j-5ae",
@@ -3490,7 +3490,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ax6zb-r4jnm-5aswz-ahoqx-ujs2a-mcvds-6gmdt-4ggxg-tkwdr-3323l-vqe": {
           "node_id": "ax6zb-r4jnm-5aswz-ahoqx-ujs2a-mcvds-6gmdt-4ggxg-tkwdr-3323l-vqe",
@@ -3510,7 +3510,7 @@
           "dc_id": "bt1",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dnorv-obqlt-6fl2s-ylxsf-o6pwv-fssdj-63kdj-jjw5d-luhdg-xe2zn-2ae": {
           "node_id": "dnorv-obqlt-6fl2s-ylxsf-o6pwv-fssdj-63kdj-jjw5d-luhdg-xe2zn-2ae",
@@ -3530,7 +3530,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "ehorg-uqvqd-ddlfa-nep3y-kq34u-j7zpx-ukwak-j47hn-x4az2-zzsoo-hqe": {
           "node_id": "ehorg-uqvqd-ddlfa-nep3y-kq34u-j7zpx-ukwak-j47hn-x4az2-zzsoo-hqe",
@@ -3550,7 +3550,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ek3yy-o3qk4-xivlj-qik4h-tgbwt-kmyyv-po3lm-hhwll-o7p3w-qrc4s-hqe": {
           "node_id": "ek3yy-o3qk4-xivlj-qik4h-tgbwt-kmyyv-po3lm-hhwll-o7p3w-qrc4s-hqe",
@@ -3570,7 +3570,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fi2eu-lgaic-n73rv-dsfr6-52z3t-7eto7-pmdg7-r7o7n-agotm-zw6o5-tae": {
           "node_id": "fi2eu-lgaic-n73rv-dsfr6-52z3t-7eto7-pmdg7-r7o7n-agotm-zw6o5-tae",
@@ -3590,7 +3590,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qtcl6-k4m2v-zr4fp-2jvwf-2h46j-l3mg5-lwlxy-3wsh7-hghcp-afdsa-6qe": {
           "node_id": "qtcl6-k4m2v-zr4fp-2jvwf-2h46j-l3mg5-lwlxy-3wsh7-hghcp-afdsa-6qe",
@@ -3610,7 +3610,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "tfw5b-kpj3p-bniym-lllfz-fzcuq-4c65m-xqv3y-dy44l-fvmsn-yebii-pqe": {
           "node_id": "tfw5b-kpj3p-bniym-lllfz-fzcuq-4c65m-xqv3y-dy44l-fvmsn-yebii-pqe",
@@ -3630,7 +3630,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wihnn-o5yix-kkneh-33pvm-ybil3-4rdf3-vu3w2-6lmg4-76yu3-feyyd-cae": {
           "node_id": "wihnn-o5yix-kkneh-33pvm-ybil3-4rdf3-vu3w2-6lmg4-76yu3-feyyd-cae",
@@ -3650,7 +3650,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wl27x-2kxme-etw5x-2iuy6-qrkna-uxfoc-swvej-o3jh2-xccz4-warv3-cqe": {
           "node_id": "wl27x-2kxme-etw5x-2iuy6-qrkna-uxfoc-swvej-o3jh2-xccz4-warv3-cqe",
@@ -3670,7 +3670,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wnuri-kqarn-qyjem-ae34x-dhkub-ocuug-3xjnj-xydiu-pmpkx-56lnn-3ae": {
           "node_id": "wnuri-kqarn-qyjem-ae34x-dhkub-ocuug-3xjnj-xydiu-pmpkx-56lnn-3ae",
@@ -3690,7 +3690,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -3751,7 +3751,7 @@
           "dc_id": "at2",
           "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5oe2d-on34f-iyvla-5ejfo-34n5u-yllm4-zxdgu-scaji-uleio-yeszd-yqe": {
           "node_id": "5oe2d-on34f-iyvla-5ejfo-34n5u-yllm4-zxdgu-scaji-uleio-yeszd-yqe",
@@ -3771,7 +3771,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6ssdj-55z6j-7q72p-vn255-utr5r-r2lgq-iitti-wnchn-rpwos-hjgrt-lqe": {
           "node_id": "6ssdj-55z6j-7q72p-vn255-utr5r-r2lgq-iitti-wnchn-rpwos-hjgrt-lqe",
@@ -3791,7 +3791,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ftgel-apwfx-aqphw-6itlw-as5il-53hfx-mtpy5-djn6y-7a6fa-3nqrs-5ae": {
           "node_id": "ftgel-apwfx-aqphw-6itlw-as5il-53hfx-mtpy5-djn6y-7a6fa-3nqrs-5ae",
@@ -3811,7 +3811,7 @@
           "dc_id": "kr2",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "inlh6-ii3uy-bpasa-uzngo-xle3x-d2p2a-ylu3h-neikw-tnmwv-wep5x-nae": {
           "node_id": "inlh6-ii3uy-bpasa-uzngo-xle3x-d2p2a-ylu3h-neikw-tnmwv-wep5x-nae",
@@ -3831,7 +3831,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kjzcx-5a22v-gcxvx-ilfil-mp54w-hlcsh-r4k6n-t36ia-vzoy4-pvedu-cae": {
           "node_id": "kjzcx-5a22v-gcxvx-ilfil-mp54w-hlcsh-r4k6n-t36ia-vzoy4-pvedu-cae",
@@ -3851,7 +3851,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "o2q5i-kszma-radgr-fdzu5-iqfps-w6xfc-aka7m-fftq4-2lpar-wj6xc-mqe": {
           "node_id": "o2q5i-kszma-radgr-fdzu5-iqfps-w6xfc-aka7m-fftq4-2lpar-wj6xc-mqe",
@@ -3871,7 +3871,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "pfmqh-xphm4-h4wkn-nafsx-aix6u-h4gbl-owfhy-wnm4y-vkqyu-nmlhl-aqe": {
           "node_id": "pfmqh-xphm4-h4wkn-nafsx-aix6u-h4gbl-owfhy-wnm4y-vkqyu-nmlhl-aqe",
@@ -3891,7 +3891,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pzdyu-3fz4j-jukm5-pimui-aqzjl-dlqxo-mpe42-ihxtg-rjzxt-ibdb6-aae": {
           "node_id": "pzdyu-3fz4j-jukm5-pimui-aqzjl-dlqxo-mpe42-ihxtg-rjzxt-ibdb6-aae",
@@ -3911,7 +3911,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qicnz-k4irc-lorep-ymp33-kx5l4-hnh6u-scxtx-rlwdu-remff-ubqb3-gae": {
           "node_id": "qicnz-k4irc-lorep-ymp33-kx5l4-hnh6u-scxtx-rlwdu-remff-ubqb3-gae",
@@ -3931,7 +3931,7 @@
           "dc_id": "jb3",
           "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "sbjj4-mggba-56ihm-lf4hg-mjzad-sg6up-lv4os-56vvp-vagid-ieawy-iae": {
           "node_id": "sbjj4-mggba-56ihm-lf4hg-mjzad-sg6up-lv4os-56vvp-vagid-ieawy-iae",
@@ -3951,7 +3951,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "wdg4t-afemy-nttou-sdh2u-b6lik-2cuxv-frfoy-wjige-z4qy5-wheg6-kae": {
           "node_id": "wdg4t-afemy-nttou-sdh2u-b6lik-2cuxv-frfoy-wjige-z4qy5-wheg6-kae",
@@ -3971,7 +3971,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zbzin-kgyio-vai3o-ghyz4-36boi-4tjvv-7fis2-d2mlq-xk7fx-d4udt-xae": {
           "node_id": "zbzin-kgyio-vai3o-ghyz4-36boi-4tjvv-7fis2-d2mlq-xk7fx-d4udt-xae",
@@ -3991,7 +3991,7 @@
           "dc_id": "vl2",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -4052,7 +4052,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6zj3x-tsbc3-jfzjr-lrnay-maejy-wwrrr-byxwk-kdzqu-nrkmz-mdcrx-aae": {
           "node_id": "6zj3x-tsbc3-jfzjr-lrnay-maejy-wwrrr-byxwk-kdzqu-nrkmz-mdcrx-aae",
@@ -4072,7 +4072,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "7ucvx-t6mxf-viej7-ils7i-k3aco-tqzsg-6cy3o-cakgs-zifaj-kiduk-cae": {
           "node_id": "7ucvx-t6mxf-viej7-ils7i-k3aco-tqzsg-6cy3o-cakgs-zifaj-kiduk-cae",
@@ -4092,7 +4092,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "b3ml3-v62hu-gdyb5-2raax-b33g2-nav6y-i5d3n-carmz-tosee-rbhk3-lqe": {
           "node_id": "b3ml3-v62hu-gdyb5-2raax-b33g2-nav6y-i5d3n-carmz-tosee-rbhk3-lqe",
@@ -4112,7 +4112,7 @@
           "dc_id": "li1",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "bayvy-p36kq-krz3d-o5lay-rxx3w-h35pc-235tv-mmhfe-b674r-xwfnq-mae": {
           "node_id": "bayvy-p36kq-krz3d-o5lay-rxx3w-h35pc-235tv-mmhfe-b674r-xwfnq-mae",
@@ -4132,7 +4132,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bhrbv-chf2l-tjjcj-mqryf-7z7ww-z6xi3-su7hl-idbfo-nnfpu-u6aju-nae": {
           "node_id": "bhrbv-chf2l-tjjcj-mqryf-7z7ww-z6xi3-su7hl-idbfo-nnfpu-u6aju-nae",
@@ -4152,7 +4152,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cekdc-hmzri-3u3or-ei7ip-su7ck-3xt6e-zsse2-tgakq-rolmv-6crkh-hqe": {
           "node_id": "cekdc-hmzri-3u3or-ei7ip-su7ck-3xt6e-zsse2-tgakq-rolmv-6crkh-hqe",
@@ -4172,7 +4172,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "efwaf-xbg25-6hqec-pjsqp-fon6d-hdljb-5kxeh-qjzku-yxaiy-6jwim-sae": {
           "node_id": "efwaf-xbg25-6hqec-pjsqp-fon6d-hdljb-5kxeh-qjzku-yxaiy-6jwim-sae",
@@ -4192,7 +4192,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "in4qi-poj7g-j5gvw-34xys-4cf6k-uki3d-exjzf-th4cu-c5my6-sdht2-cae": {
           "node_id": "in4qi-poj7g-j5gvw-34xys-4cf6k-uki3d-exjzf-th4cu-c5my6-sdht2-cae",
@@ -4212,7 +4212,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kmez2-lipof-3kjdn-nt35r-ai7oy-gvxxb-5hkv4-lk5ci-vtjya-hpd6w-wqe": {
           "node_id": "kmez2-lipof-3kjdn-nt35r-ai7oy-gvxxb-5hkv4-lk5ci-vtjya-hpd6w-wqe",
@@ -4232,7 +4232,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "llwjk-sgobf-vxycz-muu34-oyozz-lkxak-pzc67-ek4pt-kqmfh-b2b6k-3qe": {
           "node_id": "llwjk-sgobf-vxycz-muu34-oyozz-lkxak-pzc67-ek4pt-kqmfh-b2b6k-3qe",
@@ -4252,7 +4252,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "t3d5h-mcdqm-lt7jk-b7nk2-nkxfi-dl4ew-pn776-olxjd-eyott-3hpjb-iae": {
           "node_id": "t3d5h-mcdqm-lt7jk-b7nk2-nkxfi-dl4ew-pn776-olxjd-eyott-3hpjb-iae",
@@ -4272,7 +4272,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xhha5-oe4lp-ij2xv-gqhfe-pjavc-lwazu-y2wcm-rsvqw-hpvso-ksn7c-fqe": {
           "node_id": "xhha5-oe4lp-ij2xv-gqhfe-pjavc-lwazu-y2wcm-rsvqw-hpvso-ksn7c-fqe",
@@ -4292,7 +4292,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -4353,7 +4353,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5hqad-rslqs-jpdj4-zzd6o-nlia4-kqmzn-v5jed-yej6l-huspt-6q7zi-5qe": {
           "node_id": "5hqad-rslqs-jpdj4-zzd6o-nlia4-kqmzn-v5jed-yej6l-huspt-6q7zi-5qe",
@@ -4373,7 +4373,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6fm36-gj33w-34vuw-rb6se-62vzz-he655-2vasp-jnu6w-ixzel-e6azy-eae": {
           "node_id": "6fm36-gj33w-34vuw-rb6se-62vzz-he655-2vasp-jnu6w-ixzel-e6azy-eae",
@@ -4393,7 +4393,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7jxpa-y2d6g-zsy7g-vnjp6-sblcx-32lke-hulup-hj3y4-i3svi-pi2c5-yae": {
           "node_id": "7jxpa-y2d6g-zsy7g-vnjp6-sblcx-32lke-hulup-hj3y4-i3svi-pi2c5-yae",
@@ -4413,7 +4413,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "7qvtt-6lr4l-gx337-d6xvn-55ka2-6kcx2-c7iby-w36qm-u3ojf-ildyc-iqe": {
           "node_id": "7qvtt-6lr4l-gx337-d6xvn-55ka2-6kcx2-c7iby-w36qm-u3ojf-ildyc-iqe",
@@ -4433,7 +4433,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bew7t-tep7b-5hpwc-pzfcb-wvyfo-mhcu6-vnrkl-a2f6e-2aq4e-c4ezy-7ae": {
           "node_id": "bew7t-tep7b-5hpwc-pzfcb-wvyfo-mhcu6-vnrkl-a2f6e-2aq4e-c4ezy-7ae",
@@ -4453,7 +4453,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bz4m4-xsx2j-seecl-igygc-26lej-uhktf-hawf2-d6lof-2whss-3jobs-dae": {
           "node_id": "bz4m4-xsx2j-seecl-igygc-26lej-uhktf-hawf2-d6lof-2whss-3jobs-dae",
@@ -4473,7 +4473,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ew5us-dwxat-fg6sp-opp2j-fjjg7-rcmyj-d3saj-vyych-f3keg-5kor5-yqe": {
           "node_id": "ew5us-dwxat-fg6sp-opp2j-fjjg7-rcmyj-d3saj-vyych-f3keg-5kor5-yqe",
@@ -4493,7 +4493,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ijend-azski-eod2m-d2lqp-a3y3u-x44xl-7mapp-bjr6r-qw4v5-okx55-cae": {
           "node_id": "ijend-azski-eod2m-d2lqp-a3y3u-x44xl-7mapp-bjr6r-qw4v5-okx55-cae",
@@ -4513,7 +4513,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "mlbpy-pvy7z-gfwcb-5bakp-cuubm-prmi3-dppq6-rlepq-nkyvb-u7acf-fqe": {
           "node_id": "mlbpy-pvy7z-gfwcb-5bakp-cuubm-prmi3-dppq6-rlepq-nkyvb-u7acf-fqe",
@@ -4533,7 +4533,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "nhkbm-fqj7r-jdjii-spvcr-to3iu-ccrkm-pils3-6io5l-ahtry-qhlly-4ae": {
           "node_id": "nhkbm-fqj7r-jdjii-spvcr-to3iu-ccrkm-pils3-6io5l-ahtry-qhlly-4ae",
@@ -4553,7 +4553,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "u5ycx-4avna-dp4ca-svus4-iycai-cmcrg-do5ll-qmosp-segtt-5jmu7-dqe": {
           "node_id": "u5ycx-4avna-dp4ca-svus4-iycai-cmcrg-do5ll-qmosp-segtt-5jmu7-dqe",
@@ -4573,7 +4573,7 @@
           "dc_id": "bt1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "wvxfb-eqeex-26z4r-vefff-llfh7-vv76x-pje4o-oh57m-eklny-zcs56-wae": {
           "node_id": "wvxfb-eqeex-26z4r-vefff-llfh7-vv76x-pje4o-oh57m-eklny-zcs56-wae",
@@ -4593,7 +4593,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -4654,7 +4654,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5fpvj-plxyb-bsyji-b4pp5-j47gg-vlkor-q6bhy-5bhmp-kjtu6-fqkjh-iqe": {
           "node_id": "5fpvj-plxyb-bsyji-b4pp5-j47gg-vlkor-q6bhy-5bhmp-kjtu6-fqkjh-iqe",
@@ -4674,7 +4674,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5jqmb-vz4s4-tp7g3-v22ai-lqxgz-fonyb-6mmlk-xsmfs-md3u4-ovqek-zqe": {
           "node_id": "5jqmb-vz4s4-tp7g3-v22ai-lqxgz-fonyb-6mmlk-xsmfs-md3u4-ovqek-zqe",
@@ -4694,7 +4694,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "adplk-g2snv-bygay-o2r45-72zgu-kzk4z-pzhto-5nhwg-zsryj-s4llh-wqe": {
           "node_id": "adplk-g2snv-bygay-o2r45-72zgu-kzk4z-pzhto-5nhwg-zsryj-s4llh-wqe",
@@ -4714,7 +4714,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "foasq-jql3g-5njm3-75iv5-5zlx3-lbods-dnsbj-k7srs-3isgp-k4wlo-tqe": {
           "node_id": "foasq-jql3g-5njm3-75iv5-5zlx3-lbods-dnsbj-k7srs-3isgp-k4wlo-tqe",
@@ -4734,7 +4734,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ghwbi-m4ch3-f252p-czcmv-ppibh-52ucu-e3rfi-6bjib-izssn-jeh4q-eqe": {
           "node_id": "ghwbi-m4ch3-f252p-czcmv-ppibh-52ucu-e3rfi-6bjib-izssn-jeh4q-eqe",
@@ -4754,7 +4754,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jamsd-hvypj-w56fb-4cwvt-tqbmo-6652c-eaw2u-3njxg-5nfe7-ae6ht-bae": {
           "node_id": "jamsd-hvypj-w56fb-4cwvt-tqbmo-6652c-eaw2u-3njxg-5nfe7-ae6ht-bae",
@@ -4774,7 +4774,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kaoz3-4okcl-24amq-v5y4k-vim56-4njvo-fwvyk-v4grq-kuqum-7zm3p-4qe": {
           "node_id": "kaoz3-4okcl-24amq-v5y4k-vim56-4njvo-fwvyk-v4grq-kuqum-7zm3p-4qe",
@@ -4794,7 +4794,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kydvk-tokwg-vqxwp-xszgh-5reys-aprlz-jpyjd-uwhlz-rnii4-pijvj-yae": {
           "node_id": "kydvk-tokwg-vqxwp-xszgh-5reys-aprlz-jpyjd-uwhlz-rnii4-pijvj-yae",
@@ -4814,7 +4814,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "mcmqr-z4yrw-7wnwf-au7wv-5f7az-fco3a-vuxx3-7lol5-sigpc-jtnqq-aqe": {
           "node_id": "mcmqr-z4yrw-7wnwf-au7wv-5f7az-fco3a-vuxx3-7lol5-sigpc-jtnqq-aqe",
@@ -4834,7 +4834,7 @@
           "dc_id": "jb2",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "nu5cn-l6rgt-kqeyj-daqss-hfdzc-hduqr-vqio6-j2mwl-4hhto-gw3po-mqe": {
           "node_id": "nu5cn-l6rgt-kqeyj-daqss-hfdzc-hduqr-vqio6-j2mwl-4hhto-gw3po-mqe",
@@ -4854,7 +4854,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pud2o-rtmqx-ym5vr-3isia-wojnu-xwqmn-qcsxu-ktsva-udz72-m3pkg-zae": {
           "node_id": "pud2o-rtmqx-ym5vr-3isia-wojnu-xwqmn-qcsxu-ktsva-udz72-m3pkg-zae",
@@ -4874,7 +4874,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "u6e7b-mgtes-r5nay-mmrcn-p3rns-hj2fn-74dn7-cp2mu-kk24k-ljfnm-2ae": {
           "node_id": "u6e7b-mgtes-r5nay-mmrcn-p3rns-hj2fn-74dn7-cp2mu-kk24k-ljfnm-2ae",
@@ -4894,7 +4894,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -5010,7 +5010,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "a3biv-gee7t-qsjnz-4hsb5-zmvds-l3tjb-bubn5-gevin-2ehtn-thooo-hqe": {
           "node_id": "a3biv-gee7t-qsjnz-4hsb5-zmvds-l3tjb-bubn5-gevin-2ehtn-thooo-hqe",
@@ -5030,7 +5030,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ctgsx-urhsi-pslxe-6p2vy-5dlpy-mbo7b-zdpht-zzbqt-j7hga-qsptm-4ae": {
           "node_id": "ctgsx-urhsi-pslxe-6p2vy-5dlpy-mbo7b-zdpht-zzbqt-j7hga-qsptm-4ae",
@@ -5050,7 +5050,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "cvx4p-7vyi4-bfhkf-avoox-3pek3-yzlip-u4sxf-d3udp-nzzsu-equkg-oqe": {
           "node_id": "cvx4p-7vyi4-bfhkf-avoox-3pek3-yzlip-u4sxf-d3udp-nzzsu-equkg-oqe",
@@ -5070,7 +5070,7 @@
           "dc_id": "bt1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dpxqr-vscc4-sslft-6b6hn-gk344-rqsok-j65xm-3lrh5-p622q-ezrbs-bae": {
           "node_id": "dpxqr-vscc4-sslft-6b6hn-gk344-rqsok-j65xm-3lrh5-p622q-ezrbs-bae",
@@ -5090,7 +5090,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "f63hs-lnxxy-icsqv-j2wkr-aly5f-piig2-ptkk5-c6x4y-px2tp-gx67m-jqe": {
           "node_id": "f63hs-lnxxy-icsqv-j2wkr-aly5f-piig2-ptkk5-c6x4y-px2tp-gx67m-jqe",
@@ -5116,7 +5116,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jbgo7-cqnq6-mkd2d-fnqf2-6neke-h5zep-jtcmr-ahpnz-5vxox-z7saa-rae": {
           "node_id": "jbgo7-cqnq6-mkd2d-fnqf2-6neke-h5zep-jtcmr-ahpnz-5vxox-z7saa-rae",
@@ -5136,7 +5136,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ochxw-hoyfu-vxj3a-nxfik-dp74k-hfv7r-hfu2u-2e2cv-act65-jb6pd-kqe": {
           "node_id": "ochxw-hoyfu-vxj3a-nxfik-dp74k-hfv7r-hfu2u-2e2cv-act65-jb6pd-kqe",
@@ -5156,7 +5156,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "s2p3k-c7zfo-3ogmz-esx75-id6pg-6xv72-kifmd-gp46u-ay6vt-d7i5d-5ae": {
           "node_id": "s2p3k-c7zfo-3ogmz-esx75-id6pg-6xv72-kifmd-gp46u-ay6vt-d7i5d-5ae",
@@ -5176,7 +5176,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "saw4q-px4st-tqivd-luwao-njxl5-hjiuy-7j365-mvphm-a5g5x-zkooy-kae": {
           "node_id": "saw4q-px4st-tqivd-luwao-njxl5-hjiuy-7j365-mvphm-a5g5x-zkooy-kae",
@@ -5196,7 +5196,7 @@
           "dc_id": "ty3",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "sjtwn-kupfb-fmu5p-twem2-vl6zm-uhqim-ahuup-pcwvi-g6v6g-qyybo-tae": {
           "node_id": "sjtwn-kupfb-fmu5p-twem2-vl6zm-uhqim-ahuup-pcwvi-g6v6g-qyybo-tae",
@@ -5216,7 +5216,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "tlrvk-uwtes-ghpse-oekbm-jsrow-lf5kk-gqff7-c27d4-ozpou-xugiv-nqe": {
           "node_id": "tlrvk-uwtes-ghpse-oekbm-jsrow-lf5kk-gqff7-c27d4-ozpou-xugiv-nqe",
@@ -5236,7 +5236,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vsuqg-6hald-hxxxi-bxr2s-e5af5-p5lsr-2sutj-pip7r-co24u-2he35-hqe": {
           "node_id": "vsuqg-6hald-hxxxi-bxr2s-e5af5-p5lsr-2sutj-pip7r-co24u-2he35-hqe",
@@ -5256,7 +5256,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -5317,7 +5317,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "a2e7m-evijx-geoc6-o5j6s-h45ye-f3hxj-w7dfi-25e2k-v5ylv-nf7ud-aqe": {
           "node_id": "a2e7m-evijx-geoc6-o5j6s-h45ye-f3hxj-w7dfi-25e2k-v5ylv-nf7ud-aqe",
@@ -5337,7 +5337,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "c37f7-3shrz-2mk6g-e2zvp-3z6xc-uuk6r-6yegs-53uzt-c3vtf-dacsv-tae": {
           "node_id": "c37f7-3shrz-2mk6g-e2zvp-3z6xc-uuk6r-6yegs-53uzt-c3vtf-dacsv-tae",
@@ -5357,7 +5357,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "eexw3-cwz3z-6antd-yoyyc-radeu-jmt66-7p2r7-kjbkn-cij4b-kwqrb-tqe": {
           "node_id": "eexw3-cwz3z-6antd-yoyyc-radeu-jmt66-7p2r7-kjbkn-cij4b-kwqrb-tqe",
@@ -5377,7 +5377,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kq46u-pbywp-uxlqx-uahrp-rfwz3-b23sg-axiro-uotuy-fjmch-lp67q-xqe": {
           "node_id": "kq46u-pbywp-uxlqx-uahrp-rfwz3-b23sg-axiro-uotuy-fjmch-lp67q-xqe",
@@ -5397,7 +5397,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "llbvn-f4hq5-tg7bl-tdvr7-zs2cb-7uwfz-dhshp-aaomw-urgqo-gyll2-tqe": {
           "node_id": "llbvn-f4hq5-tg7bl-tdvr7-zs2cb-7uwfz-dhshp-aaomw-urgqo-gyll2-tqe",
@@ -5417,7 +5417,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "nyo3z-asy7t-jxc44-z4cvr-tts4h-2ipvj-aawbj-37xkl-7lcfq-psuoe-uqe": {
           "node_id": "nyo3z-asy7t-jxc44-z4cvr-tts4h-2ipvj-aawbj-37xkl-7lcfq-psuoe-uqe",
@@ -5437,7 +5437,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "plbgg-2silg-344nm-n7zqv-lpy4j-uktsq-darh7-shrma-srui4-xrcgp-dae": {
           "node_id": "plbgg-2silg-344nm-n7zqv-lpy4j-uktsq-darh7-shrma-srui4-xrcgp-dae",
@@ -5457,7 +5457,7 @@
           "dc_id": "ct1",
           "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "poyg5-cbmcm-a372x-j72lt-zm4rz-4sf5v-ajtle-hyqkt-rdgaz-eqzmi-5qe": {
           "node_id": "poyg5-cbmcm-a372x-j72lt-zm4rz-4sf5v-ajtle-hyqkt-rdgaz-eqzmi-5qe",
@@ -5477,7 +5477,7 @@
           "dc_id": "rg1",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "q3w37-sdo2u-z72qf-hpesy-rgqes-lzflk-aescx-c5ivv-qdbty-s6pgc-jae": {
           "node_id": "q3w37-sdo2u-z72qf-hpesy-rgqes-lzflk-aescx-c5ivv-qdbty-s6pgc-jae",
@@ -5497,7 +5497,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "xexdo-rsh52-bcci4-xrieo-3lazn-mws2u-xv4j2-egawj-gh5ps-t3oww-bae": {
           "node_id": "xexdo-rsh52-bcci4-xrieo-3lazn-mws2u-xv4j2-egawj-gh5ps-t3oww-bae",
@@ -5517,7 +5517,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "xsa4m-ko3b7-2zvcf-56q55-ahyqi-2qkho-obuu3-l4otg-4z6fn-n2r6i-cae": {
           "node_id": "xsa4m-ko3b7-2zvcf-56q55-ahyqi-2qkho-obuu3-l4otg-4z6fn-n2r6i-cae",
@@ -5537,7 +5537,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "y6mus-re3u7-vpqsx-xmhkh-jksck-rp2ko-xvjlb-7tdhu-jjm63-47alq-yae": {
           "node_id": "y6mus-re3u7-vpqsx-xmhkh-jksck-rp2ko-xvjlb-7tdhu-jjm63-47alq-yae",
@@ -5557,7 +5557,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -5618,7 +5618,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "4y5k6-auywv-zpovi-teeu2-bqfdx-spyxc-b76oo-ug55w-o4vrq-6z2jt-tae": {
           "node_id": "4y5k6-auywv-zpovi-teeu2-bqfdx-spyxc-b76oo-ug55w-o4vrq-6z2jt-tae",
@@ -5638,7 +5638,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dsnjt-rnuu4-vcgrm-wacun-da4y5-emipr-6bw7s-rxogu-7o2f3-a6zwb-yqe": {
           "node_id": "dsnjt-rnuu4-vcgrm-wacun-da4y5-emipr-6bw7s-rxogu-7o2f3-a6zwb-yqe",
@@ -5658,7 +5658,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "femah-ntebg-2txyb-6ixyr-kl62n-aoqmx-pxu7y-imzup-o72wc-qfosh-kae": {
           "node_id": "femah-ntebg-2txyb-6ixyr-kl62n-aoqmx-pxu7y-imzup-o72wc-qfosh-kae",
@@ -5678,7 +5678,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "gtc2a-34z6k-mld77-aucld-n6l4v-yv5hz-mon2d-narwo-b2z2k-thpyk-uae": {
           "node_id": "gtc2a-34z6k-mld77-aucld-n6l4v-yv5hz-mon2d-narwo-b2z2k-thpyk-uae",
@@ -5698,7 +5698,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "i5kts-s424n-xg4np-i2wnx-lbb24-d7imi-veczd-l5dwq-4bvi6-ltdpg-7qe": {
           "node_id": "i5kts-s424n-xg4np-i2wnx-lbb24-d7imi-veczd-l5dwq-4bvi6-ltdpg-7qe",
@@ -5718,7 +5718,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ifjiy-lj3rd-oxu4i-24bwr-tavxd-ga6iq-fjvne-gmeqr-krifm-r5aas-qqe": {
           "node_id": "ifjiy-lj3rd-oxu4i-24bwr-tavxd-ga6iq-fjvne-gmeqr-krifm-r5aas-qqe",
@@ -5738,7 +5738,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "l3m3j-bzfir-r3ld2-kri7q-obwcx-lix5j-7oxey-pbb6q-5tije-krocc-2qe": {
           "node_id": "l3m3j-bzfir-r3ld2-kri7q-obwcx-lix5j-7oxey-pbb6q-5tije-krocc-2qe",
@@ -5758,7 +5758,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "nioyi-lxtpk-fnexd-5ib4d-3x523-uu4ve-ro2tv-z5yuq-sf3dk-fdhrf-4qe": {
           "node_id": "nioyi-lxtpk-fnexd-5ib4d-3x523-uu4ve-ro2tv-z5yuq-sf3dk-fdhrf-4qe",
@@ -5778,7 +5778,7 @@
           "dc_id": "ty3",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pym4f-y6zlv-feua6-7y7ao-cbvlp-hkwfn-hqzjd-5sdiu-rsv33-y7245-nqe": {
           "node_id": "pym4f-y6zlv-feua6-7y7ao-cbvlp-hkwfn-hqzjd-5sdiu-rsv33-y7245-nqe",
@@ -5798,7 +5798,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rphlf-rfstt-sg5fi-ytcie-gnuwt-osv5d-fg32b-stlgf-5ajgi-tiw2i-eae": {
           "node_id": "rphlf-rfstt-sg5fi-ytcie-gnuwt-osv5d-fg32b-stlgf-5ajgi-tiw2i-eae",
@@ -5818,7 +5818,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tjg3r-ffr6q-hu7rb-4wevn-e4tlr-brdq3-zvobk-t4aof-5zix7-qfi2w-vqe": {
           "node_id": "tjg3r-ffr6q-hu7rb-4wevn-e4tlr-brdq3-zvobk-t4aof-5zix7-qfi2w-vqe",
@@ -5838,7 +5838,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vt5q3-2bev5-yhmxc-uxp3l-j26fn-tnlfb-sdstt-yoqf4-bio44-yyycs-vae": {
           "node_id": "vt5q3-2bev5-yhmxc-uxp3l-j26fn-tnlfb-sdstt-yoqf4-bio44-yyycs-vae",
@@ -5858,7 +5858,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -5919,7 +5919,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "d7dyc-slisa-nrkkz-hrpee-2xbpi-xjido-shkjk-vrtob-cmfxd-6sevt-5qe": {
           "node_id": "d7dyc-slisa-nrkkz-hrpee-2xbpi-xjido-shkjk-vrtob-cmfxd-6sevt-5qe",
@@ -5939,7 +5939,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "elru4-sjdrj-2rqqx-5lxfv-3i5dw-ktzok-7kr5v-un3y6-pubcf-7x47m-zae": {
           "node_id": "elru4-sjdrj-2rqqx-5lxfv-3i5dw-ktzok-7kr5v-un3y6-pubcf-7x47m-zae",
@@ -5959,7 +5959,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "f3wp4-qtj2k-tbqy3-vnqsc-gs5cr-sle5o-5oqt6-egtd5-wzpmj-5eett-cae": {
           "node_id": "f3wp4-qtj2k-tbqy3-vnqsc-gs5cr-sle5o-5oqt6-egtd5-wzpmj-5eett-cae",
@@ -5985,7 +5985,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "gd2vp-cewud-bap4i-b3vb4-jbxhf-3ojbk-d2n6l-wg46d-vcovk-bjwyz-tqe": {
           "node_id": "gd2vp-cewud-bap4i-b3vb4-jbxhf-3ojbk-d2n6l-wg46d-vcovk-bjwyz-tqe",
@@ -6005,7 +6005,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kc5j4-yilq3-6v4m7-5ongj-rzlki-t7srs-m7pjb-fa77e-icyep-ptouc-uqe": {
           "node_id": "kc5j4-yilq3-6v4m7-5ongj-rzlki-t7srs-m7pjb-fa77e-icyep-ptouc-uqe",
@@ -6025,7 +6025,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lfque-cnxjq-mq7nk-tcmti-tm2bn-sgwin-uclrl-kdkmt-y6epr-ltweh-zqe": {
           "node_id": "lfque-cnxjq-mq7nk-tcmti-tm2bn-sgwin-uclrl-kdkmt-y6epr-ltweh-zqe",
@@ -6045,7 +6045,7 @@
           "dc_id": "jb2",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "ltav6-3lsov-3cp5a-lswi6-dwyes-nyery-l3in3-tqcj2-6o4cc-pnqit-jqe": {
           "node_id": "ltav6-3lsov-3cp5a-lswi6-dwyes-nyery-l3in3-tqcj2-6o4cc-pnqit-jqe",
@@ -6065,7 +6065,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "t7ih7-rbewm-ftxuo-pw3gf-3dobc-lcryh-ew4wz-rwexh-667xe-a4yox-kqe": {
           "node_id": "t7ih7-rbewm-ftxuo-pw3gf-3dobc-lcryh-ew4wz-rwexh-667xe-a4yox-kqe",
@@ -6085,7 +6085,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vn5yd-eiwsz-jdwpi-ox2xg-wlwob-bbq4i-s4l2f-sz7ek-nmjtk-vhoxb-hae": {
           "node_id": "vn5yd-eiwsz-jdwpi-ox2xg-wlwob-bbq4i-s4l2f-sz7ek-nmjtk-vhoxb-hae",
@@ -6105,7 +6105,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "xtnry-ylnfl-gxtju-wn57e-qjzs3-zjjti-l2cqb-ai3vi-ylhvo-auqir-7ae": {
           "node_id": "xtnry-ylnfl-gxtju-wn57e-qjzs3-zjjti-l2cqb-ai3vi-ylhvo-auqir-7ae",
@@ -6131,7 +6131,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yh3a6-fzjir-23ow3-cnsz4-w56dj-veho7-qvu6c-psj3h-uscb5-4ikej-pae": {
           "node_id": "yh3a6-fzjir-23ow3-cnsz4-w56dj-veho7-qvu6c-psj3h-uscb5-4ikej-pae",
@@ -6151,7 +6151,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ztrgw-a7sec-ynzfd-utn5y-lnjjs-eb3w5-3yc6s-rygch-tizry-xvjwr-uae": {
           "node_id": "ztrgw-a7sec-ynzfd-utn5y-lnjjs-eb3w5-3yc6s-rygch-tizry-xvjwr-uae",
@@ -6171,7 +6171,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -6232,7 +6232,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "56ovz-lrvyd-gggsl-qtenl-uuokx-p7t3t-rg6mc-6lc5l-usfqb-fygiv-aqe": {
           "node_id": "56ovz-lrvyd-gggsl-qtenl-uuokx-p7t3t-rg6mc-6lc5l-usfqb-fygiv-aqe",
@@ -6258,7 +6258,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5v4on-bsceg-rdgxe-zcqqf-l5wnq-fpxw7-x3ktj-3x4fs-o2cny-uzhor-vqe": {
           "node_id": "5v4on-bsceg-rdgxe-zcqqf-l5wnq-fpxw7-x3ktj-3x4fs-o2cny-uzhor-vqe",
@@ -6278,7 +6278,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "bptaj-nejw4-osqqa-zwrej-ysl2o-5ffgj-hkjr6-2w6fi-jczex-vjutw-iae": {
           "node_id": "bptaj-nejw4-osqqa-zwrej-ysl2o-5ffgj-hkjr6-2w6fi-jczex-vjutw-iae",
@@ -6298,7 +6298,7 @@
           "dc_id": "ta2",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "c3xxv-clwfo-3pfn3-srt75-3wxn7-twfzm-7o5g6-pfvhd-rvsuj-47d3c-2qe": {
           "node_id": "c3xxv-clwfo-3pfn3-srt75-3wxn7-twfzm-7o5g6-pfvhd-rvsuj-47d3c-2qe",
@@ -6318,7 +6318,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cpywp-n4j5f-ja44p-oykxm-umz7h-fk6v2-rowix-bkwc4-ly4fw-tvu6c-mae": {
           "node_id": "cpywp-n4j5f-ja44p-oykxm-umz7h-fk6v2-rowix-bkwc4-ly4fw-tvu6c-mae",
@@ -6338,7 +6338,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ihttm-45oz5-an5mg-i2jtb-fayst-s47j6-vmuwr-fqotf-mp2il-n5s5x-cae": {
           "node_id": "ihttm-45oz5-an5mg-i2jtb-fayst-s47j6-vmuwr-fqotf-mp2il-n5s5x-cae",
@@ -6358,7 +6358,7 @@
           "dc_id": "bg1",
           "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "l3uqp-kuy6u-q7og4-oibsy-aisla-vu46q-hh3jr-fkmcb-cwthd-hymfj-cae": {
           "node_id": "l3uqp-kuy6u-q7og4-oibsy-aisla-vu46q-hh3jr-fkmcb-cwthd-hymfj-cae",
@@ -6378,7 +6378,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pdo46-iehoo-x2gfu-t5qu5-y3e64-cdymo-eioop-h6f4a-zebwa-fenb4-xae": {
           "node_id": "pdo46-iehoo-x2gfu-t5qu5-y3e64-cdymo-eioop-h6f4a-zebwa-fenb4-xae",
@@ -6398,7 +6398,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "r4642-fjh73-ltnlt-qhdcr-kfujl-v3up4-5pnci-o7zqi-set7a-pvi3p-5qe": {
           "node_id": "r4642-fjh73-ltnlt-qhdcr-kfujl-v3up4-5pnci-o7zqi-set7a-pvi3p-5qe",
@@ -6418,7 +6418,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "u6j47-wepye-qtjf3-vkvnv-q6nfc-a3wky-grxp6-wbjuy-xejgs-qalg4-4ae": {
           "node_id": "u6j47-wepye-qtjf3-vkvnv-q6nfc-a3wky-grxp6-wbjuy-xejgs-qalg4-4ae",
@@ -6438,7 +6438,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "um4so-2axl2-74745-lhyhn-afhgh-yog7e-pcsso-mxxho-7x5ev-x65uz-eqe": {
           "node_id": "um4so-2axl2-74745-lhyhn-afhgh-yog7e-pcsso-mxxho-7x5ev-x65uz-eqe",
@@ -6458,7 +6458,7 @@
           "dc_id": "vl2",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "uzy2p-nvzre-vqaov-qj7vj-bznwn-mllrr-t25mo-lbody-dgyf4-o5rj7-sqe": {
           "node_id": "uzy2p-nvzre-vqaov-qj7vj-bznwn-mllrr-t25mo-lbody-dgyf4-o5rj7-sqe",
@@ -6478,7 +6478,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -6541,7 +6541,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dapyz-46k2p-hgf2n-zxdjl-mq4ek-jgbvj-6xlfz-srm6z-dmfvj-wldgk-aqe": {
           "node_id": "dapyz-46k2p-hgf2n-zxdjl-mq4ek-jgbvj-6xlfz-srm6z-dmfvj-wldgk-aqe",
@@ -6561,7 +6561,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "g5zt4-f3nhd-aquto-6vecp-tnrxe-gexie-kk7fk-znuxf-45cav-zcnlz-zqe": {
           "node_id": "g5zt4-f3nhd-aquto-6vecp-tnrxe-gexie-kk7fk-znuxf-45cav-zcnlz-zqe",
@@ -6581,7 +6581,7 @@
           "dc_id": "ct1",
           "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "gd36t-bwrnm-qq6rg-sas4p-6uabz-qki2e-nrq2k-sp6dj-l2lxa-5tavx-7ae": {
           "node_id": "gd36t-bwrnm-qq6rg-sas4p-6uabz-qki2e-nrq2k-sp6dj-l2lxa-5tavx-7ae",
@@ -6601,7 +6601,7 @@
           "dc_id": "wa1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "itcju-qgal4-v2k63-llj7k-3ntsi-jmhdg-tlkhw-zz4kk-gwfkq-whb7w-aae": {
           "node_id": "itcju-qgal4-v2k63-llj7k-3ntsi-jmhdg-tlkhw-zz4kk-gwfkq-whb7w-aae",
@@ -6621,7 +6621,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "jxgxw-ublpi-lmhwt-jhiwe-fzsnm-md7ni-i4jfx-vitgi-ojusx-vcwxx-lqe": {
           "node_id": "jxgxw-ublpi-lmhwt-jhiwe-fzsnm-md7ni-i4jfx-vitgi-ojusx-vcwxx-lqe",
@@ -6641,7 +6641,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jyjmn-pp6dh-2fapa-l67th-dcga6-awrsr-pguqa-yb6e6-dkrfi-izgy6-sqe": {
           "node_id": "jyjmn-pp6dh-2fapa-l67th-dcga6-awrsr-pguqa-yb6e6-dkrfi-izgy6-sqe",
@@ -6661,7 +6661,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "n2atp-ct3so-2to22-4e67s-25y4o-naiht-5croo-lq7qj-m23gm-iav4p-3ae": {
           "node_id": "n2atp-ct3so-2to22-4e67s-25y4o-naiht-5croo-lq7qj-m23gm-iav4p-3ae",
@@ -6681,7 +6681,7 @@
           "dc_id": "aw1",
           "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "nf5ha-6wgiw-jhlaa-rs7hh-3k66r-mou6j-wudlt-pckzu-7goiz-yyfcc-gqe": {
           "node_id": "nf5ha-6wgiw-jhlaa-rs7hh-3k66r-mou6j-wudlt-pckzu-7goiz-yyfcc-gqe",
@@ -6701,7 +6701,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "np4ih-n24tu-rdhck-pe4wk-b55zi-6teik-a327g-kjh7q-plk7k-zkhnh-iqe": {
           "node_id": "np4ih-n24tu-rdhck-pe4wk-b55zi-6teik-a327g-kjh7q-plk7k-zkhnh-iqe",
@@ -6721,7 +6721,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "uj5bp-c66bz-meslf-u4uts-q3njs-tgfnr-bueq6-372lq-yz7so-4fu27-3qe": {
           "node_id": "uj5bp-c66bz-meslf-u4uts-q3njs-tgfnr-bueq6-372lq-yz7so-4fu27-3qe",
@@ -6741,7 +6741,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "x6ufc-46e3d-cvse3-vbjz6-gkrnq-4lpvu-6lloe-l24kd-y75gq-3pmt4-tqe": {
           "node_id": "x6ufc-46e3d-cvse3-vbjz6-gkrnq-4lpvu-6lloe-l24kd-y75gq-3pmt4-tqe",
@@ -6761,7 +6761,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ywict-j2wwx-ioq63-wqlrz-pmcsg-dcxrw-ibgcp-chmr5-m3dla-cjvjk-2ae": {
           "node_id": "ywict-j2wwx-ioq63-wqlrz-pmcsg-dcxrw-ibgcp-chmr5-m3dla-cjvjk-2ae",
@@ -6781,7 +6781,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -6842,7 +6842,7 @@
           "dc_id": "se1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4i64c-7p2wc-yotet-r64av-qwt2b-hp3hm-v3wad-bp5md-aeotm-gsofp-jqe": {
           "node_id": "4i64c-7p2wc-yotet-r64av-qwt2b-hp3hm-v3wad-bp5md-aeotm-gsofp-jqe",
@@ -6862,7 +6862,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6kuom-ucaom-u7xm5-s556x-3rnyk-hdjzd-wkxnx-wsejf-vpnhz-lniqi-nae": {
           "node_id": "6kuom-ucaom-u7xm5-s556x-3rnyk-hdjzd-wkxnx-wsejf-vpnhz-lniqi-nae",
@@ -6882,7 +6882,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7pxqq-e4kmr-saxrs-jziwc-sfdft-bl2wh-k7vhl-6a35o-2stq5-v6uso-3qe": {
           "node_id": "7pxqq-e4kmr-saxrs-jziwc-sfdft-bl2wh-k7vhl-6a35o-2stq5-v6uso-3qe",
@@ -6902,7 +6902,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "asad5-qg3gv-p5hrf-7liwa-zkoia-t2imf-sztmb-okb3k-gc6ei-xzp77-5qe": {
           "node_id": "asad5-qg3gv-p5hrf-7liwa-zkoia-t2imf-sztmb-okb3k-gc6ei-xzp77-5qe",
@@ -6922,7 +6922,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Degraded",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dfcny-caobt-j247e-73ira-s3ubk-3wmbu-ghlkn-5rbej-gn2t4-xenzr-xqe": {
           "node_id": "dfcny-caobt-j247e-73ira-s3ubk-3wmbu-ghlkn-5rbej-gn2t4-xenzr-xqe",
@@ -6942,7 +6942,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fnopq-cvgfn-6d32v-y7n5g-kkq6x-kpmce-7tqx3-esaht-b2ovh-qhznv-5qe": {
           "node_id": "fnopq-cvgfn-6d32v-y7n5g-kkq6x-kpmce-7tqx3-esaht-b2ovh-qhznv-5qe",
@@ -6962,7 +6962,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "m345s-atzkk-etodt-4bssh-cxcit-aw5ou-kozs4-5bipl-i46aj-uwnnh-bqe": {
           "node_id": "m345s-atzkk-etodt-4bssh-cxcit-aw5ou-kozs4-5bipl-i46aj-uwnnh-bqe",
@@ -6982,7 +6982,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "mvq4c-mbmpm-2u2mv-h74op-kekjk-6rudx-jl7qb-rpxuu-zicsk-o25td-4qe": {
           "node_id": "mvq4c-mbmpm-2u2mv-h74op-kekjk-6rudx-jl7qb-rpxuu-zicsk-o25td-4qe",
@@ -7002,7 +7002,7 @@
           "dc_id": "ge1",
           "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vodet-jwe7w-uo3lw-mzljp-orvu4-d3e2q-ymdga-kqlck-wgs5j-hmcyz-sae": {
           "node_id": "vodet-jwe7w-uo3lw-mzljp-orvu4-d3e2q-ymdga-kqlck-wgs5j-hmcyz-sae",
@@ -7022,7 +7022,7 @@
           "dc_id": "mb1",
           "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wazkf-2xehg-y26ek-2uq64-pkrbh-6frmq-4q7lf-5gaya-44q4p-v5r5z-cqe": {
           "node_id": "wazkf-2xehg-y26ek-2uq64-pkrbh-6frmq-4q7lf-5gaya-44q4p-v5r5z-cqe",
@@ -7042,7 +7042,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zdean-nwelu-yqpdn-juy4c-avlne-xpl6z-5hj4p-gh7s3-nkfyg-piu5w-jqe": {
           "node_id": "zdean-nwelu-yqpdn-juy4c-avlne-xpl6z-5hj4p-gh7s3-nkfyg-piu5w-jqe",
@@ -7062,7 +7062,7 @@
           "dc_id": "an1",
           "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zgtrt-4vlgr-pbytl-t2yqq-qf4nk-wyoos-vrfpu-hxqcw-tcnfu-73kjb-pae": {
           "node_id": "zgtrt-4vlgr-pbytl-t2yqq-qf4nk-wyoos-vrfpu-hxqcw-tcnfu-73kjb-pae",
@@ -7082,7 +7082,7 @@
           "dc_id": "bn1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -7143,7 +7143,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "4rpiz-7w7bf-smfm5-u7j3c-we6q7-qehxb-5lqnq-tjqsh-f7xu4-ihpao-zqe": {
           "node_id": "4rpiz-7w7bf-smfm5-u7j3c-we6q7-qehxb-5lqnq-tjqsh-f7xu4-ihpao-zqe",
@@ -7163,7 +7163,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4xhpj-gsmak-akpfh-z7rro-63yfp-5ewvu-i4o6g-yyrix-yd7xj-cus4y-hqe": {
           "node_id": "4xhpj-gsmak-akpfh-z7rro-63yfp-5ewvu-i4o6g-yyrix-yd7xj-cus4y-hqe",
@@ -7183,7 +7183,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7r7kx-pfeyy-apl6r-7m3mi-nhuan-zy5rd-l4bxq-6x5ak-a4632-sqoof-qqe": {
           "node_id": "7r7kx-pfeyy-apl6r-7m3mi-nhuan-zy5rd-l4bxq-6x5ak-a4632-sqoof-qqe",
@@ -7203,7 +7203,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "b3knf-xg5xg-p3oyq-dgpdw-xjz2l-n35mj-pdoyl-4dgas-u2t5l-bndrp-hqe": {
           "node_id": "b3knf-xg5xg-p3oyq-dgpdw-xjz2l-n35mj-pdoyl-4dgas-u2t5l-bndrp-hqe",
@@ -7223,7 +7223,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "d2ffc-r2mqq-yx3u5-f5j47-davp4-lske5-57oal-ilwph-o2hex-tqaz2-7qe": {
           "node_id": "d2ffc-r2mqq-yx3u5-f5j47-davp4-lske5-57oal-ilwph-o2hex-tqaz2-7qe",
@@ -7243,7 +7243,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dur57-qqxpo-wmql5-bd7cz-atitx-5ivxi-ht3ni-lvb43-ms4w4-uyep4-iae": {
           "node_id": "dur57-qqxpo-wmql5-bd7cz-atitx-5ivxi-ht3ni-lvb43-ms4w4-uyep4-iae",
@@ -7263,7 +7263,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "kegk5-wu5c5-xpe2p-athmd-4dzq6-4gucp-n4ne3-uj2zk-e2jjl-3253l-6qe": {
           "node_id": "kegk5-wu5c5-xpe2p-athmd-4dzq6-4gucp-n4ne3-uj2zk-e2jjl-3253l-6qe",
@@ -7283,7 +7283,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe": {
           "node_id": "onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe",
@@ -7303,7 +7303,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qvguz-cfp5f-otty5-v74o4-6ys5b-t2h5p-r6b5y-7wnaq-yi4x3-yazqd-hae": {
           "node_id": "qvguz-cfp5f-otty5-v74o4-6ys5b-t2h5p-r6b5y-7wnaq-yi4x3-yazqd-hae",
@@ -7323,7 +7323,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rhy7d-pjsmu-5ljz7-vuaio-ihiaq-iysyk-np226-tirem-kuw7n-v2i2w-iqe": {
           "node_id": "rhy7d-pjsmu-5ljz7-vuaio-ihiaq-iysyk-np226-tirem-kuw7n-v2i2w-iqe",
@@ -7343,7 +7343,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "scjri-zcrz3-27aoo-a2ggm-alu4o-fcu4t-r5jy4-7hdeh-prukj-4cols-qae": {
           "node_id": "scjri-zcrz3-27aoo-a2ggm-alu4o-fcu4t-r5jy4-7hdeh-prukj-4cols-qae",
@@ -7363,7 +7363,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wz42c-ah6mx-lt7c6-vnqcm-kjnd7-52x65-2yfqw-ibpxs-th23v-7z3hl-qae": {
           "node_id": "wz42c-ah6mx-lt7c6-vnqcm-kjnd7-52x65-2yfqw-ibpxs-th23v-7z3hl-qae",
@@ -7383,7 +7383,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -7446,7 +7446,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5jxvk-4hn3t-7bzwt-enxfa-4u7rh-n3fno-t33ly-74lic-z2uep-zqlvp-nqe": {
           "node_id": "5jxvk-4hn3t-7bzwt-enxfa-4u7rh-n3fno-t33ly-74lic-z2uep-zqlvp-nqe",
@@ -7466,7 +7466,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6bt7p-6zrhd-xi3rj-jsugy-c6qzy-nvip5-7thap-gk6po-ygo5h-mh4jk-tae": {
           "node_id": "6bt7p-6zrhd-xi3rj-jsugy-c6qzy-nvip5-7thap-gk6po-ygo5h-mh4jk-tae",
@@ -7486,7 +7486,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "cvryq-gpest-bfwqd-m6sce-7atse-publw-vcki4-yyny5-wb2su-yr44m-gae": {
           "node_id": "cvryq-gpest-bfwqd-m6sce-7atse-publw-vcki4-yyny5-wb2su-yr44m-gae",
@@ -7506,7 +7506,7 @@
           "dc_id": "hk4",
           "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "d2hzh-j3wzi-mkmcx-ufb6u-5gft4-ta7yt-xq4qo-dncvt-y6dov-xbujm-hae": {
           "node_id": "d2hzh-j3wzi-mkmcx-ufb6u-5gft4-ta7yt-xq4qo-dncvt-y6dov-xbujm-hae",
@@ -7526,7 +7526,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "diz6c-cfgpz-4itzw-ufwi2-zdc5d-uwcvx-gfhcd-7pjnm-526lr-lyuh5-6ae": {
           "node_id": "diz6c-cfgpz-4itzw-ufwi2-zdc5d-uwcvx-gfhcd-7pjnm-526lr-lyuh5-6ae",
@@ -7546,7 +7546,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fwpkp-tbgp3-rhl4h-njm2i-ebtn2-5susq-o765o-hjop2-qktc7-uo2kf-xae": {
           "node_id": "fwpkp-tbgp3-rhl4h-njm2i-ebtn2-5susq-o765o-hjop2-qktc7-uo2kf-xae",
@@ -7566,7 +7566,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "k2dew-yan2e-q6mzr-flizg-jqndd-3zcln-zg35a-ejv2j-waiff-le2rt-6qe": {
           "node_id": "k2dew-yan2e-q6mzr-flizg-jqndd-3zcln-zg35a-ejv2j-waiff-le2rt-6qe",
@@ -7592,7 +7592,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lz3ap-rjo2a-ilqjt-jkyhb-t4ewt-b37eu-gl246-ltnyu-jrkec-6bi5m-cqe": {
           "node_id": "lz3ap-rjo2a-ilqjt-jkyhb-t4ewt-b37eu-gl246-ltnyu-jrkec-6bi5m-cqe",
@@ -7612,7 +7612,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "mt54u-t6z4l-fkx5l-2xwfe-g3u34-kzd44-2d3f2-xu6ty-lpc6z-pex4y-5qe": {
           "node_id": "mt54u-t6z4l-fkx5l-2xwfe-g3u34-kzd44-2d3f2-xu6ty-lpc6z-pex4y-5qe",
@@ -7632,7 +7632,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pojjf-vh65n-rephu-6rm4t-3zdx3-5pnon-csrf2-wlm32-z3tak-qyefb-fae": {
           "node_id": "pojjf-vh65n-rephu-6rm4t-3zdx3-5pnon-csrf2-wlm32-z3tak-qyefb-fae",
@@ -7652,7 +7652,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zk4lm-5c2p7-zhlqv-3pi2i-hxxlf-xy6t7-ttvyc-hxenc-ixtcf-66ezn-cqe": {
           "node_id": "zk4lm-5c2p7-zhlqv-3pi2i-hxxlf-xy6t7-ttvyc-hxenc-ixtcf-66ezn-cqe",
@@ -7672,7 +7672,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zxph7-ibisu-l2d7c-k6klg-za5kr-scrws-manc5-cknfw-thpyi-vzmij-xqe": {
           "node_id": "zxph7-ibisu-l2d7c-k6klg-za5kr-scrws-manc5-cknfw-thpyi-vzmij-xqe",
@@ -7692,7 +7692,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -7753,7 +7753,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5jbfj-wygyf-jzcjw-s6ali-nlazr-nbejd-sfw6h-v44fg-hh34c-khde2-lqe": {
           "node_id": "5jbfj-wygyf-jzcjw-s6ali-nlazr-nbejd-sfw6h-v44fg-hh34c-khde2-lqe",
@@ -7773,7 +7773,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5zldm-3rijx-6pp6q-twp65-b34xz-6iitk-kqzov-flbdh-ekkx3-3an4a-eqe": {
           "node_id": "5zldm-3rijx-6pp6q-twp65-b34xz-6iitk-kqzov-flbdh-ekkx3-3an4a-eqe",
@@ -7793,7 +7793,7 @@
           "dc_id": "sg3",
           "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "agtd6-f2qxq-ciadf-bterj-vpcos-7fapt-co3cv-ypvhs-zy6mk-ijrto-uae": {
           "node_id": "agtd6-f2qxq-ciadf-bterj-vpcos-7fapt-co3cv-ypvhs-zy6mk-ijrto-uae",
@@ -7813,7 +7813,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "chzgl-n2hjh-3coyq-fozyi-tipv7-autbh-ei22q-hr6gr-rvdxz-2zh4z-aqe": {
           "node_id": "chzgl-n2hjh-3coyq-fozyi-tipv7-autbh-ei22q-hr6gr-rvdxz-2zh4z-aqe",
@@ -7833,7 +7833,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "d4ndk-jxgud-mf7j2-63lqc-2f64s-vouw3-l6k2k-akpwd-b4t4d-vur7h-jae": {
           "node_id": "d4ndk-jxgud-mf7j2-63lqc-2f64s-vouw3-l6k2k-akpwd-b4t4d-vur7h-jae",
@@ -7853,7 +7853,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "h3g2z-jgfid-7hvbw-jyfw7-4jiza-iyy4w-bvx44-nizgh-kct53-ffjtz-lae": {
           "node_id": "h3g2z-jgfid-7hvbw-jyfw7-4jiza-iyy4w-bvx44-nizgh-kct53-ffjtz-lae",
@@ -7873,7 +7873,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "l7nbu-afo7y-adwcg-m6ivf-cooqw-v3pwd-jf4w3-kgsbr-tek3p-7n3dh-3ae": {
           "node_id": "l7nbu-afo7y-adwcg-m6ivf-cooqw-v3pwd-jf4w3-kgsbr-tek3p-7n3dh-3ae",
@@ -7893,7 +7893,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "rv6cf-76ajy-qgcld-d7gil-e7v22-3sqfv-yc2zs-sn5r5-465el-pbym3-xae": {
           "node_id": "rv6cf-76ajy-qgcld-d7gil-e7v22-3sqfv-yc2zs-sn5r5-465el-pbym3-xae",
@@ -7913,7 +7913,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "sa67b-rto5p-rvyts-ehk7m-dpsnk-2c3w2-pmcx7-mzvgr-4p6co-ampd6-pqe": {
           "node_id": "sa67b-rto5p-rvyts-ehk7m-dpsnk-2c3w2-pmcx7-mzvgr-4p6co-ampd6-pqe",
@@ -7933,7 +7933,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "sqw45-bb5aa-rsstr-3lqro-2asg4-jqzqp-lp6az-2a2dr-tzil6-df7tw-gqe": {
           "node_id": "sqw45-bb5aa-rsstr-3lqro-2asg4-jqzqp-lp6az-2a2dr-tzil6-df7tw-gqe",
@@ -7953,7 +7953,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "uset5-ffvx2-tsfys-n35qu-bbx7m-d3x3r-d5fcw-7d44p-sefly-4cg4h-vqe": {
           "node_id": "uset5-ffvx2-tsfys-n35qu-bbx7m-d3x3r-d5fcw-7d44p-sefly-4cg4h-vqe",
@@ -7973,7 +7973,7 @@
           "dc_id": "an1",
           "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "za7cm-bcsh6-dkayq-wbbbi-5pw7l-5dsqk-7isoh-osqdi-rmcot-pswxd-aae": {
           "node_id": "za7cm-bcsh6-dkayq-wbbbi-5pw7l-5dsqk-7isoh-osqdi-rmcot-pswxd-aae",
@@ -7993,7 +7993,7 @@
           "dc_id": "hk3",
           "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -8054,7 +8054,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "bafm2-xnr2g-ztwfs-dnc5i-gqygr-sne73-6nyu2-66x2z-qnax4-ec5ru-hae": {
           "node_id": "bafm2-xnr2g-ztwfs-dnc5i-gqygr-sne73-6nyu2-66x2z-qnax4-ec5ru-hae",
@@ -8074,7 +8074,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bq47i-nl3wp-zbsv3-juxt5-ptcqw-wfm6e-eqv5e-m3y4e-w6xgk-z7rmw-eqe": {
           "node_id": "bq47i-nl3wp-zbsv3-juxt5-ptcqw-wfm6e-eqv5e-m3y4e-w6xgk-z7rmw-eqe",
@@ -8094,7 +8094,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cl43a-f4cfk-5bhhf-ro5s7-q7w6d-2vqow-3apn6-psfrl-i53ay-pykvk-mqe": {
           "node_id": "cl43a-f4cfk-5bhhf-ro5s7-q7w6d-2vqow-3apn6-psfrl-i53ay-pykvk-mqe",
@@ -8114,7 +8114,7 @@
           "dc_id": "pa2",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "euo2x-vl67u-3vtja-yrovf-oah6r-pq43e-pn522-j3zq2-pnly3-ad7wd-lqe": {
           "node_id": "euo2x-vl67u-3vtja-yrovf-oah6r-pq43e-pn522-j3zq2-pnly3-ad7wd-lqe",
@@ -8134,7 +8134,7 @@
           "dc_id": "pc1",
           "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "icl45-5n6st-mi35c-d5w4w-xyrww-chwnd-qbsqd-fztab-xeu6a-wck2c-2ae": {
           "node_id": "icl45-5n6st-mi35c-d5w4w-xyrww-chwnd-qbsqd-fztab-xeu6a-wck2c-2ae",
@@ -8154,7 +8154,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mtr6i-a7lue-qnbje-xizsv-z3v55-atzbw-5xzbk-yto2x-v5ynd-lsmqr-mqe": {
           "node_id": "mtr6i-a7lue-qnbje-xizsv-z3v55-atzbw-5xzbk-yto2x-v5ynd-lsmqr-mqe",
@@ -8174,7 +8174,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "o2ejh-i3l5b-tawnx-6vane-ek7hi-apzj2-d2vid-j5dro-xityu-sszcb-gqe": {
           "node_id": "o2ejh-i3l5b-tawnx-6vane-ek7hi-apzj2-d2vid-j5dro-xityu-sszcb-gqe",
@@ -8194,7 +8194,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "oaxev-miabf-nxzvk-inhz4-67wdw-urlun-euywx-656kk-iffmy-3gdp4-2ae": {
           "node_id": "oaxev-miabf-nxzvk-inhz4-67wdw-urlun-euywx-656kk-iffmy-3gdp4-2ae",
@@ -8214,7 +8214,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qkcyr-pk3wb-n4w54-hofnn-mf6g6-uvhhj-lwzir-rw737-3ji4w-hqynu-vae": {
           "node_id": "qkcyr-pk3wb-n4w54-hofnn-mf6g6-uvhhj-lwzir-rw737-3ji4w-hqynu-vae",
@@ -8234,7 +8234,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "uf3xb-i4fzz-jtgv6-a5pga-i5cs7-ex4ck-d46lp-khsjr-3yzdy-xnjrc-xqe": {
           "node_id": "uf3xb-i4fzz-jtgv6-a5pga-i5cs7-ex4ck-d46lp-khsjr-3yzdy-xnjrc-xqe",
@@ -8254,7 +8254,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "vaqrd-u6ayx-65ttp-6y5yg-touwv-dvpxn-uoxpx-n3bzg-wbq4b-7lwx3-jqe": {
           "node_id": "vaqrd-u6ayx-65ttp-6y5yg-touwv-dvpxn-uoxpx-n3bzg-wbq4b-7lwx3-jqe",
@@ -8274,7 +8274,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wwpob-ttemi-zg5fc-us2jz-3q3gm-mhzmm-higzj-2bqrr-7tmoz-ajy7l-wqe": {
           "node_id": "wwpob-ttemi-zg5fc-us2jz-3q3gm-mhzmm-higzj-2bqrr-7tmoz-ajy7l-wqe",
@@ -8294,7 +8294,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -8355,7 +8355,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5flj4-x56ts-jud7h-rzygl-a7uas-2degg-kyz5e-xojpt-pbuph-34zby-bae": {
           "node_id": "5flj4-x56ts-jud7h-rzygl-a7uas-2degg-kyz5e-xojpt-pbuph-34zby-bae",
@@ -8375,7 +8375,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "hcjwo-3h7be-ds4ff-dasid-xbp6i-4uxxq-s4dmi-kwf5g-yzvyy-wakil-hqe": {
           "node_id": "hcjwo-3h7be-ds4ff-dasid-xbp6i-4uxxq-s4dmi-kwf5g-yzvyy-wakil-hqe",
@@ -8395,7 +8395,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "ieaic-obdck-f2vgl-nouey-jjh4k-oy7tm-3g6yo-l6uuc-y2oot-nytkj-hae": {
           "node_id": "ieaic-obdck-f2vgl-nouey-jjh4k-oy7tm-3g6yo-l6uuc-y2oot-nytkj-hae",
@@ -8415,7 +8415,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ja4ju-swqtu-qpw52-y45ue-qcqev-5fmrj-4shc4-roaqq-owp2c-rbtlc-2ae": {
           "node_id": "ja4ju-swqtu-qpw52-y45ue-qcqev-5fmrj-4shc4-roaqq-owp2c-rbtlc-2ae",
@@ -8435,7 +8435,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kax7o-5oyag-q7xbn-lpm4d-wkngc-dhbig-ca4sz-kdzkk-kgkln-khtsk-dqe": {
           "node_id": "kax7o-5oyag-q7xbn-lpm4d-wkngc-dhbig-ca4sz-kdzkk-kgkln-khtsk-dqe",
@@ -8455,7 +8455,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "klluj-vrtrp-k27jr-cb2fm-oyw2o-hrksz-lbojt-xv3ts-off62-cdcbz-iae": {
           "node_id": "klluj-vrtrp-k27jr-cb2fm-oyw2o-hrksz-lbojt-xv3ts-off62-cdcbz-iae",
@@ -8475,7 +8475,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q6bkk-dqhlg-orvwk-4lfjk-3fbpu-y3s4e-v4ivs-5ys2a-v6ok7-yqolr-iqe": {
           "node_id": "q6bkk-dqhlg-orvwk-4lfjk-3fbpu-y3s4e-v4ivs-5ys2a-v6ok7-yqolr-iqe",
@@ -8495,7 +8495,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "td5qx-fiwi4-mssne-56n7d-2fx6t-ccol7-t2ubd-3djlf-owwus-jgnoe-nqe": {
           "node_id": "td5qx-fiwi4-mssne-56n7d-2fx6t-ccol7-t2ubd-3djlf-owwus-jgnoe-nqe",
@@ -8515,7 +8515,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "trupz-4o3zm-6itr3-6fjf3-ipbci-r2scy-pvycg-xlh4x-vtokf-avpr6-oqe": {
           "node_id": "trupz-4o3zm-6itr3-6fjf3-ipbci-r2scy-pvycg-xlh4x-vtokf-avpr6-oqe",
@@ -8535,7 +8535,7 @@
           "dc_id": "jb1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "ucumw-ex6s5-r7nyd-x546u-f4rcl-qllyh-waid4-xxzvn-25op7-gnsjy-bae": {
           "node_id": "ucumw-ex6s5-r7nyd-x546u-f4rcl-qllyh-waid4-xxzvn-25op7-gnsjy-bae",
@@ -8555,7 +8555,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xs5iy-nxwwp-pf2br-3544d-el6uf-xu2kf-qxqzm-sizvd-vgwfm-iqifv-jae": {
           "node_id": "xs5iy-nxwwp-pf2br-3544d-el6uf-xu2kf-qxqzm-sizvd-vgwfm-iqifv-jae",
@@ -8575,7 +8575,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "y6xdi-6nbil-4w6ju-4vqux-wdl5m-uofuq-2hbv4-dels3-knu42-xievh-hae": {
           "node_id": "y6xdi-6nbil-4w6ju-4vqux-wdl5m-uofuq-2hbv4-dels3-knu42-xievh-hae",
@@ -8595,7 +8595,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -8656,7 +8656,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "c6on3-qhvg5-k5v5v-wcson-2wek7-blvc7-xnr54-gyakg-6etp7-khw33-qqe": {
           "node_id": "c6on3-qhvg5-k5v5v-wcson-2wek7-blvc7-xnr54-gyakg-6etp7-khw33-qqe",
@@ -8676,7 +8676,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dd3ye-qncdq-jvghc-iymve-55lbp-hf6mq-6a3pa-ms5yj-espcn-n32jm-3qe": {
           "node_id": "dd3ye-qncdq-jvghc-iymve-55lbp-hf6mq-6a3pa-ms5yj-espcn-n32jm-3qe",
@@ -8696,7 +8696,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fqczw-cfksr-xl2d4-5bubi-2am2s-znzzk-k6tma-5o6dq-hmvnc-rjhfs-wqe": {
           "node_id": "fqczw-cfksr-xl2d4-5bubi-2am2s-znzzk-k6tma-5o6dq-hmvnc-rjhfs-wqe",
@@ -8716,7 +8716,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "jemyk-uhint-w6ftv-s3xpy-ne4hr-xbcpu-aqskm-6a4cy-orm5q-aqqwd-gqe": {
           "node_id": "jemyk-uhint-w6ftv-s3xpy-ne4hr-xbcpu-aqskm-6a4cy-orm5q-aqqwd-gqe",
@@ -8736,7 +8736,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "pzhdx-bue7v-bemr2-zkw4b-bpije-pc2jc-wrhwo-hfrwj-p646g-ibscz-dae": {
           "node_id": "pzhdx-bue7v-bemr2-zkw4b-bpije-pc2jc-wrhwo-hfrwj-p646g-ibscz-dae",
@@ -8756,7 +8756,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tkoxk-7juao-nynai-s6dt7-mpsfm-alwl7-yg5md-2zsbl-twivd-xbdae-4qe": {
           "node_id": "tkoxk-7juao-nynai-s6dt7-mpsfm-alwl7-yg5md-2zsbl-twivd-xbdae-4qe",
@@ -8776,7 +8776,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ucznq-t6max-wjxsb-yryjd-qgrbu-5nn4z-qfwqk-chaap-lymtj-cktlx-jae": {
           "node_id": "ucznq-t6max-wjxsb-yryjd-qgrbu-5nn4z-qfwqk-chaap-lymtj-cktlx-jae",
@@ -8796,7 +8796,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vdvh4-bdy7m-gyxbj-7pt5m-ykhey-mtobh-ul4kq-mwozd-t6enu-3pcau-jqe": {
           "node_id": "vdvh4-bdy7m-gyxbj-7pt5m-ykhey-mtobh-ul4kq-mwozd-t6enu-3pcau-jqe",
@@ -8816,7 +8816,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vtbf4-olrta-q4eso-47b2z-ncgrs-lksia-xohkj-slwil-m5xoi-uxovi-wae": {
           "node_id": "vtbf4-olrta-q4eso-47b2z-ncgrs-lksia-xohkj-slwil-m5xoi-uxovi-wae",
@@ -8836,7 +8836,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xbcli-rnhjh-26fm2-om2gn-ysqvs-kufba-vvz4a-dy32s-ntpwk-pdkfs-aae": {
           "node_id": "xbcli-rnhjh-26fm2-om2gn-ysqvs-kufba-vvz4a-dy32s-ntpwk-pdkfs-aae",
@@ -8856,7 +8856,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yjbaw-7mgap-u2qrc-ol6db-ncf2z-wgxuy-4337g-2wjw2-6jjcj-wzdgc-5ae": {
           "node_id": "yjbaw-7mgap-u2qrc-ol6db-ncf2z-wgxuy-4337g-2wjw2-6jjcj-wzdgc-5ae",
@@ -8876,7 +8876,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "yszpk-lt4rh-gktee-rctwj-hrajy-vbg62-jy24t-47ua3-mu55b-yxonx-zae": {
           "node_id": "yszpk-lt4rh-gktee-rctwj-hrajy-vbg62-jy24t-47ua3-mu55b-yxonx-zae",
@@ -8896,7 +8896,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -8978,7 +8978,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3y7fy-fd2oe-33qxg-wq7y6-zzplk-33jhm-n4glx-2c7ij-k24nn-jbsst-xae": {
           "node_id": "3y7fy-fd2oe-33qxg-wq7y6-zzplk-33jhm-n4glx-2c7ij-k24nn-jbsst-xae",
@@ -8998,7 +8998,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "5wzcz-mfner-c5wor-3liei-7mpao-vkult-zdds6-6n3rg-42ksv-6zzqt-vae": {
           "node_id": "5wzcz-mfner-c5wor-3liei-7mpao-vkult-zdds6-6n3rg-42ksv-6zzqt-vae",
@@ -9018,7 +9018,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "6df7i-epxjg-xjgjb-reyqa-3d5a5-cvgxz-zscfa-ycszz-32cuu-ruhx5-lae": {
           "node_id": "6df7i-epxjg-xjgjb-reyqa-3d5a5-cvgxz-zscfa-ycszz-32cuu-ruhx5-lae",
@@ -9038,7 +9038,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6ricl-vwbej-yk73y-6ttjb-oefyv-cpjta-7ttqk-e4ucl-5rxsq-v2bag-zae": {
           "node_id": "6ricl-vwbej-yk73y-6ttjb-oefyv-cpjta-7ttqk-e4ucl-5rxsq-v2bag-zae",
@@ -9058,7 +9058,7 @@
           "dc_id": "hk4",
           "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "afu64-x2met-w2vxb-4lzus-z4fhf-divej-q46gf-wvpek-dj67h-fptsd-aae": {
           "node_id": "afu64-x2met-w2vxb-4lzus-z4fhf-divej-q46gf-wvpek-dj67h-fptsd-aae",
@@ -9078,7 +9078,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "bkult-ic75e-xfviw-iyidh-tivyz-r7fvw-7r4xt-aawip-cp7vm-4iu2v-rae": {
           "node_id": "bkult-ic75e-xfviw-iyidh-tivyz-r7fvw-7r4xt-aawip-cp7vm-4iu2v-rae",
@@ -9098,7 +9098,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "c2ewt-wic55-asi27-6eoeu-rn7bq-xjzmz-dzxg2-pxrfw-qeinw-yrj52-7ae": {
           "node_id": "c2ewt-wic55-asi27-6eoeu-rn7bq-xjzmz-dzxg2-pxrfw-qeinw-yrj52-7ae",
@@ -9118,7 +9118,7 @@
           "dc_id": "bt1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "e6334-h54qb-rfmfa-kktez-s5tjs-q2ihe-fazyk-ybuo5-leln6-v3cfi-dae": {
           "node_id": "e6334-h54qb-rfmfa-kktez-s5tjs-q2ihe-fazyk-ybuo5-leln6-v3cfi-dae",
@@ -9138,7 +9138,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "eqe4v-xnyd5-sqimm-7qxav-sxmuf-c5jjj-bpqq3-ccpso-g6jqf-2a4yo-bqe": {
           "node_id": "eqe4v-xnyd5-sqimm-7qxav-sxmuf-c5jjj-bpqq3-ccpso-g6jqf-2a4yo-bqe",
@@ -9158,7 +9158,7 @@
           "dc_id": "rg1",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "flzwv-lslut-uvzxu-nrlrj-64b4q-om4c6-amsu4-nswej-io3nd-4gkkg-6ae": {
           "node_id": "flzwv-lslut-uvzxu-nrlrj-64b4q-om4c6-amsu4-nswej-io3nd-4gkkg-6ae",
@@ -9178,7 +9178,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "g765q-rteh7-xio4e-vtyea-ww46p-beylc-3e3s3-yhvuy-in6jd-hj5qo-3qe": {
           "node_id": "g765q-rteh7-xio4e-vtyea-ww46p-beylc-3e3s3-yhvuy-in6jd-hj5qo-3qe",
@@ -9198,7 +9198,7 @@
           "dc_id": "ba1",
           "node_provider_id": "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "irpwa-t65vg-ellmb-rg37m-ge5or-g3crz-3vbri-m4spq-eldkq-v2vs7-pae": {
           "node_id": "irpwa-t65vg-ellmb-rg37m-ge5or-g3crz-3vbri-m4spq-eldkq-v2vs7-pae",
@@ -9218,7 +9218,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "j6uir-h4bk3-chdqr-hxnkr-3jp7o-yb3el-skdsd-7oejj-eubk5-5onvy-zae": {
           "node_id": "j6uir-h4bk3-chdqr-hxnkr-3jp7o-yb3el-skdsd-7oejj-eubk5-5onvy-zae",
@@ -9238,7 +9238,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "krw4e-sr2h7-2yry5-6mrco-peytk-k243g-dya4k-vz6ye-i2woc-ar4s2-cae": {
           "node_id": "krw4e-sr2h7-2yry5-6mrco-peytk-k243g-dya4k-vz6ye-i2woc-ar4s2-cae",
@@ -9258,7 +9258,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "laeit-abiku-vm7d5-xnwpi-lf3ti-yfdjy-nunxn-ktpyc-gmpyl-idvtj-fae": {
           "node_id": "laeit-abiku-vm7d5-xnwpi-lf3ti-yfdjy-nunxn-ktpyc-gmpyl-idvtj-fae",
@@ -9278,7 +9278,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mhfef-zbxsl-rocpc-ovqeh-jg3ct-7nvmi-gzpnm-xjmm4-uekgj-rquls-uqe": {
           "node_id": "mhfef-zbxsl-rocpc-ovqeh-jg3ct-7nvmi-gzpnm-xjmm4-uekgj-rquls-uqe",
@@ -9298,7 +9298,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "myguv-fs4u6-jl53y-vk4pf-6xojw-4umwc-r55jy-jyy7q-f4gmu-wvliw-2qe": {
           "node_id": "myguv-fs4u6-jl53y-vk4pf-6xojw-4umwc-r55jy-jyy7q-f4gmu-wvliw-2qe",
@@ -9318,7 +9318,7 @@
           "dc_id": "zg1",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "np33o-vcmlt-zvs5o-wfwgf-l2qcj-htqw4-vdp4e-5vcki-6edum-ejtqz-jae": {
           "node_id": "np33o-vcmlt-zvs5o-wfwgf-l2qcj-htqw4-vdp4e-5vcki-6edum-ejtqz-jae",
@@ -9338,7 +9338,7 @@
           "dc_id": "tv1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ntk4m-3jwml-24enm-akwhr-gps2m-xe36d-qlkd2-scgcu-qmjik-nrk3b-wae": {
           "node_id": "ntk4m-3jwml-24enm-akwhr-gps2m-xe36d-qlkd2-scgcu-qmjik-nrk3b-wae",
@@ -9358,7 +9358,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "pbken-vny4r-j4a2m-zlvt2-kjj4i-pwehn-ftsa4-ne4xu-yz72s-fk6nz-eqe": {
           "node_id": "pbken-vny4r-j4a2m-zlvt2-kjj4i-pwehn-ftsa4-ne4xu-yz72s-fk6nz-eqe",
@@ -9378,7 +9378,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q4mjg-ahyte-ffbko-kvp2t-fjlub-nprnf-ttxza-yrkhp-7xo5g-c4e3x-iqe": {
           "node_id": "q4mjg-ahyte-ffbko-kvp2t-fjlub-nprnf-ttxza-yrkhp-7xo5g-c4e3x-iqe",
@@ -9398,7 +9398,7 @@
           "dc_id": "aw1",
           "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qzhuj-nrvb7-pe3j4-qe2td-jfgco-xfkln-7zmcr-wopiq-pb3jk-dchd4-6qe": {
           "node_id": "qzhuj-nrvb7-pe3j4-qe2td-jfgco-xfkln-7zmcr-wopiq-pb3jk-dchd4-6qe",
@@ -9418,7 +9418,7 @@
           "dc_id": "an1",
           "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rtjw5-ja7cv-j7nyl-jc5mc-t7lol-wjouh-nh6tm-baoba-wzra6-toyp5-iqe": {
           "node_id": "rtjw5-ja7cv-j7nyl-jc5mc-t7lol-wjouh-nh6tm-baoba-wzra6-toyp5-iqe",
@@ -9438,7 +9438,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "shtwt-kuy74-afhyd-sivzp-nj3vl-vh2zl-hdsvv-yunlj-k3asp-zsigu-cae": {
           "node_id": "shtwt-kuy74-afhyd-sivzp-nj3vl-vh2zl-hdsvv-yunlj-k3asp-zsigu-cae",
@@ -9458,7 +9458,7 @@
           "dc_id": "cm1",
           "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "snwzs-jy7bs-y6t3i-kegus-3s5xm-ob7yz-bcje6-qjb2m-jgndt-5dvbl-oae": {
           "node_id": "snwzs-jy7bs-y6t3i-kegus-3s5xm-ob7yz-bcje6-qjb2m-jgndt-5dvbl-oae",
@@ -9478,7 +9478,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "tws6x-33lmm-tptgb-v2tte-opnm4-fychj-thpve-x4ofu-cn4vo-6yuhl-qqe": {
           "node_id": "tws6x-33lmm-tptgb-v2tte-opnm4-fychj-thpve-x4ofu-cn4vo-6yuhl-qqe",
@@ -9498,7 +9498,7 @@
           "dc_id": "bg1",
           "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "v27at-hedf7-4a2my-tboq6-escdm-77krt-2qfuq-zjptf-z2sbk-vd7zs-xae": {
           "node_id": "v27at-hedf7-4a2my-tboq6-escdm-77krt-2qfuq-zjptf-z2sbk-vd7zs-xae",
@@ -9518,7 +9518,7 @@
           "dc_id": "ar1",
           "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "w2zci-bq5jo-vzrng-42mks-hvytn-she3z-52pej-vmigw-tic67-4prc6-qqe": {
           "node_id": "w2zci-bq5jo-vzrng-42mks-hvytn-she3z-52pej-vmigw-tic67-4prc6-qqe",
@@ -9538,7 +9538,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "w7v5s-nethv-crfsc-zzq5e-gibjz-dmmyp-mrl6e-vkvid-g56eh-iilcm-eqe": {
           "node_id": "w7v5s-nethv-crfsc-zzq5e-gibjz-dmmyp-mrl6e-vkvid-g56eh-iilcm-eqe",
@@ -9564,7 +9564,7 @@
           "dc_id": "ns1",
           "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "wgxbt-4e5xm-lsyc6-kazar-7kvzj-7biff-vzt52-2hddx-h3ddg-pfd3n-iae": {
           "node_id": "wgxbt-4e5xm-lsyc6-kazar-7kvzj-7biff-vzt52-2hddx-h3ddg-pfd3n-iae",
@@ -9590,7 +9590,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wr22o-nmso7-rmkqr-vzkv5-eg2cd-kxx3o-jbjnc-e5tjy-ety5p-rz4vf-uqe": {
           "node_id": "wr22o-nmso7-rmkqr-vzkv5-eg2cd-kxx3o-jbjnc-e5tjy-ety5p-rz4vf-uqe",
@@ -9610,7 +9610,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "yzi7p-lnf22-u2wot-tgxzn-v3ubs-4yuqq-fywh7-4tkk7-ly2xh-r5byg-mqe": {
           "node_id": "yzi7p-lnf22-u2wot-tgxzn-v3ubs-4yuqq-fywh7-4tkk7-ly2xh-r5byg-mqe",
@@ -9630,7 +9630,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zgeaf-fcq4e-fcnht-g7mpg-sb7ff-r6awk-zvkwp-gkloc-rr6jl-ghsse-mqe": {
           "node_id": "zgeaf-fcq4e-fcnht-g7mpg-sb7ff-r6awk-zvkwp-gkloc-rr6jl-ghsse-mqe",
@@ -9650,7 +9650,7 @@
           "dc_id": "ta2",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -9768,7 +9768,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bxczc-ao2x4-yzmq4-o2ezo-7mjct-ypeqs-6rcyl-ozl5d-j64m6-blata-iae": {
           "node_id": "bxczc-ao2x4-yzmq4-o2ezo-7mjct-ypeqs-6rcyl-ozl5d-j64m6-blata-iae",
@@ -9788,7 +9788,7 @@
           "dc_id": "pc1",
           "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dcbkk-imyhf-imyqt-ezzv4-g6krm-m7taq-l6mne-pqbmu-3ichw-y7x4r-2ae": {
           "node_id": "dcbkk-imyhf-imyqt-ezzv4-g6krm-m7taq-l6mne-pqbmu-3ichw-y7x4r-2ae",
@@ -9808,7 +9808,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "ikdvw-5ohcj-bucuv-m2gp3-56pff-ridwp-nvq5u-edpdi-idqzy-qyko3-wae": {
           "node_id": "ikdvw-5ohcj-bucuv-m2gp3-56pff-ridwp-nvq5u-edpdi-idqzy-qyko3-wae",
@@ -9828,7 +9828,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mqriv-hkd6f-wety4-rbjcl-ibf7a-i7kpp-62jsh-6yrie-2ahci-aql6t-dqe": {
           "node_id": "mqriv-hkd6f-wety4-rbjcl-ibf7a-i7kpp-62jsh-6yrie-2ahci-aql6t-dqe",
@@ -9854,7 +9854,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "njrl2-xk3tb-n662s-ckjbn-a6nrw-efzr2-o2352-su2lq-csj4k-pjlgs-rqe": {
           "node_id": "njrl2-xk3tb-n662s-ckjbn-a6nrw-efzr2-o2352-su2lq-csj4k-pjlgs-rqe",
@@ -9874,7 +9874,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "nr6q7-lhbao-gj6jo-5nfem-lttds-nammh-hfc3u-zjv2a-g4tno-tslx5-sqe": {
           "node_id": "nr6q7-lhbao-gj6jo-5nfem-lttds-nammh-hfc3u-zjv2a-g4tno-tslx5-sqe",
@@ -9894,7 +9894,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ozzf3-fgu6i-zazyu-53tna-6zxsi-6vh22-fvvuq-omtpr-hjrqn-n3ufz-cae": {
           "node_id": "ozzf3-fgu6i-zazyu-53tna-6zxsi-6vh22-fvvuq-omtpr-hjrqn-n3ufz-cae",
@@ -9914,7 +9914,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "spr2z-4kaf5-2dxlg-hatfo-obp75-b6vwh-ts2z5-eurny-rbun2-z6m4h-kae": {
           "node_id": "spr2z-4kaf5-2dxlg-hatfo-obp75-b6vwh-ts2z5-eurny-rbun2-z6m4h-kae",
@@ -9934,7 +9934,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tnjj3-xy6c4-ftk6z-kuhrs-zijli-xlbfg-j5gqt-qa77l-ehjkq-yxlua-2ae": {
           "node_id": "tnjj3-xy6c4-ftk6z-kuhrs-zijli-xlbfg-j5gqt-qa77l-ehjkq-yxlua-2ae",
@@ -9954,7 +9954,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tqkdx-4m6y2-avyzo-hkd6d-jqwka-3ys6i-ju6do-2auph-gb4bj-o7neg-bqe": {
           "node_id": "tqkdx-4m6y2-avyzo-hkd6d-jqwka-3ys6i-ju6do-2auph-gb4bj-o7neg-bqe",
@@ -9974,7 +9974,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ukmex-exflw-a4lyh-hrbdr-hjywz-v555q-cxq5y-md4as-2zt6b-fwxzt-aae": {
           "node_id": "ukmex-exflw-a4lyh-hrbdr-hjywz-v555q-cxq5y-md4as-2zt6b-fwxzt-aae",
@@ -9994,7 +9994,7 @@
           "dc_id": "si1",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "z23fe-7tw5j-f3lfl-4vprq-f6pdm-22uqa-73lqa-pokor-bvb2z-gsu5f-xqe": {
           "node_id": "z23fe-7tw5j-f3lfl-4vprq-f6pdm-22uqa-73lqa-pokor-bvb2z-gsu5f-xqe",
@@ -10014,7 +10014,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -10075,7 +10075,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7tayv-2pmqc-gaiwu-3kd3h-fh4qh-3moqd-aawsb-4rq6o-ui7fp-dofcu-iqe": {
           "node_id": "7tayv-2pmqc-gaiwu-3kd3h-fh4qh-3moqd-aawsb-4rq6o-ui7fp-dofcu-iqe",
@@ -10095,7 +10095,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "bs2f6-hqzox-bkqoe-aw3jj-7lso3-hyo33-tiq74-kuinv-ucdez-vtt4a-3ae": {
           "node_id": "bs2f6-hqzox-bkqoe-aw3jj-7lso3-hyo33-tiq74-kuinv-ucdez-vtt4a-3ae",
@@ -10115,7 +10115,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ctwsk-mtlet-rcsk6-p44am-6yabc-psi27-den2q-gaeg4-lk5zi-hr23q-6ae": {
           "node_id": "ctwsk-mtlet-rcsk6-p44am-6yabc-psi27-den2q-gaeg4-lk5zi-hr23q-6ae",
@@ -10135,7 +10135,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cxuqe-ou4rp-y6vot-zzuar-x3qwp-3jj5s-abhs4-yxacr-nxl4p-2cgb5-jae": {
           "node_id": "cxuqe-ou4rp-y6vot-zzuar-x3qwp-3jj5s-abhs4-yxacr-nxl4p-2cgb5-jae",
@@ -10155,7 +10155,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ddbl6-37efl-b75e4-jpfsb-zioa6-ilvzo-tldwy-fnbhm-nbuoy-66cza-uqe": {
           "node_id": "ddbl6-37efl-b75e4-jpfsb-zioa6-ilvzo-tldwy-fnbhm-nbuoy-66cza-uqe",
@@ -10175,7 +10175,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fvy7i-ux7is-cuvfm-2n2zh-5lpb4-oe2vz-bfnhz-oi5s5-jkzhk-phlj2-gqe": {
           "node_id": "fvy7i-ux7is-cuvfm-2n2zh-5lpb4-oe2vz-bfnhz-oi5s5-jkzhk-phlj2-gqe",
@@ -10195,7 +10195,7 @@
           "dc_id": "cr1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ii5t4-bvjp2-sypuy-pqz6v-v44yf-lzox2-ja3tp-m7gtj-7pszo-fk66d-cqe": {
           "node_id": "ii5t4-bvjp2-sypuy-pqz6v-v44yf-lzox2-ja3tp-m7gtj-7pszo-fk66d-cqe",
@@ -10215,7 +10215,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "lyhuu-ljnh7-ba3zz-g5ftu-xepo5-a3bqy-sggtx-6wgu2-5sw77-cxnfk-iae": {
           "node_id": "lyhuu-ljnh7-ba3zz-g5ftu-xepo5-a3bqy-sggtx-6wgu2-5sw77-cxnfk-iae",
@@ -10235,7 +10235,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "pmlsj-nmtc5-6pm7r-di22w-6ftne-5wjyw-xeivl-bzthp-fx7q3-5cgmo-hae": {
           "node_id": "pmlsj-nmtc5-6pm7r-di22w-6ftne-5wjyw-xeivl-bzthp-fx7q3-5cgmo-hae",
@@ -10255,7 +10255,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "u3bgl-kw7h5-djuod-zigyy-xp3ux-l6y3z-e223a-wmaki-i3kbh-fmoib-sae": {
           "node_id": "u3bgl-kw7h5-djuod-zigyy-xp3ux-l6y3z-e223a-wmaki-i3kbh-fmoib-sae",
@@ -10275,7 +10275,7 @@
           "dc_id": "jb1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "x3rso-73u7b-3pyeo-3fmcu-g635n-ri47m-jv3kg-zjfub-aqxsb-tnxbq-nqe": {
           "node_id": "x3rso-73u7b-3pyeo-3fmcu-g635n-ri47m-jv3kg-zjfub-aqxsb-tnxbq-nqe",
@@ -10295,7 +10295,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ys5ct-b73ij-z33xq-y4tej-vby6a-pwzjk-t7ob5-y5nub-oe4vo-alrjn-oae": {
           "node_id": "ys5ct-b73ij-z33xq-y4tej-vby6a-pwzjk-t7ob5-y5nub-oe4vo-alrjn-oae",
@@ -10315,7 +10315,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -10376,7 +10376,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3lgs3-hz4d6-jgdro-tdx6k-vzqp3-cuq65-lgrmm-j7bj3-u2cku-2bw5k-fae": {
           "node_id": "3lgs3-hz4d6-jgdro-tdx6k-vzqp3-cuq65-lgrmm-j7bj3-u2cku-2bw5k-fae",
@@ -10396,7 +10396,7 @@
           "dc_id": "vl2",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "4lqcl-tzzs3-jztya-ro7ak-ew5ue-l3tlc-5cxk3-4jt7m-z66st-ad5ld-aae": {
           "node_id": "4lqcl-tzzs3-jztya-ro7ak-ew5ue-l3tlc-5cxk3-4jt7m-z66st-ad5ld-aae",
@@ -10416,7 +10416,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "dnxq6-e2xox-dtmag-4ofwe-xfyko-iqr4i-zewbt-raveo-dipyk-zbjqq-rae": {
           "node_id": "dnxq6-e2xox-dtmag-4ofwe-xfyko-iqr4i-zewbt-raveo-dipyk-zbjqq-rae",
@@ -10436,7 +10436,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fl2ks-flv23-luwoe-t3tza-xmurj-aa3ts-bcuda-gpz53-gnnfn-xzm7x-4qe": {
           "node_id": "fl2ks-flv23-luwoe-t3tza-xmurj-aa3ts-bcuda-gpz53-gnnfn-xzm7x-4qe",
@@ -10456,7 +10456,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kpvfz-zg5cs-5ofal-k5zng-uop7b-gjm4v-z4ug3-sggef-4zu7x-ihvcw-yqe": {
           "node_id": "kpvfz-zg5cs-5ofal-k5zng-uop7b-gjm4v-z4ug3-sggef-4zu7x-ihvcw-yqe",
@@ -10476,7 +10476,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mtti3-fw4qf-27www-bah3o-ctlkw-lebmb-3m6e6-eesv4-l7onf-4db2y-qae": {
           "node_id": "mtti3-fw4qf-27www-bah3o-ctlkw-lebmb-3m6e6-eesv4-l7onf-4db2y-qae",
@@ -10496,7 +10496,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "rl4ec-tk6gm-5pc5u-2vtnm-vim5f-xgjik-iolpy-lhjof-yvnu2-mwixm-vae": {
           "node_id": "rl4ec-tk6gm-5pc5u-2vtnm-vim5f-xgjik-iolpy-lhjof-yvnu2-mwixm-vae",
@@ -10516,7 +10516,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "shg6y-mwjc2-rqfxr-7pi76-x3jed-yfn4p-v6gue-jbai7-uraz4-i35vp-eqe": {
           "node_id": "shg6y-mwjc2-rqfxr-7pi76-x3jed-yfn4p-v6gue-jbai7-uraz4-i35vp-eqe",
@@ -10536,7 +10536,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "umi6t-fnncc-uc7hn-ve6ng-6gefg-t2oxq-qy7zs-xcw4r-5uuh7-tlyn5-5qe": {
           "node_id": "umi6t-fnncc-uc7hn-ve6ng-6gefg-t2oxq-qy7zs-xcw4r-5uuh7-tlyn5-5qe",
@@ -10556,7 +10556,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wxpaf-p35qf-lgbep-ea4cu-dfxwf-65xgh-5hoyq-lplcs-ztt5m-nbweu-zae": {
           "node_id": "wxpaf-p35qf-lgbep-ea4cu-dfxwf-65xgh-5hoyq-lplcs-ztt5m-nbweu-zae",
@@ -10582,7 +10582,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xp737-mf6s2-27fc3-w22ge-g67ck-levhr-yf4a3-f2luo-4xd3y-3veag-pae": {
           "node_id": "xp737-mf6s2-27fc3-w22ge-g67ck-levhr-yf4a3-f2luo-4xd3y-3veag-pae",
@@ -10602,7 +10602,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yld6m-kvarh-m5a63-yxlak-4ukqc-zxa6g-aenp4-hjb3o-muwtu-h3zba-zae": {
           "node_id": "yld6m-kvarh-m5a63-yxlak-4ukqc-zxa6g-aenp4-hjb3o-muwtu-h3zba-zae",
@@ -10622,7 +10622,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -10689,7 +10689,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7effw-j4nle-7smlm-xzebk-ttmdp-lndrw-jk5a6-nsr4b-fikx3-zpuee-6ae": {
           "node_id": "7effw-j4nle-7smlm-xzebk-ttmdp-lndrw-jk5a6-nsr4b-fikx3-zpuee-6ae",
@@ -10709,7 +10709,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7up6g-ihrwe-e2at5-bi6e2-6rjeu-yk5mv-wabsc-qsu7x-ve6kj-2kyq4-vae": {
           "node_id": "7up6g-ihrwe-e2at5-bi6e2-6rjeu-yk5mv-wabsc-qsu7x-ve6kj-2kyq4-vae",
@@ -10729,7 +10729,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "axmok-d4arr-sjcjs-cd56j-biooj-lo4fh-vfuoo-fextc-5iw2d-6zhq5-4ae": {
           "node_id": "axmok-d4arr-sjcjs-cd56j-biooj-lo4fh-vfuoo-fextc-5iw2d-6zhq5-4ae",
@@ -10749,7 +10749,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dqhdk-ebgsg-zvcgz-wbwja-xdmng-li73v-yrkd2-mblw5-li2wp-blgx5-eqe": {
           "node_id": "dqhdk-ebgsg-zvcgz-wbwja-xdmng-li73v-yrkd2-mblw5-li2wp-blgx5-eqe",
@@ -10769,7 +10769,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "g2cpu-evuez-tk76a-n54kf-nxeik-c5b5g-hpdxo-sqlq5-st2ov-4xgzi-hqe": {
           "node_id": "g2cpu-evuez-tk76a-n54kf-nxeik-c5b5g-hpdxo-sqlq5-st2ov-4xgzi-hqe",
@@ -10789,7 +10789,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "if4w2-pekba-btwrw-6rlcx-erlgo-fdvuq-qlaa7-en4bx-iedqt-nrdo7-pae": {
           "node_id": "if4w2-pekba-btwrw-6rlcx-erlgo-fdvuq-qlaa7-en4bx-iedqt-nrdo7-pae",
@@ -10815,7 +10815,7 @@
           "dc_id": "ct1",
           "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "jdqro-ad2ju-bncnk-igcfw-u4z73-bckrs-kg5s7-6gxey-ijnzx-vxoir-lae": {
           "node_id": "jdqro-ad2ju-bncnk-igcfw-u4z73-bckrs-kg5s7-6gxey-ijnzx-vxoir-lae",
@@ -10835,7 +10835,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "pk6jo-5oauw-yubar-gifh2-zhhkd-erh4g-2wagj-5zh7c-saq7w-pb73t-dqe": {
           "node_id": "pk6jo-5oauw-yubar-gifh2-zhhkd-erh4g-2wagj-5zh7c-saq7w-pb73t-dqe",
@@ -10855,7 +10855,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pzuk7-f54ar-77de6-nkxs2-ybva6-dpn63-blie4-rg2no-vtyl7-pvviz-tqe": {
           "node_id": "pzuk7-f54ar-77de6-nkxs2-ybva6-dpn63-blie4-rg2no-vtyl7-pvviz-tqe",
@@ -10875,7 +10875,7 @@
           "dc_id": "ar1",
           "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "q36yu-tbutb-rdwfe-oyda7-gregz-3speg-zemom-hhjpt-ow74s-p5tyw-tae": {
           "node_id": "q36yu-tbutb-rdwfe-oyda7-gregz-3speg-zemom-hhjpt-ow74s-p5tyw-tae",
@@ -10895,7 +10895,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q654n-n2u4q-spico-lpel4-ixfuj-m74mf-47yyv-gzwj6-wc5tu-maluy-zqe": {
           "node_id": "q654n-n2u4q-spico-lpel4-ixfuj-m74mf-47yyv-gzwj6-wc5tu-maluy-zqe",
@@ -10915,7 +10915,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wzobn-oqy6r-qnhrl-6qvxp-3dizc-5gb2q-tbtnc-ptnfl-vyxkw-g7gxc-4qe": {
           "node_id": "wzobn-oqy6r-qnhrl-6qvxp-3dizc-5gb2q-tbtnc-ptnfl-vyxkw-g7gxc-4qe",
@@ -10935,7 +10935,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -11025,7 +11025,7 @@
           "dc_id": "bt1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "2ftux-ivgjc-t4i2d-lq5hs-myjdg-3h2pz-l2ddl-nsxfc-wlaq7-fkbc5-6ae": {
           "node_id": "2ftux-ivgjc-t4i2d-lq5hs-myjdg-3h2pz-l2ddl-nsxfc-wlaq7-fkbc5-6ae",
@@ -11045,7 +11045,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "2nehn-z42p7-36s7j-qqcz6-sy5rb-euhte-necpl-egqsv-hdoph-gx7qd-6ae": {
           "node_id": "2nehn-z42p7-36s7j-qqcz6-sy5rb-euhte-necpl-egqsv-hdoph-gx7qd-6ae",
@@ -11071,7 +11071,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "3zfpk-du6xx-yg7j5-h7c5w-6rr7z-cmkbf-pfos7-lhu65-svdmj-co7nc-cae": {
           "node_id": "3zfpk-du6xx-yg7j5-h7c5w-6rr7z-cmkbf-pfos7-lhu65-svdmj-co7nc-cae",
@@ -11091,7 +11091,7 @@
           "dc_id": "sg3",
           "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4jkq7-io75m-ox4jr-gb76l-zyoqy-gttw3-m2ttq-4d4md-637uk-ukltt-5qe": {
           "node_id": "4jkq7-io75m-ox4jr-gb76l-zyoqy-gttw3-m2ttq-4d4md-637uk-ukltt-5qe",
@@ -11111,7 +11111,7 @@
           "dc_id": "an1",
           "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5gcqu-upr5b-ol3fj-vz273-3ov5j-s2dzp-d3n4o-c3rdz-rnhto-tovcx-zqe": {
           "node_id": "5gcqu-upr5b-ol3fj-vz273-3ov5j-s2dzp-d3n4o-c3rdz-rnhto-tovcx-zqe",
@@ -11131,7 +11131,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5iihd-fkroy-ow5zp-hlvwz-bsgbl-mecta-kxubm-6adxr-ckcu6-prsus-fqe": {
           "node_id": "5iihd-fkroy-ow5zp-hlvwz-bsgbl-mecta-kxubm-6adxr-ckcu6-prsus-fqe",
@@ -11151,7 +11151,7 @@
           "dc_id": "hk4",
           "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5mpdi-v4qj2-64are-tbe6r-6335g-6tksh-c7uzq-w3xyz-o4p5g-rwnll-vqe": {
           "node_id": "5mpdi-v4qj2-64are-tbe6r-6335g-6tksh-c7uzq-w3xyz-o4p5g-rwnll-vqe",
@@ -11171,7 +11171,7 @@
           "dc_id": "ty3",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "67m4d-5jvep-mnm7z-fjsm7-7aec4-bycrw-dntq6-v4ahv-4mele-yljgc-tae": {
           "node_id": "67m4d-5jvep-mnm7z-fjsm7-7aec4-bycrw-dntq6-v4ahv-4mele-yljgc-tae",
@@ -11191,7 +11191,7 @@
           "dc_id": "ta1",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "6hkcx-vz4jv-4n33r-ywdvs-sefaa-tb2on-rac6s-4csut-iyahu-zmct2-5qe": {
           "node_id": "6hkcx-vz4jv-4n33r-ywdvs-sefaa-tb2on-rac6s-4csut-iyahu-zmct2-5qe",
@@ -11211,7 +11211,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6hvx2-ymemx-tmykh-vxyic-bgfhv-2lcmt-3oy4x-rysuf-rnerz-vqokw-sqe": {
           "node_id": "6hvx2-ymemx-tmykh-vxyic-bgfhv-2lcmt-3oy4x-rysuf-rnerz-vqokw-sqe",
@@ -11231,7 +11231,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "anudy-m6vfi-lphxb-sazpy-la4ti-2hriw-c67ny-butfn-axcel-otvuh-oqe": {
           "node_id": "anudy-m6vfi-lphxb-sazpy-la4ti-2hriw-c67ny-butfn-axcel-otvuh-oqe",
@@ -11251,7 +11251,7 @@
           "dc_id": "mtl1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "daawl-5c7hb-iltb3-rkphn-d272x-kkpu4-vb5nr-4qxzp-azreg-47okd-gqe": {
           "node_id": "daawl-5c7hb-iltb3-rkphn-d272x-kkpu4-vb5nr-4qxzp-azreg-47okd-gqe",
@@ -11271,7 +11271,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "gj6gc-mbslq-bt63y-72b7h-xs2xw-6vyuj-frvp3-tx375-dsqx5-wem6o-vqe": {
           "node_id": "gj6gc-mbslq-bt63y-72b7h-xs2xw-6vyuj-frvp3-tx375-dsqx5-wem6o-vqe",
@@ -11291,7 +11291,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "gsrhr-kwp6h-y6ibc-yftud-fzi66-vg5df-subl3-wiren-uzza6-rb5fc-dae": {
           "node_id": "gsrhr-kwp6h-y6ibc-yftud-fzi66-vg5df-subl3-wiren-uzza6-rb5fc-dae",
@@ -11311,7 +11311,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "gvm7l-ds4n6-vkyjn-gwalp-3vdo6-qfmq7-pxhu4-zvqcu-ozvb7-qz3gr-vqe": {
           "node_id": "gvm7l-ds4n6-vkyjn-gwalp-3vdo6-qfmq7-pxhu4-zvqcu-ozvb7-qz3gr-vqe",
@@ -11331,7 +11331,7 @@
           "dc_id": "tv1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "isegs-i4akf-kb7st-hnqjn-4col7-qxpph-pncbs-25hiy-5pwsu-nyw3x-xae": {
           "node_id": "isegs-i4akf-kb7st-hnqjn-4col7-qxpph-pncbs-25hiy-5pwsu-nyw3x-xae",
@@ -11351,7 +11351,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "jmuoq-7kbey-cbtmm-zlz6t-chwt6-dk7ly-d3jim-5nuu4-y5tou-l5egg-7qe": {
           "node_id": "jmuoq-7kbey-cbtmm-zlz6t-chwt6-dk7ly-d3jim-5nuu4-y5tou-l5egg-7qe",
@@ -11371,7 +11371,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jyh32-azcnn-mwosu-urewl-m3pyx-6pmlq-lu5fu-vqjyl-gwx3j-zqrjr-gae": {
           "node_id": "jyh32-azcnn-mwosu-urewl-m3pyx-6pmlq-lu5fu-vqjyl-gwx3j-zqrjr-gae",
@@ -11391,7 +11391,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "k2ovz-ptdmz-hzmkh-ntfqn-evhux-ktxz4-26jg6-qjjsa-rpgal-wkdjo-kqe": {
           "node_id": "k2ovz-ptdmz-hzmkh-ntfqn-evhux-ktxz4-26jg6-qjjsa-rpgal-wkdjo-kqe",
@@ -11411,7 +11411,7 @@
           "dc_id": "rg3",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "lh2af-66zso-76kqu-d57ag-jca5d-yvmfo-rcabh-ptlvj-ltfdf-kyg6q-lqe": {
           "node_id": "lh2af-66zso-76kqu-d57ag-jca5d-yvmfo-rcabh-ptlvj-ltfdf-kyg6q-lqe",
@@ -11431,7 +11431,7 @@
           "dc_id": "li2",
           "node_provider_id": "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "lxgqb-dlqzi-schn4-i2mha-qh6re-eq3c2-3k6cn-oqumg-jkmgk-d4gex-3qe": {
           "node_id": "lxgqb-dlqzi-schn4-i2mha-qh6re-eq3c2-3k6cn-oqumg-jkmgk-d4gex-3qe",
@@ -11451,7 +11451,7 @@
           "dc_id": "cm1",
           "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "m2g5i-bmomq-dyjao-k642i-fsfxg-trxki-6i42q-hm6ec-xu5cd-n5jhq-sqe": {
           "node_id": "m2g5i-bmomq-dyjao-k642i-fsfxg-trxki-6i42q-hm6ec-xu5cd-n5jhq-sqe",
@@ -11471,7 +11471,7 @@
           "dc_id": "hu1",
           "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mae7q-ggnbj-xb52f-hvest-dgqoc-whvsq-yui5d-5cys2-zeold-l5ydx-oae": {
           "node_id": "mae7q-ggnbj-xb52f-hvest-dgqoc-whvsq-yui5d-5cys2-zeold-l5ydx-oae",
@@ -11491,7 +11491,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "mjte3-dopva-7tttu-5hnnu-q572b-p3wwy-b56of-4q6h7-hbtf4-f3m32-tae": {
           "node_id": "mjte3-dopva-7tttu-5hnnu-q572b-p3wwy-b56of-4q6h7-hbtf4-f3m32-tae",
@@ -11511,7 +11511,7 @@
           "dc_id": "pa1",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ncr4b-rasb7-tueb3-n4uos-5nxou-3wbxv-xmyt3-wfdsd-vu4b6-5x3cp-aqe": {
           "node_id": "ncr4b-rasb7-tueb3-n4uos-5nxou-3wbxv-xmyt3-wfdsd-vu4b6-5x3cp-aqe",
@@ -11537,7 +11537,7 @@
           "dc_id": "ld1",
           "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "noos2-mfe4u-r4gp3-jrjow-ancs2-ncakm-zi72z-zzcbg-uam7p-d4s6s-6qe": {
           "node_id": "noos2-mfe4u-r4gp3-jrjow-ancs2-ncakm-zi72z-zzcbg-uam7p-d4s6s-6qe",
@@ -11557,7 +11557,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "oirv5-oatly-ra7gr-dswc6-67xg6-2yvmi-zrjm6-2erp7-fls6r-xlu43-tqe": {
           "node_id": "oirv5-oatly-ra7gr-dswc6-67xg6-2yvmi-zrjm6-2erp7-fls6r-xlu43-tqe",
@@ -11577,7 +11577,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ouffe-miylc-6zcwl-afv2d-lai62-qwzns-xtlji-p7pu2-qkx2e-x72y2-sqe": {
           "node_id": "ouffe-miylc-6zcwl-afv2d-lai62-qwzns-xtlji-p7pu2-qkx2e-x72y2-sqe",
@@ -11597,7 +11597,7 @@
           "dc_id": "wa3",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "q4ksz-lpvfy-ikkem-wyuaa-abopq-nmu5k-ovh6h-xfoqk-hx3x3-g2bk6-4qe": {
           "node_id": "q4ksz-lpvfy-ikkem-wyuaa-abopq-nmu5k-ovh6h-xfoqk-hx3x3-g2bk6-4qe",
@@ -11617,7 +11617,7 @@
           "dc_id": "jb3",
           "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qknkg-ssedm-jiaaw-dst4j-reyue-zaymp-b3b4a-yk3gp-ix7ch-ibyhm-sae": {
           "node_id": "qknkg-ssedm-jiaaw-dst4j-reyue-zaymp-b3b4a-yk3gp-ix7ch-ibyhm-sae",
@@ -11637,7 +11637,7 @@
           "dc_id": "st1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rcxhc-af5ln-myck4-qrbsj-aelzk-l4hy4-o4fws-7kx57-ajldl-v6pmo-fqe": {
           "node_id": "rcxhc-af5ln-myck4-qrbsj-aelzk-l4hy4-o4fws-7kx57-ajldl-v6pmo-fqe",
@@ -11657,7 +11657,7 @@
           "dc_id": "hk3",
           "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "rg2yy-3or4h-pllvs-aczz3-dgf2k-3m3d5-oresl-easzv-2xa6h-7eoda-zqe": {
           "node_id": "rg2yy-3or4h-pllvs-aczz3-dgf2k-3m3d5-oresl-easzv-2xa6h-7eoda-zqe",
@@ -11677,7 +11677,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tg4ec-b2g4p-h42kd-k7zvb-6rls2-i2q7l-gtr4h-ymr6v-rrez4-w6fao-oqe": {
           "node_id": "tg4ec-b2g4p-h42kd-k7zvb-6rls2-i2q7l-gtr4h-ymr6v-rrez4-w6fao-oqe",
@@ -11697,7 +11697,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "u4zo2-i6nsc-mowwj-lf6az-s6rdo-caskt-a6yx6-fke5w-qyezs-lyqvn-tqe": {
           "node_id": "u4zo2-i6nsc-mowwj-lf6az-s6rdo-caskt-a6yx6-fke5w-qyezs-lyqvn-tqe",
@@ -11717,7 +11717,7 @@
           "dc_id": "sc1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ulhxy-qlokv-5iual-yizlo-dtlmi-aavz5-bi7ez-kjwqz-la64z-cxjuk-fae": {
           "node_id": "ulhxy-qlokv-5iual-yizlo-dtlmi-aavz5-bi7ez-kjwqz-la64z-cxjuk-fae",
@@ -11743,7 +11743,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vysyd-tlwq5-f5vfi-kw2jc-ziylz-di2s5-sf4p3-iflm7-vyvjv-hz3b3-pae": {
           "node_id": "vysyd-tlwq5-f5vfi-kw2jc-ziylz-di2s5-sf4p3-iflm7-vyvjv-hz3b3-pae",
@@ -11769,7 +11769,7 @@
           "dc_id": "kr2",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "w2sev-mtuls-aa7m5-cdjgi-5vipg-2jn7i-4awvf-o6suu-73ebs-sw5db-kqe": {
           "node_id": "w2sev-mtuls-aa7m5-cdjgi-5vipg-2jn7i-4awvf-o6suu-73ebs-sw5db-kqe",
@@ -11789,7 +11789,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "yahq2-6rnmm-n7ubm-q76zd-256dl-5f7k6-jxx5l-njyo2-hl7tk-sqcet-6ae": {
           "node_id": "yahq2-6rnmm-n7ubm-q76zd-256dl-5f7k6-jxx5l-njyo2-hl7tk-sqcet-6ae",
@@ -11809,7 +11809,7 @@
           "dc_id": "ar1",
           "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zatyv-4l26n-3lecc-xpeme-ul34o-yiye2-3d447-aiiz4-5pxtm-v44nh-cqe": {
           "node_id": "zatyv-4l26n-3lecc-xpeme-ul34o-yiye2-3d447-aiiz4-5pxtm-v44nh-cqe",
@@ -11829,7 +11829,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 3670016,
@@ -11915,7 +11915,7 @@
           "dc_id": "or1",
           "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "3hibk-2fnod-r7pab-hb3im-blyqv-lyvdx-v273s-psxjn-yfsue-iakax-yae": {
           "node_id": "3hibk-2fnod-r7pab-hb3im-blyqv-lyvdx-v273s-psxjn-yfsue-iakax-yae",
@@ -11935,7 +11935,7 @@
           "dc_id": "hk4",
           "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3jol6-6a6dv-ysedb-5qlxc-baclw-ub23p-d324m-7sfus-bkbnk-jlh6b-jqe": {
           "node_id": "3jol6-6a6dv-ysedb-5qlxc-baclw-ub23p-d324m-7sfus-bkbnk-jlh6b-jqe",
@@ -11961,7 +11961,7 @@
           "dc_id": "ld1",
           "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3o5rr-5acje-r4kun-h2deq-fbv6e-gyujh-222t2-b4ob6-rukpb-kmjn7-hae": {
           "node_id": "3o5rr-5acje-r4kun-h2deq-fbv6e-gyujh-222t2-b4ob6-rukpb-kmjn7-hae",
@@ -11981,7 +11981,7 @@
           "dc_id": "dl1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "67t6p-i4h3c-msv6p-kmbmm-rr6gj-z3nix-d6lo2-mq3q4-3h6rb-lwkbc-lae": {
           "node_id": "67t6p-i4h3c-msv6p-kmbmm-rr6gj-z3nix-d6lo2-mq3q4-3h6rb-lwkbc-lae",
@@ -12001,7 +12001,7 @@
           "dc_id": "nd1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "6adxp-p7u63-xsdtk-lo6oc-vpqmi-44hgt-yv652-cbm5p-mssge-wsrz6-oqe": {
           "node_id": "6adxp-p7u63-xsdtk-lo6oc-vpqmi-44hgt-yv652-cbm5p-mssge-wsrz6-oqe",
@@ -12021,7 +12021,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "74qsa-j6jno-nmxmb-7jpf5-u6nig-g7hgo-thvjm-6f6zu-c2ugp-krple-qae": {
           "node_id": "74qsa-j6jno-nmxmb-7jpf5-u6nig-g7hgo-thvjm-6f6zu-c2ugp-krple-qae",
@@ -12041,7 +12041,7 @@
           "dc_id": "ba1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "7m3y7-s24j3-i5oji-6h64r-2ah6w-2z236-rh7ro-b3plo-rrdwn-xwhc2-aqe": {
           "node_id": "7m3y7-s24j3-i5oji-6h64r-2ah6w-2z236-rh7ro-b3plo-rrdwn-xwhc2-aqe",
@@ -12061,7 +12061,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "aajth-ndp7x-ro5ok-yikyd-4i7xn-5k5ki-e3d37-hh4gn-s4opz-bnzxf-4qe": {
           "node_id": "aajth-ndp7x-ro5ok-yikyd-4i7xn-5k5ki-e3d37-hh4gn-s4opz-bnzxf-4qe",
@@ -12081,7 +12081,7 @@
           "dc_id": "bg1",
           "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dyycg-wc45f-jwks2-abddo-m3n5r-o5kxy-g5xhm-7ve4u-3tlk7-i7xec-oae": {
           "node_id": "dyycg-wc45f-jwks2-abddo-m3n5r-o5kxy-g5xhm-7ve4u-3tlk7-i7xec-oae",
@@ -12107,7 +12107,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ecxbl-3dp33-mpskv-yvs6f-674ct-tpr4d-dhzdg-jfgf4-gzhny-n6zzx-lqe": {
           "node_id": "ecxbl-3dp33-mpskv-yvs6f-674ct-tpr4d-dhzdg-jfgf4-gzhny-n6zzx-lqe",
@@ -12127,7 +12127,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "engai-flho6-5z6nk-4eirk-ozvgk-z73wc-bgayv-lbnls-djvfe-lheum-jae": {
           "node_id": "engai-flho6-5z6nk-4eirk-ozvgk-z73wc-bgayv-lbnls-djvfe-lheum-jae",
@@ -12147,7 +12147,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "fhg3q-muslh-pp7ur-hcivl-q3kof-mju7a-kjyyf-hjifg-nsa35-nqjv3-7qe": {
           "node_id": "fhg3q-muslh-pp7ur-hcivl-q3kof-mju7a-kjyyf-hjifg-nsa35-nqjv3-7qe",
@@ -12167,7 +12167,7 @@
           "dc_id": "cm1",
           "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "g4avo-ecrmg-ki3ol-dxah7-zksar-suefa-26fco-fudva-ajioq-xvhmq-4ae": {
           "node_id": "g4avo-ecrmg-ki3ol-dxah7-zksar-suefa-26fco-fudva-ajioq-xvhmq-4ae",
@@ -12187,7 +12187,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "go5zz-xs6yg-mylwl-v7uob-7bg4b-wjzhe-vmrwe-uy7mz-ckaz2-idm33-rqe": {
           "node_id": "go5zz-xs6yg-mylwl-v7uob-7bg4b-wjzhe-vmrwe-uy7mz-ckaz2-idm33-rqe",
@@ -12207,7 +12207,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "hlc73-cklhu-zo4mt-waxb6-ew5tx-gm4or-coy2j-xnwmy-xsycn-j6f4e-iae": {
           "node_id": "hlc73-cklhu-zo4mt-waxb6-ew5tx-gm4or-coy2j-xnwmy-xsycn-j6f4e-iae",
@@ -12227,7 +12227,7 @@
           "dc_id": "hk3",
           "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "j4et3-lkqhr-32t4q-3o57n-nm7u3-hvgsd-7v574-3z7mj-eyks5-twtxo-zae": {
           "node_id": "j4et3-lkqhr-32t4q-3o57n-nm7u3-hvgsd-7v574-3z7mj-eyks5-twtxo-zae",
@@ -12247,7 +12247,7 @@
           "dc_id": "jb2",
           "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "kgo2t-vidyw-yw2g5-pqwrt-nr227-rbq2o-pog27-zarc2-dfrlw-vvjge-4qe": {
           "node_id": "kgo2t-vidyw-yw2g5-pqwrt-nr227-rbq2o-pog27-zarc2-dfrlw-vvjge-4qe",
@@ -12267,7 +12267,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "km5ur-yacty-d2nvm-sitx7-zvnw4-bdjuf-lm3qv-vtftj-fv4vz-3d5y7-kae": {
           "node_id": "km5ur-yacty-d2nvm-sitx7-zvnw4-bdjuf-lm3qv-vtftj-fv4vz-3d5y7-kae",
@@ -12287,7 +12287,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kwryq-ezysk-c4ono-aet7a-hh6h5-4o3bb-a33et-ef4g5-42tot-zaek6-fae": {
           "node_id": "kwryq-ezysk-c4ono-aet7a-hh6h5-4o3bb-a33et-ef4g5-42tot-zaek6-fae",
@@ -12313,7 +12313,7 @@
           "dc_id": "jb3",
           "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "lilkb-wf7hu-iv6gp-gbbv6-f6bpj-amtp5-v2jyi-3s7jw-6dysi-yzm4g-hae": {
           "node_id": "lilkb-wf7hu-iv6gp-gbbv6-f6bpj-amtp5-v2jyi-3s7jw-6dysi-yzm4g-hae",
@@ -12333,7 +12333,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "nrz3y-3qhvi-mhz6v-zlvpg-wvwn3-fsmom-wtkla-p67ly-fgsl2-sf5g4-bae": {
           "node_id": "nrz3y-3qhvi-mhz6v-zlvpg-wvwn3-fsmom-wtkla-p67ly-fgsl2-sf5g4-bae",
@@ -12353,7 +12353,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q3ums-xaeuo-t73ww-ojrns-lcpa4-2hf37-re7ho-zjspe-zrggb-2el6z-jae": {
           "node_id": "q3ums-xaeuo-t73ww-ojrns-lcpa4-2hf37-re7ho-zjspe-zrggb-2el6z-jae",
@@ -12373,7 +12373,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q3vac-kcwo2-ruiht-nflb7-ifoev-vkjcw-quybi-ugvgn-pqfwp-jntxi-dqe": {
           "node_id": "q3vac-kcwo2-ruiht-nflb7-ifoev-vkjcw-quybi-ugvgn-pqfwp-jntxi-dqe",
@@ -12393,7 +12393,7 @@
           "dc_id": "zg1",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qlk52-xi45d-fpbsj-epcof-uoghd-xkmb2-woudx-aci7c-tpglx-rq5mj-vqe": {
           "node_id": "qlk52-xi45d-fpbsj-epcof-uoghd-xkmb2-woudx-aci7c-tpglx-rq5mj-vqe",
@@ -12413,7 +12413,7 @@
           "dc_id": "rg1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qlvmn-xucv5-o6qp6-nmhaa-mfm2g-x42bb-6sisq-wrytb-wpxkm-fser2-dqe": {
           "node_id": "qlvmn-xucv5-o6qp6-nmhaa-mfm2g-x42bb-6sisq-wrytb-wpxkm-fser2-dqe",
@@ -12433,7 +12433,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qp3lh-25yxy-dlk4t-ay73d-frr4t-3kmi5-35kqg-3vvbq-26qhh-6xrdr-oqe": {
           "node_id": "qp3lh-25yxy-dlk4t-ay73d-frr4t-3kmi5-35kqg-3vvbq-26qhh-6xrdr-oqe",
@@ -12459,7 +12459,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "rfkza-27bii-6jan4-u4zll-lkvmz-snmao-irmlj-arpdd-kyxrg-xnq3a-7ae": {
           "node_id": "rfkza-27bii-6jan4-u4zll-lkvmz-snmao-irmlj-arpdd-kyxrg-xnq3a-7ae",
@@ -12479,7 +12479,7 @@
           "dc_id": "tv1",
           "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "tpz2t-27cno-fbljl-lczc6-qjxrc-6fiby-naauq-3o6q3-fsxdf-yqg2v-yae": {
           "node_id": "tpz2t-27cno-fbljl-lczc6-qjxrc-6fiby-naauq-3o6q3-fsxdf-yqg2v-yae",
@@ -12499,7 +12499,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ulsfy-bqajl-ktzwn-pgr2u-s4uyu-jipgr-etcjd-smsyr-ulind-u3nr5-hqe": {
           "node_id": "ulsfy-bqajl-ktzwn-pgr2u-s4uyu-jipgr-etcjd-smsyr-ulind-u3nr5-hqe",
@@ -12519,7 +12519,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "w4ri3-ytfnq-jg3z3-qseka-se4xe-b2fl2-km766-ruzwd-riw72-6bifs-4ae": {
           "node_id": "w4ri3-ytfnq-jg3z3-qseka-se4xe-b2fl2-km766-ruzwd-riw72-6bifs-4ae",
@@ -12539,7 +12539,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "xll74-g2hbn-jkxky-c2m6n-bfobh-j4k33-haawc-ggiuh-ro5ce-uwm3z-xqe": {
           "node_id": "xll74-g2hbn-jkxky-c2m6n-bfobh-j4k33-haawc-ggiuh-ro5ce-uwm3z-xqe",
@@ -12559,7 +12559,7 @@
           "dc_id": "an1",
           "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yi6r6-u4kax-jphcr-jcqr5-t3zpm-gmp3b-2hiew-iinpf-sgjos-eabha-aqe": {
           "node_id": "yi6r6-u4kax-jphcr-jcqr5-t3zpm-gmp3b-2hiew-iinpf-sgjos-eabha-aqe",
@@ -12579,7 +12579,7 @@
           "dc_id": "ma1",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zjiki-pzvnv-m4rnn-fodt3-poon4-uldx7-d3wkq-gptsu-g2mjs-boi35-3qe": {
           "node_id": "zjiki-pzvnv-m4rnn-fodt3-poon4-uldx7-d3wkq-gptsu-g2mjs-boi35-3qe",
@@ -12599,7 +12599,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 3670016,
@@ -12719,7 +12719,7 @@
           "dc_id": "zh5",
           "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "abg3e-zrvni-lab54-xuqtf-beh5q-lijks-zlbd5-wkpwg-xua7u-e4g7y-oae": {
           "node_id": "abg3e-zrvni-lab54-xuqtf-beh5q-lijks-zlbd5-wkpwg-xua7u-e4g7y-oae",
@@ -12739,7 +12739,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "clfor-3la2h-lohby-tfriy-xfjkf-fnqpw-kkhjw-ctb2i-tscfx-ddwu7-bqe": {
           "node_id": "clfor-3la2h-lohby-tfriy-xfjkf-fnqpw-kkhjw-ctb2i-tscfx-ddwu7-bqe",
@@ -12759,7 +12759,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "csrkp-dimpe-7dybx-jmzjj-tjcjf-t57c4-tf4cq-cjeix-6tyah-qkyre-zae": {
           "node_id": "csrkp-dimpe-7dybx-jmzjj-tjcjf-t57c4-tf4cq-cjeix-6tyah-qkyre-zae",
@@ -12779,7 +12779,7 @@
           "dc_id": "se1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ctqez-oqvmf-kkwto-wlehz-grh5a-l7enx-7e7ds-hcn75-mpdj5-pujdj-eae": {
           "node_id": "ctqez-oqvmf-kkwto-wlehz-grh5a-l7enx-7e7ds-hcn75-mpdj5-pujdj-eae",
@@ -12805,7 +12805,7 @@
           "dc_id": "zh4",
           "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "f6etz-5w6fg-ho2uo-gjklb-7oxto-i2z2u-udqih-6evln-4tb5s-iliw3-7ae": {
           "node_id": "f6etz-5w6fg-ho2uo-gjklb-7oxto-i2z2u-udqih-6evln-4tb5s-iliw3-7ae",
@@ -12825,7 +12825,7 @@
           "dc_id": "sg3",
           "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jux3z-ivwyz-ury64-jth4b-rrbfi-sx5af-ci72l-j4ot3-nl5jk-z4ilu-6qe": {
           "node_id": "jux3z-ivwyz-ury64-jth4b-rrbfi-sx5af-ci72l-j4ot3-nl5jk-z4ilu-6qe",
@@ -12845,7 +12845,7 @@
           "dc_id": "hk4",
           "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "ognrk-q4exl-3wf25-yrrsy-mtezk-e3qww-k6s5v-2pikz-gto6z-dyl2y-eae": {
           "node_id": "ognrk-q4exl-3wf25-yrrsy-mtezk-e3qww-k6s5v-2pikz-gto6z-dyl2y-eae",
@@ -12865,7 +12865,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "uajv3-ocqku-n5d2z-kbw3g-mqsir-er7gs-mhsdg-27f6d-xbfjl-uugdr-cae": {
           "node_id": "uajv3-ocqku-n5d2z-kbw3g-mqsir-er7gs-mhsdg-27f6d-xbfjl-uugdr-cae",
@@ -12885,7 +12885,7 @@
           "dc_id": "sc1",
           "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "uw4qe-cjsp5-sfdvk-3d5y7-ufvcj-mi6x5-f3xtd-ovphb-6ipa2-aw3pq-lqe": {
           "node_id": "uw4qe-cjsp5-sfdvk-3d5y7-ufvcj-mi6x5-f3xtd-ovphb-6ipa2-aw3pq-lqe",
@@ -12905,7 +12905,7 @@
           "dc_id": "mb1",
           "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xszxr-w2ae6-g2fof-f6hp4-cquvx-4vyu2-ux2tn-nij6l-b7hue-4r4kl-gqe": {
           "node_id": "xszxr-w2ae6-g2fof-f6hp4-cquvx-4vyu2-ux2tn-nij6l-b7hue-4r4kl-gqe",
@@ -12925,7 +12925,7 @@
           "dc_id": "st1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ywdqr-vd2io-gz6n3-ey4ns-h7gu7-l4huz-dk36s-fr7er-lsftp-77wde-gae": {
           "node_id": "ywdqr-vd2io-gz6n3-ey4ns-h7gu7-l4huz-dk36s-fr7er-lsftp-77wde-gae",
@@ -12945,7 +12945,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "z2tgr-ilz6g-ifi6c-3yeiq-zo5sc-humd5-vc6s6-wogpu-yj5rp-wwuta-sqe": {
           "node_id": "z2tgr-ilz6g-ifi6c-3yeiq-zo5sc-humd5-vc6s6-wogpu-yj5rp-wwuta-sqe",
@@ -12965,7 +12965,7 @@
           "dc_id": "an1",
           "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -13026,7 +13026,7 @@
           "dc_id": "jb1",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "5j5bj-nof4w-umwfb-jqemy-uhcqy-bzioi-23ct7-xsb4m-ojzy6-4jxz5-rqe": {
           "node_id": "5j5bj-nof4w-umwfb-jqemy-uhcqy-bzioi-23ct7-xsb4m-ojzy6-4jxz5-rqe",
@@ -13046,7 +13046,7 @@
           "dc_id": "lj1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "b44r4-u77ay-myhhv-d6d75-jusik-b7ry2-g6ms5-6okxm-tumyx-rjm4g-4ae": {
           "node_id": "b44r4-u77ay-myhhv-d6d75-jusik-b7ry2-g6ms5-6okxm-tumyx-rjm4g-4ae",
@@ -13066,7 +13066,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "hober-6po5w-o6flx-nxc4v-pr5j7-g423z-i72ls-rxwtl-ghabg-p75vf-iqe": {
           "node_id": "hober-6po5w-o6flx-nxc4v-pr5j7-g423z-i72ls-rxwtl-ghabg-p75vf-iqe",
@@ -13086,7 +13086,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kwlys-46pnx-4t2m3-wqrly-q5qg5-lzr6p-75c77-celqe-rbtan-oclkg-5ae": {
           "node_id": "kwlys-46pnx-4t2m3-wqrly-q5qg5-lzr6p-75c77-celqe-rbtan-oclkg-5ae",
@@ -13106,7 +13106,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "n6zwz-reuil-fdhjj-bvsph-rsnvl-ru3jg-2ywjx-bxt4w-j3jkz-vlheq-wqe": {
           "node_id": "n6zwz-reuil-fdhjj-bvsph-rsnvl-ru3jg-2ywjx-bxt4w-j3jkz-vlheq-wqe",
@@ -13126,7 +13126,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "oijdr-tw52e-rxqz3-jqz3p-svaqt-xkl36-uwesu-rlfgq-b6ztg-7r7no-kqe": {
           "node_id": "oijdr-tw52e-rxqz3-jqz3p-svaqt-xkl36-uwesu-rlfgq-b6ztg-7r7no-kqe",
@@ -13152,7 +13152,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "q6i2a-r2jyo-qvchx-fx2eg-5vz74-tb674-au7zd-cy24h-wvywl-zbyro-7ae": {
           "node_id": "q6i2a-r2jyo-qvchx-fx2eg-5vz74-tb674-au7zd-cy24h-wvywl-zbyro-7ae",
@@ -13172,7 +13172,7 @@
           "dc_id": "hk1",
           "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "qvskl-y3tsp-bnmtl-k4duq-vdcnn-zb4f2-vea23-x2vz2-jpv5d-jzwzx-eqe": {
           "node_id": "qvskl-y3tsp-bnmtl-k4duq-vdcnn-zb4f2-vea23-x2vz2-jpv5d-jzwzx-eqe",
@@ -13192,7 +13192,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "vmzrz-weexa-xlaci-rs37k-ld6pb-xe7x3-y7ryv-qvxkx-syybl-t7pcy-nqe": {
           "node_id": "vmzrz-weexa-xlaci-rs37k-ld6pb-xe7x3-y7ryv-qvxkx-syybl-t7pcy-nqe",
@@ -13212,7 +13212,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wvdeg-tfq6p-ahjbt-mdicu-hh3hr-243lv-hd5pw-xz2ym-xgaz6-bwmg6-mae": {
           "node_id": "wvdeg-tfq6p-ahjbt-mdicu-hh3hr-243lv-hd5pw-xz2ym-xgaz6-bwmg6-mae",
@@ -13232,7 +13232,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xiagf-4pdgj-efen3-ywuo5-jv2wz-fwc5y-bdzwj-epe6u-vxpa5-xc4nx-6qe": {
           "node_id": "xiagf-4pdgj-efen3-ywuo5-jv2wz-fwc5y-bdzwj-epe6u-vxpa5-xc4nx-6qe",
@@ -13252,7 +13252,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "zqwwk-hrvpl-isozp-ls5ab-wsej3-bvfry-gkebu-6542b-grakp-yxffy-4ae": {
           "node_id": "zqwwk-hrvpl-isozp-ls5ab-wsej3-bvfry-gkebu-6542b-grakp-yxffy-4ae",
@@ -13272,7 +13272,7 @@
           "dc_id": "br2",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -13333,7 +13333,7 @@
           "dc_id": "sh1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7s6kl-ygytv-rqall-6j2ub-hb6ig-bv3wl-gn5rr-ddnmx-okxap-z6ctq-iae": {
           "node_id": "7s6kl-ygytv-rqall-6j2ub-hb6ig-bv3wl-gn5rr-ddnmx-okxap-z6ctq-iae",
@@ -13359,7 +13359,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "d6thv-qf4lw-o3n7c-rfg5q-zupjh-25a2d-kaxkp-y5wr6-nzjly-w2bcy-pqe": {
           "node_id": "d6thv-qf4lw-o3n7c-rfg5q-zupjh-25a2d-kaxkp-y5wr6-nzjly-w2bcy-pqe",
@@ -13379,7 +13379,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "fe7vt-yjpwr-js7dn-62rht-w46qq-kbxls-ujd3f-bgotr-hjdzy-wu5kq-vae": {
           "node_id": "fe7vt-yjpwr-js7dn-62rht-w46qq-kbxls-ujd3f-bgotr-hjdzy-wu5kq-vae",
@@ -13399,7 +13399,7 @@
           "dc_id": "ph1",
           "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ihb24-7542u-a5hwt-le3wd-ion4f-wbduk-yawte-kaxrd-bv5kf-7jyld-bqe": {
           "node_id": "ihb24-7542u-a5hwt-le3wd-ion4f-wbduk-yawte-kaxrd-bv5kf-7jyld-bqe",
@@ -13419,7 +13419,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jk3km-afmc3-lk6bk-ej7aw-4e2md-56ywu-uvolh-trr2p-vs3wf-f6fo4-vae": {
           "node_id": "jk3km-afmc3-lk6bk-ej7aw-4e2md-56ywu-uvolh-trr2p-vs3wf-f6fo4-vae",
@@ -13445,7 +13445,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "lkq7d-2ephj-zfh25-lgc7c-jvene-3k2cu-a7z36-46fz2-ngrl2-vojne-gae": {
           "node_id": "lkq7d-2ephj-zfh25-lgc7c-jvene-3k2cu-a7z36-46fz2-ngrl2-vojne-gae",
@@ -13471,7 +13471,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "tmevu-x7kon-mdgqs-552gs-e3gwf-wdeqd-egoxr-wn3av-v3vy7-ul7ca-tae": {
           "node_id": "tmevu-x7kon-mdgqs-552gs-e3gwf-wdeqd-egoxr-wn3av-v3vy7-ul7ca-tae",
@@ -13491,7 +13491,7 @@
           "dc_id": "pl2",
           "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "udlch-g42nv-er23m-bgpxk-oiymd-knkro-2dczg-hyv4x-2yiw6-q2jcz-hqe": {
           "node_id": "udlch-g42nv-er23m-bgpxk-oiymd-knkro-2dczg-hyv4x-2yiw6-q2jcz-hqe",
@@ -13511,7 +13511,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "vivoi-pgaro-d7j64-broi5-wf4ig-3n2jq-sp366-rgh56-yx6do-gcx3w-mqe": {
           "node_id": "vivoi-pgaro-d7j64-broi5-wf4ig-3n2jq-sp366-rgh56-yx6do-gcx3w-mqe",
@@ -13531,7 +13531,7 @@
           "dc_id": "rg1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "xoefx-zvgdp-ccp4e-3fri6-6r3dp-agydz-fcph4-xu4bz-n5wku-g7jk3-2qe": {
           "node_id": "xoefx-zvgdp-ccp4e-3fri6-6r3dp-agydz-fcph4-xu4bz-n5wku-g7jk3-2qe",
@@ -13551,7 +13551,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xu6mr-rd7cf-pq6uo-xf4bm-ivd5c-hpnp7-dpjhc-kkwnu-xeaqu-eue5r-sae": {
           "node_id": "xu6mr-rd7cf-pq6uo-xf4bm-ivd5c-hpnp7-dpjhc-kkwnu-xeaqu-eue5r-sae",
@@ -13571,7 +13571,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yim23-u5r3y-yffo3-3hrab-vtvok-nw2qw-uzzbf-mvepc-fvnso-hjar4-6ae": {
           "node_id": "yim23-u5r3y-yffo3-3hrab-vtvok-nw2qw-uzzbf-mvepc-fvnso-hjar4-6ae",
@@ -13591,7 +13591,7 @@
           "dc_id": "mtl1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -13675,7 +13675,7 @@
           "dc_id": "pc1",
           "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "3krwb-x4ghq-uue6j-bttho-5svt5-4ugk3-vckyr-u23kr-75sjg-275bu-5qe": {
           "node_id": "3krwb-x4ghq-uue6j-bttho-5svt5-4ugk3-vckyr-u23kr-75sjg-275bu-5qe",
@@ -13695,7 +13695,7 @@
           "dc_id": "ch3",
           "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "5irn3-rlxhd-lp3cf-caeka-xu2ph-54ceg-afnwr-atwlj-a33ip-odxsy-iae": {
           "node_id": "5irn3-rlxhd-lp3cf-caeka-xu2ph-54ceg-afnwr-atwlj-a33ip-odxsy-iae",
@@ -13715,7 +13715,7 @@
           "dc_id": "pa2",
           "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5osj4-6yxs6-czubw-7e547-kbpd5-j2na3-37ciw-xhu7l-pqefv-orvkk-bae": {
           "node_id": "5osj4-6yxs6-czubw-7e547-kbpd5-j2na3-37ciw-xhu7l-pqefv-orvkk-bae",
@@ -13735,7 +13735,7 @@
           "dc_id": "jb3",
           "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "5resh-f6n7z-xxkbq-7lpod-spptk-nyt7n-tcvf6-f5ecb-ixxwc-6k5ai-rqe": {
           "node_id": "5resh-f6n7z-xxkbq-7lpod-spptk-nyt7n-tcvf6-f5ecb-ixxwc-6k5ai-rqe",
@@ -13755,7 +13755,7 @@
           "dc_id": "ar1",
           "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "7pch3-7nre2-7su6p-ouf2h-zrpqi-oc4vw-3j2ce-swypv-xiu4y-qj6b2-7qe": {
           "node_id": "7pch3-7nre2-7su6p-ouf2h-zrpqi-oc4vw-3j2ce-swypv-xiu4y-qj6b2-7qe",
@@ -13775,7 +13775,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "7pvxh-37ula-relu7-uim72-jvx46-dcnvm-52zsf-vkqzm-xsjoy-4xf4l-hqe": {
           "node_id": "7pvxh-37ula-relu7-uim72-jvx46-dcnvm-52zsf-vkqzm-xsjoy-4xf4l-hqe",
@@ -13795,7 +13795,7 @@
           "dc_id": "bg1",
           "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "bv2x3-p2b3h-b23rg-aoq3s-kdzo2-pipmf-5y2me-jfa4w-tb7vr-qistz-2ae": {
           "node_id": "bv2x3-p2b3h-b23rg-aoq3s-kdzo2-pipmf-5y2me-jfa4w-tb7vr-qistz-2ae",
@@ -13815,7 +13815,7 @@
           "dc_id": "cm1",
           "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "catzb-pqs4z-h25rr-jwdtx-hutzu-qqw4j-kkqux-w53ey-mg56o-tb4ay-fae": {
           "node_id": "catzb-pqs4z-h25rr-jwdtx-hutzu-qqw4j-kkqux-w53ey-mg56o-tb4ay-fae",
@@ -13835,7 +13835,7 @@
           "dc_id": "wa3",
           "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "cq5nh-ez2pp-dwce6-o5olk-bckwf-vxyhb-ahine-jsczg-6g5ri-uj3kx-fqe": {
           "node_id": "cq5nh-ez2pp-dwce6-o5olk-bckwf-vxyhb-ahine-jsczg-6g5ri-uj3kx-fqe",
@@ -13855,7 +13855,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ct3c3-aaohu-xben4-mbsjf-evtcb-bvf4i-qax6r-i4lm2-tcn6j-ybqpz-wae": {
           "node_id": "ct3c3-aaohu-xben4-mbsjf-evtcb-bvf4i-qax6r-i4lm2-tcn6j-ybqpz-wae",
@@ -13875,7 +13875,7 @@
           "dc_id": "dr1",
           "node_provider_id": "trxbq-wy5xi-3y27q-bkpaf-mhi2m-puexs-yatgt-nhwiy-dh6jy-rolw5-zqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "dnt7y-wwa7a-6kdko-zjtn6-nkahd-cfcn4-yw5ai-pc6jg-6g46r-qq6jr-uae": {
           "node_id": "dnt7y-wwa7a-6kdko-zjtn6-nkahd-cfcn4-yw5ai-pc6jg-6g46r-qq6jr-uae",
@@ -13895,7 +13895,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "efnid-smcmg-3orkr-3csy7-yo6jp-4vejo-zo2xa-zobrf-qkez7-5y3ui-3ae": {
           "node_id": "efnid-smcmg-3orkr-3csy7-yo6jp-4vejo-zo2xa-zobrf-qkez7-5y3ui-3ae",
@@ -13915,7 +13915,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "f7hyn-ga437-hpalr-zqueh-4v4fr-zvt7s-galuf-fspe5-fnd6w-rao5b-gae": {
           "node_id": "f7hyn-ga437-hpalr-zqueh-4v4fr-zvt7s-galuf-fspe5-fnd6w-rao5b-gae",
@@ -13935,7 +13935,7 @@
           "dc_id": "mtl1",
           "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "hrhn3-gzwom-ni6br-ywxaj-55bk3-gkh2d-ckb5s-4max7-xpnep-7kafw-eae": {
           "node_id": "hrhn3-gzwom-ni6br-ywxaj-55bk3-gkh2d-ckb5s-4max7-xpnep-7kafw-eae",
@@ -13955,7 +13955,7 @@
           "dc_id": "mn2",
           "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "i5xgw-uzqkn-xrfkd-7nqdz-3yvas-lujhr-mvs5w-sxv5u-m7zrn-hrd2k-pqe": {
           "node_id": "i5xgw-uzqkn-xrfkd-7nqdz-3yvas-lujhr-mvs5w-sxv5u-m7zrn-hrd2k-pqe",
@@ -13975,7 +13975,7 @@
           "dc_id": "sg2",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "innof-igqna-w2xyu-nzbwo-3ilyf-yxldi-lk426-e2eta-w5iio-lfg5y-gqe": {
           "node_id": "innof-igqna-w2xyu-nzbwo-3ilyf-yxldi-lk426-e2eta-w5iio-lfg5y-gqe",
@@ -13995,7 +13995,7 @@
           "dc_id": "im1",
           "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "izmdg-yz3l4-jp5vr-rva2j-5btpc-bzgt5-7snt4-wwy2g-jaq7v-rzpsv-oae": {
           "node_id": "izmdg-yz3l4-jp5vr-rva2j-5btpc-bzgt5-7snt4-wwy2g-jaq7v-rzpsv-oae",
@@ -14015,7 +14015,7 @@
           "dc_id": "bn1",
           "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "j3pcf-ielts-wwr24-73hhq-flvsq-d7yh3-ly5li-r6csx-5tczk-wkpc3-5ae": {
           "node_id": "j3pcf-ielts-wwr24-73hhq-flvsq-d7yh3-ly5li-r6csx-5tczk-wkpc3-5ae",
@@ -14041,7 +14041,7 @@
           "dc_id": "ns1",
           "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "m6pbx-6q64u-443wl-43j3t-tysy5-bb3f2-dtotm-hd6zq-qbemu-dizp5-zae": {
           "node_id": "m6pbx-6q64u-443wl-43j3t-tysy5-bb3f2-dtotm-hd6zq-qbemu-dizp5-zae",
@@ -14061,7 +14061,7 @@
           "dc_id": "bc1",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "noil6-vtxju-xxtvs-y4jbv-ke7k7-erdq3-rad3q-iubb7-e5gfq-dizbp-fqe": {
           "node_id": "noil6-vtxju-xxtvs-y4jbv-ke7k7-erdq3-rad3q-iubb7-e5gfq-dizbp-fqe",
@@ -14081,7 +14081,7 @@
           "dc_id": "an1",
           "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "nxeqo-y6jk3-5zpcu-waryv-lz3ha-c2iuu-jljee-yzew7-jo5dk-6dgr7-3qe": {
           "node_id": "nxeqo-y6jk3-5zpcu-waryv-lz3ha-c2iuu-jljee-yzew7-jo5dk-6dgr7-3qe",
@@ -14101,7 +14101,7 @@
           "dc_id": "ct1",
           "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "oh5wh-qqgpq-brv22-hsr24-jsgng-iiuew-gs34v-tgavl-e5wgu-vzany-fqe": {
           "node_id": "oh5wh-qqgpq-brv22-hsr24-jsgng-iiuew-gs34v-tgavl-e5wgu-vzany-fqe",
@@ -14121,7 +14121,7 @@
           "dc_id": "lv1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "pbva7-4kbrk-oyagu-q2y77-izb74-bqzmb-xrpil-nfjxu-qzzpk-zgzid-bqe": {
           "node_id": "pbva7-4kbrk-oyagu-q2y77-izb74-bqzmb-xrpil-nfjxu-qzzpk-zgzid-bqe",
@@ -14141,7 +14141,7 @@
           "dc_id": "ma1",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "phgey-5cyzw-2ype7-y5q7w-yce6j-3yvg7-tlkfe-quvvy-pqpt4-252od-fqe": {
           "node_id": "phgey-5cyzw-2ype7-y5q7w-yce6j-3yvg7-tlkfe-quvvy-pqpt4-252od-fqe",
@@ -14161,7 +14161,7 @@
           "dc_id": "hk1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "pm6hc-2ghis-xwera-jdcuf-xo6mv-ura5k-aurmb-xzoip-lx6nn-2rtew-aae": {
           "node_id": "pm6hc-2ghis-xwera-jdcuf-xo6mv-ura5k-aurmb-xzoip-lx6nn-2rtew-aae",
@@ -14181,7 +14181,7 @@
           "dc_id": "lj2",
           "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "qnn43-fomt4-663kx-fqetc-54jan-ccsww-j54nw-quf3n-vudjb-qsfg3-pae": {
           "node_id": "qnn43-fomt4-663kx-fqetc-54jan-ccsww-j54nw-quf3n-vudjb-qsfg3-pae",
@@ -14201,7 +14201,7 @@
           "dc_id": "ty1",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "u3ahx-ft3kq-pzlkr-imzus-aeqxm-cirqv-ymehh-xzctz-os4ud-3a74m-vae": {
           "node_id": "u3ahx-ft3kq-pzlkr-imzus-aeqxm-cirqv-ymehh-xzctz-os4ud-3a74m-vae",
@@ -14221,7 +14221,7 @@
           "dc_id": "li1",
           "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "vcl5k-pctnh-iqitr-mg7h4-a3bb3-j5cpy-w6yvz-ak5tb-q4dgq-z5lgw-4ae": {
           "node_id": "vcl5k-pctnh-iqitr-mg7h4-a3bb3-j5cpy-w6yvz-ak5tb-q4dgq-z5lgw-4ae",
@@ -14241,7 +14241,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "wwwxf-wrvqf-3l3mr-iryoj-gvsjj-yex74-mhput-ag4mv-yftkg-xny2a-gqe": {
           "node_id": "wwwxf-wrvqf-3l3mr-iryoj-gvsjj-yex74-mhput-ag4mv-yftkg-xny2a-gqe",
@@ -14261,7 +14261,7 @@
           "dc_id": "ge2",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "xnraq-n62so-zdfy3-63wd4-dbf55-m2h66-xcpbu-laatr-52ytd-5gdv3-wae": {
           "node_id": "xnraq-n62so-zdfy3-63wd4-dbf55-m2h66-xcpbu-laatr-52ytd-5gdv3-wae",
@@ -14281,7 +14281,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "y7vmg-unfmv-u6gdl-piob6-7en2w-zmwjb-oqbpn-ufqkm-4i2cr-osl3d-iae": {
           "node_id": "y7vmg-unfmv-u6gdl-piob6-7en2w-zmwjb-oqbpn-ufqkm-4i2cr-osl3d-iae",
@@ -14301,7 +14301,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yyjdt-kk2xx-ddp26-4rioj-spbg2-pvh5w-omag3-odlzq-nscru-4k4vq-oae": {
           "node_id": "yyjdt-kk2xx-ddp26-4rioj-spbg2-pvh5w-omag3-odlzq-nscru-4k4vq-oae",
@@ -14321,7 +14321,7 @@
           "dc_id": "ta1",
           "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "zk7wk-ueuvm-5quvh-lm6kq-etjru-i63xr-u2xmc-srfx6-uzqq4-jx5j2-nae": {
           "node_id": "zk7wk-ueuvm-5quvh-lm6kq-etjru-i63xr-u2xmc-srfx6-uzqq4-jx5j2-nae",
@@ -14341,7 +14341,7 @@
           "dc_id": "bt1",
           "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         }
       },
       "max_ingress_bytes_per_message": 3670016,
@@ -14408,7 +14408,7 @@
           "dc_id": "sg3",
           "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "3s6fj-wulzc-ml7vo-vpvhj-4loap-25asb-m6efr-f52qf-ehpxb-7mh3k-vae": {
           "node_id": "3s6fj-wulzc-ml7vo-vpvhj-4loap-25asb-m6efr-f52qf-ehpxb-7mh3k-vae",
@@ -14428,7 +14428,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "4jv6f-e5bq5-dwr5u-pptpu-5lh32-4zcfq-ujlq6-ckdbm-zwonj-yyxci-rqe": {
           "node_id": "4jv6f-e5bq5-dwr5u-pptpu-5lh32-4zcfq-ujlq6-ckdbm-zwonj-yyxci-rqe",
@@ -14448,7 +14448,7 @@
           "dc_id": "se1",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6bbgn-jvexd-25pja-q5wgj-spyfw-lfm3g-pjf2t-x3zmf-7llwq-p63wm-rqe": {
           "node_id": "6bbgn-jvexd-25pja-q5wgj-spyfw-lfm3g-pjf2t-x3zmf-7llwq-p63wm-rqe",
@@ -14468,7 +14468,7 @@
           "dc_id": "lv1",
           "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "7fiyj-xjxkj-fjvbl-tl4rp-6xvg3-moow7-dwtyi-nsxeg-unw7n-ivshf-pqe": {
           "node_id": "7fiyj-xjxkj-fjvbl-tl4rp-6xvg3-moow7-dwtyi-nsxeg-unw7n-ivshf-pqe",
@@ -14494,7 +14494,7 @@
           "dc_id": "ct2",
           "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "cgm5b-6rf6e-ut46u-bidiy-ik7tp-w6q5a-l3oo3-qplkv-q5ced-mev5s-wae": {
           "node_id": "cgm5b-6rf6e-ut46u-bidiy-ik7tp-w6q5a-l3oo3-qplkv-q5ced-mev5s-wae",
@@ -14514,7 +14514,7 @@
           "dc_id": "ty3",
           "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "cp7d4-uiulo-a46se-yzti4-6qpmz-4rhug-d6rln-7aa5r-nc63x-6q7u7-aae": {
           "node_id": "cp7d4-uiulo-a46se-yzti4-6qpmz-4rhug-d6rln-7aa5r-nc63x-6q7u7-aae",
@@ -14534,7 +14534,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "f4xs2-aejji-yt4ks-7sjyb-g7zxl-ayuc3-lw6tv-khrii-nlh7j-ttbqy-zae": {
           "node_id": "f4xs2-aejji-yt4ks-7sjyb-g7zxl-ayuc3-lw6tv-khrii-nlh7j-ttbqy-zae",
@@ -14554,7 +14554,7 @@
           "dc_id": "gn1",
           "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "g2yrq-l6heq-ztxzm-fd6aa-piqxh-wno3t-q3bhj-5qvd5-vukzm-z4bjx-kae": {
           "node_id": "g2yrq-l6heq-ztxzm-fd6aa-piqxh-wno3t-q3bhj-5qvd5-vukzm-z4bjx-kae",
@@ -14580,7 +14580,7 @@
           "dc_id": "ge1",
           "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "qpt6h-7m7xq-4crv7-pml2g-2jsxx-vxgv4-eka6d-hq4xj-73u5v-bsaki-zae": {
           "node_id": "qpt6h-7m7xq-4crv7-pml2g-2jsxx-vxgv4-eka6d-hq4xj-73u5v-bsaki-zae",
@@ -14600,7 +14600,7 @@
           "dc_id": "cm1",
           "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "xatzx-j3mph-3xzxk-jz53j-afa3d-qxnac-fbejn-hvgpy-cmhlb-dkuhv-nqe": {
           "node_id": "xatzx-j3mph-3xzxk-jz53j-afa3d-qxnac-fbejn-hvgpy-cmhlb-dkuhv-nqe",
@@ -14620,7 +14620,7 @@
           "dc_id": "sl1",
           "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
           "status": "Healthy",
-          "node_type": "unknown:multiple_rewardable_nodes"
+          "node_reward_type": "unknown:multiple_rewardable_nodes"
         },
         "xbeha-2lqtl-qb5tx-t2zgf-y3t22-iuqkv-fhemo-dnpr5-wwlxl-auyrq-jae": {
           "node_id": "xbeha-2lqtl-qb5tx-t2zgf-y3t22-iuqkv-fhemo-dnpr5-wwlxl-auyrq-jae",
@@ -14640,7 +14640,7 @@
           "dc_id": "im2",
           "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "yzwxm-j2n2r-whdxh-xqftn-lobyp-h5c5c-zomu3-uqc7k-gatex-aoayd-pae": {
           "node_id": "yzwxm-j2n2r-whdxh-xqftn-lobyp-h5c5c-zomu3-uqc7k-gatex-aoayd-pae",
@@ -14660,7 +14660,7 @@
           "dc_id": "zh6",
           "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -14721,7 +14721,7 @@
           "dc_id": "nm1",
           "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         },
         "2sjsi-fu2xz-jbtds-6rhym-cdfxi-dseok-64txt-exaul-e4usk-ouhx7-xqe": {
           "node_id": "2sjsi-fu2xz-jbtds-6rhym-cdfxi-dseok-64txt-exaul-e4usk-ouhx7-xqe",
@@ -14741,7 +14741,7 @@
           "dc_id": "to2",
           "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "6pt6z-rdv25-glenj-xvuq3-zdeeu-4c74r-smqeh-tgt34-exgd6-2wxvv-eqe": {
           "node_id": "6pt6z-rdv25-glenj-xvuq3-zdeeu-4c74r-smqeh-tgt34-exgd6-2wxvv-eqe",
@@ -14761,7 +14761,7 @@
           "dc_id": "hu1",
           "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "d46vh-m3zki-yvo54-bbb2b-rejve-nhgiy-6cb5m-amog7-25mpn-dnua4-7ae": {
           "node_id": "d46vh-m3zki-yvo54-bbb2b-rejve-nhgiy-6cb5m-amog7-25mpn-dnua4-7ae",
@@ -14781,7 +14781,7 @@
           "dc_id": "kr1",
           "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "fxdqu-epq5z-kmnok-ch46f-jxujv-of7ws-3ec4b-gszap-gtklj-sxfiv-wae": {
           "node_id": "fxdqu-epq5z-kmnok-ch46f-jxujv-of7ws-3ec4b-gszap-gtklj-sxfiv-wae",
@@ -14801,7 +14801,7 @@
           "dc_id": "br1",
           "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "jthcr-uruul-ytxuj-qbvv2-byyz2-tyyo4-yy4ku-2fu4d-aufm7-d5k6l-7ae": {
           "node_id": "jthcr-uruul-ytxuj-qbvv2-byyz2-tyyo4-yy4ku-2fu4d-aufm7-d5k6l-7ae",
@@ -14821,7 +14821,7 @@
           "dc_id": "mb1",
           "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "k6zrw-n3gr2-3wb3v-ejowh-5tw2u-kqbr6-ucttf-hayoz-ebxvi-3wiib-bqe": {
           "node_id": "k6zrw-n3gr2-3wb3v-ejowh-5tw2u-kqbr6-ucttf-hayoz-ebxvi-3wiib-bqe",
@@ -14841,7 +14841,7 @@
           "dc_id": "sg1",
           "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kvj4i-xw67n-f673e-7unem-npgcc-ag7ya-f46sk-g7qq6-ep6l4-brrkt-tqe": {
           "node_id": "kvj4i-xw67n-f673e-7unem-npgcc-ag7ya-f46sk-g7qq6-ep6l4-brrkt-tqe",
@@ -14861,7 +14861,7 @@
           "dc_id": "fr2",
           "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "kxmey-hzsm7-7lfch-yfrbq-ereis-e2t7b-ztii4-7ib5t-fljrs-kjkey-kqe": {
           "node_id": "kxmey-hzsm7-7lfch-yfrbq-ereis-e2t7b-ztii4-7ib5t-fljrs-kjkey-kqe",
@@ -14881,7 +14881,7 @@
           "dc_id": "bu1",
           "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe": {
           "node_id": "mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe",
@@ -14901,7 +14901,7 @@
           "dc_id": "wa2",
           "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "r5zha-ytiej-livta-dgmfr-j6kma-rdl4t-hldjg-hbydh-ogyjt-fow5r-4qe": {
           "node_id": "r5zha-ytiej-livta-dgmfr-j6kma-rdl4t-hldjg-hbydh-ogyjt-fow5r-4qe",
@@ -14921,7 +14921,7 @@
           "dc_id": "tb1",
           "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
           "status": "Healthy",
-          "node_type": "type3.1"
+          "node_reward_type": "type3.1"
         },
         "rp2ka-fxcyf-ghmgv-rgi3q-ugpxs-t2xfv-an2zj-yjzfk-kkpuu-pbha5-5qe": {
           "node_id": "rp2ka-fxcyf-ghmgv-rgi3q-ugpxs-t2xfv-an2zj-yjzfk-kkpuu-pbha5-5qe",
@@ -14941,7 +14941,7 @@
           "dc_id": "zh2",
           "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "status": "Healthy",
-          "node_type": "type1.1"
+          "node_reward_type": "type1.1"
         },
         "ulcre-xbhsb-in5ny-xqhwy-nolvb-xzw22-fcp65-jutld-c2pjz-y7ydr-gqe": {
           "node_id": "ulcre-xbhsb-in5ny-xqhwy-nolvb-xzw22-fcp65-jutld-c2pjz-y7ydr-gqe",
@@ -14961,7 +14961,7 @@
           "dc_id": "jb2",
           "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
           "status": "Healthy",
-          "node_type": "type3"
+          "node_reward_type": "type3"
         }
       },
       "max_ingress_bytes_per_message": 2097152,
@@ -15006,7 +15006,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "235hh-hmjhq-dejel-3q5oi-pdz66-dygbp-yi2sy-zmuiq-rj7r7-65hue-wae",
@@ -15026,7 +15026,7 @@
       "dc_id": "dr1",
       "node_provider_id": "trxbq-wy5xi-3y27q-bkpaf-mhi2m-puexs-yatgt-nhwiy-dh6jy-rolw5-zqe",
       "status": "Dead",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "23jbm-6z6mi-ki2ut-fkz5x-yy4uy-6llls-yyodh-xv537-2qonk-2iod3-jae",
@@ -15046,7 +15046,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "23kbh-5xqrz-2avco-tddeh-p6724-shtvz-rg3nq-d7rhu-ztedb-vki46-dqe",
@@ -15066,7 +15066,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "24fcm-3onfs-cykax-al4jb-gvdd3-u76zl-ht6ef-hcsbc-xwf54-xbrym-xae",
@@ -15086,7 +15086,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "24fsy-32ewt-f447o-7p5th-njgys-2qawz-gk5iw-k4qzj-7opkx-ofbm3-5qe",
@@ -15112,7 +15112,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "24iqu-pqcde-wwgok-6sndd-lfhaj-gyjhu-zg73l-sqvwi-xbevy-kcuqp-4ae",
@@ -15132,7 +15132,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "25a7h-yfxtk-5wcoz-p56pu-bzpsa-xkr4h-7mlkz-slh2e-iwrtk-kqeav-cae",
@@ -15152,7 +15152,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "25o6i-sdjsl-vjlfn-6duch-vskdu-26pf5-cwibg-zooqk-sdn2e-cgugm-tae",
@@ -15172,7 +15172,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2a7fq-jivc5-upcob-l5e6k-v3l6a-xo4fc-5rfga-7t5ng-cnv72-t6z7d-wqe",
@@ -15192,7 +15192,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2aked-uorat-s6ubw-kqnnf-lp3ep-ykinc-xcare-wws7l-pzhim-ixk7p-zae",
@@ -15212,7 +15212,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2bicw-jtnmv-rjuil-2p4px-npmif-w37em-qreuq-4lxof-7wkcl-a3gan-oqe",
@@ -15232,7 +15232,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2c4nq-s43ex-jhm42-4tczp-mugkx-n57at-a7skw-ruhmb-qfj3j-g7vfi-yqe",
@@ -15252,7 +15252,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2dzst-xscbm-fudmf-67coh-wopas-z46qm-2awcg-d2xjh-xxlnz-ru3pg-rqe",
@@ -15272,7 +15272,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2eqbk-www2z-qcopx-wujey-4frhx-cpstt-4ecyv-7wh64-qozmi-wwkpe-yqe",
@@ -15292,7 +15292,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2ew2x-bmzxs-o6sw6-xbxv6-efhzc-47y5k-vy5ce-luaqo-lecdi-33z4i-gqe",
@@ -15312,7 +15312,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2ftux-ivgjc-t4i2d-lq5hs-myjdg-3h2pz-l2ddl-nsxfc-wlaq7-fkbc5-6ae",
@@ -15332,7 +15332,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "2grd6-wl4h5-ckvc2-agagg-kn5it-axvmv-4nogx-frgyx-5ulsj-kuoyo-lae",
@@ -15352,7 +15352,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2h6dm-k5h3n-nmqek-m5gty-yy3xq-a3atf-54its-biy25-ijh3c-xvit4-mae",
@@ -15372,7 +15372,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2h77x-ywmcq-vxt3r-t2ml4-43px2-wdn6u-kqus7-hmdzo-eu4qm-4afbe-pqe",
@@ -15392,7 +15392,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "2htd7-tusvn-5az76-uabki-trilh-egfi4-5t2tv-z4j7e-bcgbj-dkxru-sae",
@@ -15412,7 +15412,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2k7jv-zmube-yklqn-i3z46-mdvk6-xshpb-gb5jz-kkg7z-vlqh4-xmqyw-hae",
@@ -15432,7 +15432,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2katp-edgoa-qnmux-ynruc-wwgub-y5von-zavsw-nvzfs-dwj4i-t7jil-fqe",
@@ -15452,7 +15452,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2klnm-d2wrs-tnn3k-mphtu-fgdmq-e2bny-juyda-ww7hv-l6pzx-35tkm-kae",
@@ -15472,7 +15472,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "2kvun-y7qfw-krhhm-aftvi-ll56o-yvkuj-noc5w-xozic-mnewn-i47x5-tqe",
@@ -15492,7 +15492,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2lhun-vmepu-zc7ic-6lrjj-o4yda-nlmwn-m4i2i-h4oby-hwv4y-mpv7c-fae",
@@ -15512,7 +15512,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2mjgp-xtlo2-elgwk-onn5k-7uhh7-erq34-vr24g-imzfx-pr72w-mewn6-aqe",
@@ -15532,7 +15532,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2mmpk-6kvr3-3syvq-twao3-g3fxc-gz3n2-o3tgf-34irb-idruv-cogfq-sqe",
@@ -15552,7 +15552,7 @@
       "dc_id": "ma3",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2n6eu-vv67p-bvuwq-eqfwb-r6jdi-wp3fo-jcodd-a7jtx-frju7-3sh3j-zqe",
@@ -15572,7 +15572,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2ndxm-inbpv-tmvib-5y2qk-lc2je-b3gbw-2u4nn-x57bs-tu3kx-m47t6-5qe",
@@ -15592,7 +15592,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2nehn-z42p7-36s7j-qqcz6-sy5rb-euhte-necpl-egqsv-hdoph-gx7qd-6ae",
@@ -15618,7 +15618,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2p4i3-ukstx-utpts-btuau-lidyg-c76us-nfcvp-a32u2-k5jtx-cz7i4-bae",
@@ -15638,7 +15638,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2qclu-jxgmm-cjrng-h2wwe-i6ku5-dmj6p-e5qzy-ktplm-yu6kw-zkao2-xae",
@@ -15658,7 +15658,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2qlts-dmxtt-ly45j-m2qcg-tde6r-i337l-shimz-mtshu-tp3ir-hkbyt-dae",
@@ -15678,7 +15678,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "2r7p2-nll7a-gipvg-6wtpt-pgss2-lge3d-gylsc-bvo3n-7u4am-xeom5-nqe",
@@ -15698,7 +15698,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2ric4-rm3mb-x4rc4-xv7f3-o3fq6-oryc6-oyn4x-cpiyz-woh7c-eyorf-qae",
@@ -15718,7 +15718,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2sjsi-fu2xz-jbtds-6rhym-cdfxi-dseok-64txt-exaul-e4usk-ouhx7-xqe",
@@ -15738,7 +15738,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2w5be-ukk5g-kmecu-jxtan-w2gsb-htdfz-z5czd-6yacq-cemqu-qhjpm-iqe",
@@ -15758,7 +15758,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2x3w4-erxz5-cf3jb-za33k-oo33d-zmpir-btrb5-h34vy-ooduw-un6ws-vqe",
@@ -15778,7 +15778,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "2xph2-xvn4v-pc5xz-3upfj-etpio-qaf2k-d2s3v-jnceu-vcher-qhqav-rqe",
@@ -15798,7 +15798,7 @@
       "dc_id": "pc1",
       "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "2xqqr-g3ltb-muk6e-5mmjr-bmxvo-3vuab-n7n2z-fecrs-burep-2bhu4-oqe",
@@ -15824,7 +15824,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "2yjqo-sw2lo-4tqkt-6znj3-42w5f-iixil-q5b6b-shnbo-fnmvr-gvgwd-dqe",
@@ -15844,7 +15844,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "2yzcy-lywoi-fpfpg-ghagw-3emh7-2lj3p-ritfh-6e542-poww3-rafkw-wae",
@@ -15864,7 +15864,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "32yxi-hqan7-bhpqw-ypgjn-zq64m-6uqxs-htba2-sldaq-dkm7c-af3o5-vae",
@@ -15884,7 +15884,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "33s7q-wsjbb-6iyyw-bwfuz-lq2yr-lu7gt-qhc7s-oyxrq-vhfnm-wbaxb-dqe",
@@ -15910,7 +15910,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "34vxs-3ebd4-x454e-jacqp-5rxv3-lfna4-xtoua-vzulm-lwh77-zu5fq-lqe",
@@ -15936,7 +15936,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "35ddr-mltrg-nxmdq-34ttq-ic4ra-ygatb-vwo2p-7bz2e-lgkex-5djch-3qe",
@@ -15956,7 +15956,7 @@
       "dc_id": "ta2",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "364us-2y667-wg3qr-zordv-pqlou-bra44-gjhhv-2jtnc-mr6xr-kmenh-4qe",
@@ -15976,7 +15976,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3655m-si4pt-xysac-y2fwl-htr7g-yhynz-zaey6-xzglx-yqnso-vutgb-lqe",
@@ -15996,7 +15996,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "36vim-qv27i-6j52j-aaezj-s4lgp-ex65o-3j2ho-rdvl6-odnhe-32k7e-jae",
@@ -16016,7 +16016,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "37qlx-cydv7-gafnm-i3rdp-l5acg-hwqnu-iyirl-ypjg7-naeqh-vjxme-hqe",
@@ -16036,7 +16036,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3b2lt-4in5i-knoux-f6nkg-tgfpa-ifejj-xkw5s-qtqam-3sqxi-bhpqc-6ae",
@@ -16056,7 +16056,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3bcpj-2mjor-ykckj-5m2ya-i4zn3-rdtfi-vofgu-elihb-53mje-fpywx-dae",
@@ -16076,7 +16076,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3beeq-bvtv4-mxeff-2ypcm-jnw74-envji-bflpz-sipbb-e6gnt-kfptx-5qe",
@@ -16096,7 +16096,7 @@
       "dc_id": "rg3",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3c6dj-5mjuu-imudt-5z457-prrqe-f5m7r-axjky-ocoix-kf6de-xgi6u-2ae",
@@ -16116,7 +16116,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3d7ai-2u6yp-lstfm-jbb3l-74tuq-ylbdi-wrrrd-ctpwc-rrch4-j6zxb-rae",
@@ -16136,7 +16136,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3fgii-zd73c-ftxy2-ypsbx-hnqf2-nzhc6-veurh-bru27-mz6bg-j62qd-xqe",
@@ -16156,7 +16156,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3fmsy-wcbr4-5s5gp-pe2n3-qg2d4-gemyh-52qrr-m7e3e-a3i4l-xay4v-qqe",
@@ -16176,7 +16176,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "3h65u-r2zrh-ydt5b-sura7-p3tdl-d2xcx-4kvwe-x464t-cug7r-uzlvr-vae",
@@ -16196,7 +16196,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "3hibk-2fnod-r7pab-hb3im-blyqv-lyvdx-v273s-psxjn-yfsue-iakax-yae",
@@ -16216,7 +16216,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3hmzi-i26ng-ckcmj-lev6h-ssbbl-3qsft-p6kyo-3e5rz-2qfsj-nsbjk-kae",
@@ -16236,7 +16236,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3iqf7-6febz-vfgsb-z6ryj-c2vwi-n54ss-5zmjo-52ldz-z5are-aabr3-fqe",
@@ -16256,7 +16256,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3j5ux-jgus3-zeips-xzbai-u2jsc-yyc6o-oz2af-jri53-juerg-2exz5-fqe",
@@ -16276,7 +16276,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3jfof-q5mok-apuqv-du4j7-jqe6i-iga26-zim7o-fcmxg-la35o-5hnqj-tqe",
@@ -16296,7 +16296,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3jol6-6a6dv-ysedb-5qlxc-baclw-ub23p-d324m-7sfus-bkbnk-jlh6b-jqe",
@@ -16322,7 +16322,7 @@
       "dc_id": "ld1",
       "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3k35b-gsfkj-bbcx5-35roy-ixma5-yn6ug-3btuq-6qdoj-zzt4v-vgpze-wqe",
@@ -16348,7 +16348,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3kg25-3ikga-ufves-caaly-5pbz6-4rwjo-r6twb-ptje6-bxb33-lacj4-qqe",
@@ -16368,7 +16368,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3krwb-x4ghq-uue6j-bttho-5svt5-4ugk3-vckyr-u23kr-75sjg-275bu-5qe",
@@ -16388,7 +16388,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3lgs3-hz4d6-jgdro-tdx6k-vzqp3-cuq65-lgrmm-j7bj3-u2cku-2bw5k-fae",
@@ -16408,7 +16408,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3o5rr-5acje-r4kun-h2deq-fbv6e-gyujh-222t2-b4ob6-rukpb-kmjn7-hae",
@@ -16428,7 +16428,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3ojqg-v6jhs-frq5l-a3l7k-7xvhc-kolvz-2e4to-pdf4l-xiuem-h72b3-bqe",
@@ -16448,7 +16448,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3pjo5-pzanu-lcywl-mybke-dymuw-qfx63-i5tss-4lotj-nfx4j-dniyi-7qe",
@@ -16468,7 +16468,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3ppfv-vqufk-yrg2j-nos4h-6fxos-iucst-jsf7h-be4fn-im63d-fnbir-jae",
@@ -16488,7 +16488,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3s3yn-g6jbs-ybsmx-aq7la-nueos-xxrci-zhxif-vj7gw-4dbos-kbbhu-oqe",
@@ -16508,7 +16508,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3s6fj-wulzc-ml7vo-vpvhj-4loap-25asb-m6efr-f52qf-ehpxb-7mh3k-vae",
@@ -16528,7 +16528,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3smci-63tqe-6q5xc-wpdmj-pnhan-own4t-6km2r-77mfh-c2h7d-xzunk-cqe",
@@ -16548,7 +16548,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3tbjz-erih4-dfm4f-ul544-mgyqe-eeesn-hhggl-ooq2x-czsh2-nuy6n-cae",
@@ -16568,7 +16568,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3wc5p-yqjw2-ul5u4-oitcf-6g67a-czta2-oimin-cr6au-vxxqz-bag3v-eqe",
@@ -16588,7 +16588,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "3y7fy-fd2oe-33qxg-wq7y6-zzplk-33jhm-n4glx-2c7ij-k24nn-jbsst-xae",
@@ -16608,7 +16608,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "3yok3-yvswm-l4ior-bjh62-fsi73-vfqp3-77wji-coglq-l2bjw-rxrph-uqe",
@@ -16628,7 +16628,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "3zfpk-du6xx-yg7j5-h7c5w-6rr7z-cmkbf-pfos7-lhu65-svdmj-co7nc-cae",
@@ -16648,7 +16648,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "42rj3-7tytn-gbyte-cyj5m-tkzta-pkezr-ijl6a-larzs-cjo2r-r3lhz-bqe",
@@ -16668,7 +16668,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "45huy-6h3k3-m7uao-7w4bu-dtcgx-4yxpc-s36gr-pq7k5-xesnw-vnjut-oae",
@@ -16688,7 +16688,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "45wdz-2btxk-y57lh-du4ko-fr2k7-agdmq-66szd-smfgo-elizx-b7cq4-6ae",
@@ -16708,7 +16708,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "467sz-tjcqd-k2nce-vrhe7-juh6s-2oohm-3ydhi-cms7g-lzo5o-7zyzs-aqe",
@@ -16728,7 +16728,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "46dgm-up32t-4urre-upnr3-p5o2g-kamxl-lm5wp-k3rhi-zo26u-bpiha-iae",
@@ -16748,7 +16748,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "46dt2-4xmck-pnwis-6tzhm-32mtr-ahcus-dwstw-j4t7c-mulgs-oaazo-vae",
@@ -16768,7 +16768,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4aarv-httc6-rtrjt-mbswg-nplqa-sbyuw-jiniq-vjz4l-yhb3p-af3hy-hae",
@@ -16788,7 +16788,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4c63m-yfsxg-sy4dc-qhhvt-nwkgn-ib5fj-3qewz-svezz-2og3i-tlxll-eae",
@@ -16808,7 +16808,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "4cldf-jb7ta-kvxlu-e6otc-fotnw-cgjot-vmo27-pt63w-btc7d-yo6dn-eae",
@@ -16828,7 +16828,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4e2ty-mcqal-loqca-j2d5b-qgou4-n6y6h-yojne-kvqlg-ld4jx-rjree-3qe",
@@ -16848,7 +16848,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4fssn-4vi43-2qufr-hlrfz-hfohd-jgrwc-7l7ok-uatwb-ukau7-lwmoz-tae",
@@ -16874,7 +16874,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4fxl5-7naq3-jw64y-qyetj-27kir-bi4r4-tdyyo-h64th-rqssm-u6ua6-2ae",
@@ -16894,7 +16894,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4g6xd-mzufa-jwlvm-7kwze-buu3o-btx3q-ugco5-wsow6-oimf3-re3kl-nqe",
@@ -16914,7 +16914,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4gvj7-o7ylc-hpbec-daxvh-wlmpi-3w3sg-nzhdw-e7r65-edxmw-x5gzq-tqe",
@@ -16934,7 +16934,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4i64c-7p2wc-yotet-r64av-qwt2b-hp3hm-v3wad-bp5md-aeotm-gsofp-jqe",
@@ -16954,7 +16954,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4ilsj-76cys-w3sdj-znt6m-vsv6q-ak5st-iawte-mr4o7-o5d6s-jhego-7qe",
@@ -16974,7 +16974,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "4itjx-vyshn-cw55d-zywto-yston-7b5i7-upxxx-b2hhp-eajpv-lvygs-dae",
@@ -16994,7 +16994,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "4jf5x-7jffe-qbtoz-czwrh-6ko6m-coxky-jdegu-dlhaj-jkv5x-zytf6-vqe",
@@ -17020,7 +17020,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "4jkq7-io75m-ox4jr-gb76l-zyoqy-gttw3-m2ttq-4d4md-637uk-ukltt-5qe",
@@ -17040,7 +17040,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4jv6f-e5bq5-dwr5u-pptpu-5lh32-4zcfq-ujlq6-ckdbm-zwonj-yyxci-rqe",
@@ -17060,7 +17060,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4jw4w-tfndm-owhae-xvmpp-cy6z4-6oyia-yi47r-3bmlb-ok557-hlfzc-rqe",
@@ -17080,7 +17080,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4kimr-mx6yo-ncuyf-temzj-lii2h-ex7ub-gvopk-iecxu-3kkt7-wogi3-hae",
@@ -17100,7 +17100,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4l2e6-g2ujv-ksiel-cfrww-zwyhq-26nbr-f2jik-xhxfp-2xkd3-hmx23-6ae",
@@ -17120,7 +17120,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4l7la-7zmuq-ois3n-leowc-2xvrh-3vozh-iutqe-ev2xx-nkgni-atitg-5qe",
@@ -17140,7 +17140,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4lg7u-gpcph-smmt7-3c3mu-qyw6i-qlcvp-l2xws-piw34-vjd6x-665bt-lqe",
@@ -17160,7 +17160,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4lqcl-tzzs3-jztya-ro7ak-ew5ue-l3tlc-5cxk3-4jt7m-z66st-ad5ld-aae",
@@ -17180,7 +17180,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4mdc3-dywcq-5uuj5-uv4z7-otsmu-pb4sq-iu3eo-4b7z2-5a7rl-xzpcm-gae",
@@ -17200,7 +17200,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "4mm7j-dmeng-7ib4h-yvt3c-g5ed6-i5yar-rrc6w-rp7tk-ej3by-gilvv-kae",
@@ -17220,7 +17220,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4nkoi-tdk2r-bfboy-5dokf-zc2tp-sokpx-hqfr5-6znc4-vqnxe-kr7ro-iqe",
@@ -17240,7 +17240,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "4nldz-xzkm4-2y6gi-nw2s4-wuz54-xonqo-alj57-tgeqb-hbeyf-epcgh-kqe",
@@ -17260,7 +17260,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4o6mo-mspvu-kvs6u-4gvmc-uqrs7-mr7jy-z2hts-u3qv5-5lvvq-ixgr4-mqe",
@@ -17280,7 +17280,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4p3lu-7sy3a-ph47t-wlvb6-naehi-oki2f-pkokv-hovam-s5iul-sxvwk-3ae",
@@ -17306,7 +17306,7 @@
       "dc_id": "nd1",
       "node_provider_id": "pa5mu-yxsey-b4yrk-bodka-dhjnm-a3nx4-w2grw-3b766-ddr6e-nupu4-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "4ql5c-ky7on-eceuo-hqkl7-lzxvo-mrjco-znpn5-hfs4b-kuel6-35hmg-qqe",
@@ -17326,7 +17326,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4rpiz-7w7bf-smfm5-u7j3c-we6q7-qehxb-5lqnq-tjqsh-f7xu4-ihpao-zqe",
@@ -17346,7 +17346,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4tm5f-kojws-d53sx-t26bm-lgpwi-zspap-bepp6-3jl7c-rxg3p-iwhh2-eqe",
@@ -17366,7 +17366,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "4txlq-o5ukt-if4pj-adxtx-jwp42-jch73-z5nfy-77gi5-4lll7-eou2p-rqe",
@@ -17386,7 +17386,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4vpak-qnqtn-vggke-um4f2-zkk2m-awc6p-bkhi5-cm22y-zhdiz-yx5rt-cqe",
@@ -17406,7 +17406,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4vwpn-budhw-o2kvm-axlue-sr5lt-vy3be-ammju-rw22w-w4qtn-sns52-3qe",
@@ -17426,7 +17426,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "4vzqk-sugue-telln-ixzna-ujcsw-6llis-gcsbd-lbadw-tstbd-a7el7-kqe",
@@ -17446,7 +17446,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4whgz-3ksfr-4rroh-dluex-fptua-mrxjo-uzmgg-lvuws-oe72b-aynhj-fae",
@@ -17466,7 +17466,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4wpbr-3jxbi-wlcvc-gfu2l-nzgtl-gi57y-moyhd-r4ukq-ggudv-a7f4o-rqe",
@@ -17486,7 +17486,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4xhpj-gsmak-akpfh-z7rro-63yfp-5ewvu-i4o6g-yyrix-yd7xj-cus4y-hqe",
@@ -17506,7 +17506,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "4y5k6-auywv-zpovi-teeu2-bqfdx-spyxc-b76oo-ug55w-o4vrq-6z2jt-tae",
@@ -17526,7 +17526,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "52ykw-kxabl-twia6-x24hj-4last-tmdmd-4v3tf-fwtkh-mrdat-3vcpn-dqe",
@@ -17552,7 +17552,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "53caz-qstwb-e4nak-dtune-7wtlc-4eyyr-xmnmw-2fghu-r6ili-z5qls-qqe",
@@ -17572,7 +17572,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "53n2t-tuarp-uwcbl-ep6ax-bf6vl-o2lnd-cyna5-43zse-sdsht-xunkb-4ae",
@@ -17592,7 +17592,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "53p5r-qqup5-e2z7n-eeg65-kzklr-ekrsa-6g3hc-vrmqu-wtows-6q2t7-6ae",
@@ -17612,7 +17612,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "545fc-ouac2-s7etx-5oiuv-2beh3-s3n7u-xxkvm-6abvp-c6aue-nypdg-2ae",
@@ -17632,7 +17632,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "54wam-7qnwl-a5rcq-juvci-d7eqd-txtey-mjwnn-wrs2q-uajzs-eyxic-oqe",
@@ -17652,7 +17652,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "55aa5-j6ipq-ypfns-k6qjr-zncgq-6q7xm-5oyri-mwswh-thrpu-jxo2i-hae",
@@ -17672,7 +17672,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "55nob-iffps-r2vwq-gjrc6-owksr-2j4mq-rwcup-qbcr2-iomah-7pych-rae",
@@ -17692,7 +17692,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "56ovz-lrvyd-gggsl-qtenl-uuokx-p7t3t-rg6mc-6lc5l-usfqb-fygiv-aqe",
@@ -17718,7 +17718,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5aaq4-rdwmq-au7kc-lziuc-ii4hi-ygyx7-qalig-2ytfu-rsxtm-h6pt5-aae",
@@ -17738,7 +17738,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5ab5z-6tgb7-aoafe-n6nnb-etesx-h6xt7-pu3ul-gfgjd-7uv3m-dth3x-jqe",
@@ -17758,7 +17758,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5alj6-ij6fd-4efxw-chag5-7a327-7uvyj-lhait-ojze2-gxxtr-mgfkf-rae",
@@ -17778,7 +17778,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5az5s-5xxrd-ip5m2-6ps3s-uptc2-mz5gh-5ntqe-bmu7p-bhdyu-x4hu3-dae",
@@ -17798,7 +17798,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "5bw5k-uuvti-kxds2-knvoo-rbkpw-wy6us-fgpua-mzssx-pq5tp-udbap-6ae",
@@ -17818,7 +17818,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5dfvs-7jxus-lmnm7-4o3jm-buisw-55hay-6eofd-i27dk-ecrd4-4evso-hae",
@@ -17838,7 +17838,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae",
@@ -17864,7 +17864,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5efad-ubiwy-ejsis-o2cfe-7atnx-lzy7j-mu6pe-wig7g-e426v-wrn5p-5qe",
@@ -17884,7 +17884,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "5ei6o-6mx3z-zag6b-ubdsz-odxr3-ytixv-rrnv3-khmkc-4tuni-ber6p-mae",
@@ -17904,7 +17904,7 @@
       "dc_id": "hk3",
       "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5eixt-ipfle-nr2qo-odmfu-rymbn-5ommv-n5rw5-yaili-g7tam-kzsac-rqe",
@@ -17930,7 +17930,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5ezcu-l5n6q-3ddda-ap3qi-ir7gl-zvksq-lsino-d3uji-h66zk-53u6m-3qe",
@@ -17950,7 +17950,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5flj4-x56ts-jud7h-rzygl-a7uas-2degg-kyz5e-xojpt-pbuph-34zby-bae",
@@ -17970,7 +17970,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5fpvj-plxyb-bsyji-b4pp5-j47gg-vlkor-q6bhy-5bhmp-kjtu6-fqkjh-iqe",
@@ -17990,7 +17990,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5fpzb-vvlbo-rtbdy-4kcev-qy4k2-okbxr-3wtbp-nmjra-bqknh-zmquz-kqe",
@@ -18010,7 +18010,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5gcqu-upr5b-ol3fj-vz273-3ov5j-s2dzp-d3n4o-c3rdz-rnhto-tovcx-zqe",
@@ -18030,7 +18030,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5hni3-coaib-iuz4m-dxyvz-7bntg-hnwji-rghvw-sjvtj-nd2rd-jgjsn-jae",
@@ -18050,7 +18050,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "5hqad-rslqs-jpdj4-zzd6o-nlia4-kqmzn-v5jed-yej6l-huspt-6q7zi-5qe",
@@ -18070,7 +18070,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5hvab-67ek5-c7j2t-se7xt-zd3df-xjp6a-bnz76-kjx6e-bbx7e-rnwhz-nqe",
@@ -18096,7 +18096,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5i7he-lt457-b3ov6-fsi2c-pufn7-4i2mp-zkacf-4yysn-7fhr6-zfxg2-4qe",
@@ -18116,7 +18116,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5iihd-fkroy-ow5zp-hlvwz-bsgbl-mecta-kxubm-6adxr-ckcu6-prsus-fqe",
@@ -18136,7 +18136,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5irn3-rlxhd-lp3cf-caeka-xu2ph-54ceg-afnwr-atwlj-a33ip-odxsy-iae",
@@ -18156,7 +18156,7 @@
       "dc_id": "pa2",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5j5bj-nof4w-umwfb-jqemy-uhcqy-bzioi-23ct7-xsb4m-ojzy6-4jxz5-rqe",
@@ -18176,7 +18176,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5jbfj-wygyf-jzcjw-s6ali-nlazr-nbejd-sfw6h-v44fg-hh34c-khde2-lqe",
@@ -18196,7 +18196,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5jqmb-vz4s4-tp7g3-v22ai-lqxgz-fonyb-6mmlk-xsmfs-md3u4-ovqek-zqe",
@@ -18216,7 +18216,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5jxvk-4hn3t-7bzwt-enxfa-4u7rh-n3fno-t33ly-74lic-z2uep-zqlvp-nqe",
@@ -18236,7 +18236,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5kc7d-5fv6m-3ps2z-n4gf2-vm63s-a3nyz-7g4gv-rkgg2-nkccw-arwq3-wae",
@@ -18256,7 +18256,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5krcu-e3t4g-aa2al-x6tzs-o4a4p-ulx3p-sbk2n-fregk-xswvx-yrueq-eqe",
@@ -18276,7 +18276,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5lwhb-2a5za-eatmy-3e7hy-otnjn-h3c6l-ov53b-qpt7u-cutea-wcxiv-kqe",
@@ -18296,7 +18296,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5mpdi-v4qj2-64are-tbe6r-6335g-6tksh-c7uzq-w3xyz-o4p5g-rwnll-vqe",
@@ -18316,7 +18316,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5nkgj-r45dd-5qojg-ecnqn-ig7uo-hqndz-v5udk-gxygg-bfigl-r6lh3-jae",
@@ -18336,7 +18336,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5oe2d-on34f-iyvla-5ejfo-34n5u-yllm4-zxdgu-scaji-uleio-yeszd-yqe",
@@ -18356,7 +18356,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae",
@@ -18376,7 +18376,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5osj4-6yxs6-czubw-7e547-kbpd5-j2na3-37ciw-xhu7l-pqefv-orvkk-bae",
@@ -18396,7 +18396,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5qfrp-jovqw-wjlmz-apmeg-vgumc-nzhpi-k3g4d-lzeju-o2mcj-3iffn-yae",
@@ -18416,7 +18416,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5qmio-5ls3e-yujlz-eqt7k-qk5ys-bscfd-7w2rn-2q3fq-6smjq-n7asc-xae",
@@ -18436,7 +18436,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5qrvh-zivm6-xblci-b3xzm-le2tg-fvubr-52bqk-6qiz3-5cyid-7cg35-lae",
@@ -18456,7 +18456,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5qw6d-gs4jl-hfhco-hetj6-avx4k-q6kee-s3pq6-io33z-iyjx6-dkx5l-5qe",
@@ -18476,7 +18476,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5resh-f6n7z-xxkbq-7lpod-spptk-nyt7n-tcvf6-f5ecb-ixxwc-6k5ai-rqe",
@@ -18496,7 +18496,7 @@
       "dc_id": "ar1",
       "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5rlin-3oohc-lsgxy-hacdm-64my5-7y3p4-22nhe-2e36h-dlvjt-2nkuh-wqe",
@@ -18516,7 +18516,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5rvo7-6mntd-ibedt-p3a6p-u3iaa-uhpqg-wqel6-pfw5f-ppus7-5ek4z-sae",
@@ -18536,7 +18536,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5sabo-gkucg-7krz7-oxmyj-ylifc-w2r6u-bt62i-eqq2x-47rwh-gmjph-hae",
@@ -18556,7 +18556,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe",
@@ -18576,7 +18576,7 @@
       "dc_id": "si1",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5u6dm-zixbp-mbblj-xc7en-hsc7i-upw4t-3dzyb-63tfg-h3f5p-3q3b5-4qe",
@@ -18596,7 +18596,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5u7le-tmied-z6u52-adg7a-mo3wa-yry7m-awfv7-rbiax-o3oc3-le4q6-oae",
@@ -18616,7 +18616,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5v2bn-uoktd-3ne5o-lxcws-askra-k4iyq-fxt2j-3gdpc-t2gxb-hiybx-4ae",
@@ -18636,7 +18636,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5v4on-bsceg-rdgxe-zcqqf-l5wnq-fpxw7-x3ktj-3x4fs-o2cny-uzhor-vqe",
@@ -18656,7 +18656,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5wzcz-mfner-c5wor-3liei-7mpao-vkult-zdds6-6n3rg-42ksv-6zzqt-vae",
@@ -18676,7 +18676,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "5z7nd-pyjgc-ct6hz-mylu6-i7mdd-zyneg-csyti-lmjyd-nwefu-pw6pc-5ae",
@@ -18696,7 +18696,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5zldm-3rijx-6pp6q-twp65-b34xz-6iitk-kqzov-flbdh-ekkx3-3an4a-eqe",
@@ -18716,7 +18716,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "5zqhj-66qn7-he3p5-76gnj-hlsvl-ajlt5-k356i-fgm4m-5it4c-6m5ag-7qe",
@@ -18736,7 +18736,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "5zrsg-qcrev-mm3cc-km55r-kk2ug-w6dkh-ljlnk-vj26z-yqmez-ftbfk-xqe",
@@ -18762,7 +18762,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "627qw-ey6wj-efg3t-76ixt-o2x5p-r6bmb-vf4c6-ycmyy-oiba5-wloig-dqe",
@@ -18782,7 +18782,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "62pbm-psjwv-sf3fc-hyisj-5qsoh-fvpac-tacne-jotrs-owsmo-3j7jo-wqe",
@@ -18802,7 +18802,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "62qwz-bp4wo-tdrcm-vincq-mdhz3-g6bfq-axwcr-vog76-fe4f3-lvepx-bae",
@@ -18822,7 +18822,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "62yzt-726hf-rwk73-c3j6k-fjdls-7oqh5-exbnn-bvrsn-2soat-m4vg3-7ae",
@@ -18848,7 +18848,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "63bsb-jbwja-suy6t-ftoim-ooxag-jiytd-rayru-4kgx5-tx5gb-2b2hj-qae",
@@ -18868,7 +18868,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "63rak-vvm6t-c4cfc-bgak4-mkcsc-oy7jy-p4ow4-kdebr-otqwx-ok23w-fqe",
@@ -18888,7 +18888,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "64fwz-oyjy7-3r6wn-n5bhn-534fp-bjw2l-b5gel-gdrt4-egsun-6tkiw-cae",
@@ -18908,7 +18908,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "67m4d-5jvep-mnm7z-fjsm7-7aec4-bycrw-dntq6-v4ahv-4mele-yljgc-tae",
@@ -18928,7 +18928,7 @@
       "dc_id": "ta1",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "67t6p-i4h3c-msv6p-kmbmm-rr6gj-z3nix-d6lo2-mq3q4-3h6rb-lwkbc-lae",
@@ -18948,7 +18948,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6a7nv-kllgd-pgq3t-nnv2w-miosm-g7kzz-4ozr4-pzq2e-iozln-ufbpr-mqe",
@@ -18968,7 +18968,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6adxp-p7u63-xsdtk-lo6oc-vpqmi-44hgt-yv652-cbm5p-mssge-wsrz6-oqe",
@@ -18988,7 +18988,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6bbgn-jvexd-25pja-q5wgj-spyfw-lfm3g-pjf2t-x3zmf-7llwq-p63wm-rqe",
@@ -19008,7 +19008,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6bdng-zgonq-l7cou-qgy7a-pxesb-jgvdf-7drst-dqqaa-pzwne-obya4-eqe",
@@ -19028,7 +19028,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6bp3h-ds5qd-6o7ae-6nmnu-brwpj-2c5iw-yjfnk-4drxh-vxa2o-qcchx-6qe",
@@ -19048,7 +19048,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6bt7p-6zrhd-xi3rj-jsugy-c6qzy-nvip5-7thap-gk6po-ygo5h-mh4jk-tae",
@@ -19068,7 +19068,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6cknu-fqcy2-2keuj-gicsk-6ecfx-bwcjo-ppw7m-ler7z-bwjah-jvdbj-fqe",
@@ -19088,7 +19088,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "6df7i-epxjg-xjgjb-reyqa-3d5a5-cvgxz-zscfa-ycszz-32cuu-ruhx5-lae",
@@ -19108,7 +19108,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6dmez-tuvfo-pxyw3-h3ds7-wie24-mpalp-fhjym-w7oh2-s2mqo-bsxkc-5ae",
@@ -19128,7 +19128,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6euda-lnsnf-bpzly-5ohu6-y2vco-we5va-emgzd-y22k2-fcpbj-q3kuw-kae",
@@ -19148,7 +19148,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6fm36-gj33w-34vuw-rb6se-62vzz-he655-2vasp-jnu6w-ixzel-e6azy-eae",
@@ -19168,7 +19168,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6hkcx-vz4jv-4n33r-ywdvs-sefaa-tb2on-rac6s-4csut-iyahu-zmct2-5qe",
@@ -19188,7 +19188,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6hqi5-ctyoo-qijwz-dtvwo-g5puo-yaftz-dmaid-rambc-li5dx-q46y2-sae",
@@ -19208,7 +19208,7 @@
       "dc_id": "li2",
       "node_provider_id": "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe",
       "status": "Dead",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6hvx2-ymemx-tmykh-vxyic-bgfhv-2lcmt-3oy4x-rysuf-rnerz-vqokw-sqe",
@@ -19228,7 +19228,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "6imhm-ocz2z-gn6x5-hpx3k-52pjt-5roy5-uc3ua-mmi42-onrf2-yq3ie-qqe",
@@ -19248,7 +19248,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6jidn-uqgyz-hl2l3-ou2rg-slu73-iztvd-yhdu7-hjfuz-cy4wc-jvoqc-uae",
@@ -19268,7 +19268,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6jkz4-2yffr-w3ywl-iji2o-zopfz-jbboh-l3bho-6rrws-4syul-elii5-rae",
@@ -19288,7 +19288,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6joub-fk2lr-mcxa6-lo2x5-e3alk-lrgf5-6slof-x7yxi-m6ceb-up5wv-qqe",
@@ -19308,7 +19308,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6kuom-ucaom-u7xm5-s556x-3rnyk-hdjzd-wkxnx-wsejf-vpnhz-lniqi-nae",
@@ -19328,7 +19328,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6plly-42la6-6ogks-ngyyq-bzjqd-wygdg-mmulz-onmbp-crpy5-5fm5d-pqe",
@@ -19348,7 +19348,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6pt6z-rdv25-glenj-xvuq3-zdeeu-4c74r-smqeh-tgt34-exgd6-2wxvv-eqe",
@@ -19368,7 +19368,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6pueo-uz4kt-quvid-v3q7y-pyqsb-wmv5o-qi6ay-jd3ex-ypddd-3vysx-eae",
@@ -19388,7 +19388,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae",
@@ -19408,7 +19408,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6qzmz-5jtwm-kuv6j-wa3dv-n7yse-ex5rl-vmbx5-suunp-hdqxe-bnerj-iqe",
@@ -19428,7 +19428,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6ricl-vwbej-yk73y-6ttjb-oefyv-cpjta-7ttqk-e4ucl-5rxsq-v2bag-zae",
@@ -19448,7 +19448,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6s4xm-dhqvo-nnfu6-piffk-qttw2-tga5m-hnf3f-bvnio-77hoh-k2ju5-4ae",
@@ -19468,7 +19468,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6souc-qqdhe-7rxo2-fvtpn-suxfz-dnvtb-k2q2h-n3pvf-ttjvc-b4lj7-uqe",
@@ -19488,7 +19488,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6ssdj-55z6j-7q72p-vn255-utr5r-r2lgq-iitti-wnchn-rpwos-hjgrt-lqe",
@@ -19508,7 +19508,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6syks-la2v3-ua4aj-iyt6f-oivnq-6yosi-cqxwo-ahzno-ieuvx-bl7pf-vqe",
@@ -19528,7 +19528,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6t3hc-abwek-snx4i-s57g2-w7u2g-beaec-jsjgx-g47s7-zjeb2-cb5pu-yqe",
@@ -19548,7 +19548,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6ucn7-aiavt-uucq2-cvnjf-nwmr5-vetsg-q73h7-uzqjt-klm5x-e7qxu-mqe",
@@ -19568,7 +19568,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6uvnb-d6g2t-wp6rq-gbxtj-yqeal-kgno7-xj53m-mr6hf-itthv-jio66-3qe",
@@ -19588,7 +19588,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "6wnv3-oxkmg-rtcgq-slqsn-5xlwu-7a27t-524pa-st7b3-epsck-tixsa-uqe",
@@ -19608,7 +19608,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "6x7cr-ldy7t-2hlkf-cfsfb-w3gtt-waqnj-2dfrd-2krz2-32cig-bwfkv-jqe",
@@ -19628,7 +19628,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "6zj3x-tsbc3-jfzjr-lrnay-maejy-wwrrr-byxwk-kdzqu-nrkmz-mdcrx-aae",
@@ -19648,7 +19648,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "6zx2i-t6ne2-rpbqi-et535-zje77-tati6-fakrq-pciub-lfln2-5rpxm-tae",
@@ -19668,7 +19668,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "74qsa-j6jno-nmxmb-7jpf5-u6nig-g7hgo-thvjm-6f6zu-c2ugp-krple-qae",
@@ -19688,7 +19688,7 @@
       "dc_id": "ba1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "76mrs-zalfr-lfsvi-6vdnf-aqk3j-uaajm-2vo7c-mqez7-7y4oe-srw5e-zae",
@@ -19708,7 +19708,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "773ks-thhym-rpwf7-rrz2t-4apte-tq7tl-gwq3n-xfy53-hbgwr-doywj-fae",
@@ -19728,7 +19728,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "77ugi-5645h-z5227-mqssl-mqbhp-cgsko-y2bmc-nqecb-plpuv-orjek-lae",
@@ -19748,7 +19748,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "77vl2-fnnm5-k5m3d-lkgnn-pspvq-ld7iy-xp7s2-3hk2s-ufzbi-tcclc-gqe",
@@ -19768,7 +19768,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7agd5-pfc4g-rdozn-zajij-aax72-7jft2-rzw36-y3flc-xwt77-pjg5w-7qe",
@@ -19788,7 +19788,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7aspd-jcgr7-jxpfs-5lauj-qnjz5-b2x6h-vu7rc-q2h5h-pjckk-nig7u-sqe",
@@ -19808,7 +19808,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "7cxax-hnjlw-qp45t-3k7y3-hlraz-bovyp-u2oyz-46ozt-x44dr-yhkb5-mqe",
@@ -19828,7 +19828,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7effw-j4nle-7smlm-xzebk-ttmdp-lndrw-jk5a6-nsr4b-fikx3-zpuee-6ae",
@@ -19848,7 +19848,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7exbb-k4tu4-mw24y-3zylh-bopa5-fwdsc-f4a3z-45hh4-twpin-4zv4a-yae",
@@ -19868,7 +19868,7 @@
       "dc_id": "ba1",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7f5c7-l7cuq-7jnfc-yexo3-bytd3-yf6xa-ctk76-wywln-jsy2n-ds2lp-tqe",
@@ -19888,7 +19888,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7fiyj-xjxkj-fjvbl-tl4rp-6xvg3-moow7-dwtyi-nsxeg-unw7n-ivshf-pqe",
@@ -19914,7 +19914,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7ft3v-76mqt-5r3h4-qiwe4-mkobb-mcsue-qugga-ctzdk-623if-rynkj-jqe",
@@ -19934,7 +19934,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7g3hi-3ypt3-4u3qa-6jmvf-eptxu-loh2i-poiih-fmgxl-7vlyd-g5hy3-nqe",
@@ -19954,7 +19954,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7gdir-f577j-c4hmo-nowiq-uwgp3-7n3br-q6d3m-7uqi6-643jo-kosf3-wae",
@@ -19974,7 +19974,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7h3aw-y3ygk-37mdb-cbuj7-ric2q-b7pgf-xwspg-bxzq5-cxid3-lqqwi-nae",
@@ -19994,7 +19994,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7igzi-pqopv-veiyq-itcgq-mvfdk-4v3ff-46yc7-tw6al-4dv6s-smzoe-vqe",
@@ -20014,7 +20014,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7jjmd-p43kv-2h3bp-yrcuv-gc3ia-zaess-2rj6p-p4xgr-f43xy-6hk55-xqe",
@@ -20034,7 +20034,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7jxpa-y2d6g-zsy7g-vnjp6-sblcx-32lke-hulup-hj3y4-i3svi-pi2c5-yae",
@@ -20054,7 +20054,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7klzr-dpt77-vylqj-ji5lh-5zlrb-kwlis-3d7wy-dj2kw-fjlyt-7jjts-bqe",
@@ -20074,7 +20074,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7lada-t4fmt-3mmah-y3e6x-dgzky-tv4r6-27a5f-sjwzk-svkry-gmuaz-qqe",
@@ -20094,7 +20094,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "7m3y7-s24j3-i5oji-6h64r-2ah6w-2z236-rh7ro-b3plo-rrdwn-xwhc2-aqe",
@@ -20114,7 +20114,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "7meyc-3kacw-uidhh-kqorx-mziq5-hnr2e-qhhcq-mgjpp-j6sep-73gvv-nae",
@@ -20134,7 +20134,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7muaz-6c5bc-6wjw2-f65xy-i7poz-jwhob-ty26j-ol5dh-hf3oo-dkgb3-6qe",
@@ -20154,7 +20154,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7n3h7-npgiy-wqi2a-3mlzv-rq6os-ifjbp-tqqox-qhqjf-cgxci-zpzxj-qqe",
@@ -20174,7 +20174,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7nj4d-fspc7-c652p-joehv-jgk4g-ksyml-cy3h2-e5q3g-udbnz-v2fy6-hae",
@@ -20194,7 +20194,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7ospr-xybr6-5muyc-h7gn3-73rpz-f2sn7-g7gqd-nny3h-b6gbe-cbnd6-4ae",
@@ -20214,7 +20214,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7pch3-7nre2-7su6p-ouf2h-zrpqi-oc4vw-3j2ce-swypv-xiu4y-qj6b2-7qe",
@@ -20234,7 +20234,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "7pq5q-kh6ns-xjvke-hunxi-lvn3b-yq54h-nfark-n7dqs-wb3xu-edeic-vae",
@@ -20254,7 +20254,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7prmk-rel7w-5znpq-ir3y6-7twqb-zh2t5-buguy-sdu27-fjdw3-dg6xl-fae",
@@ -20274,7 +20274,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7pvxh-37ula-relu7-uim72-jvx46-dcnvm-52zsf-vkqzm-xsjoy-4xf4l-hqe",
@@ -20294,7 +20294,7 @@
       "dc_id": "bg1",
       "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7pwmx-4zsiq-saplf-kl2sd-4yvr3-la2yi-artrs-m7voc-htak4-fii5y-sqe",
@@ -20314,7 +20314,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7pxqq-e4kmr-saxrs-jziwc-sfdft-bl2wh-k7vhl-6a35o-2stq5-v6uso-3qe",
@@ -20334,7 +20334,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7qvtt-6lr4l-gx337-d6xvn-55ka2-6kcx2-c7iby-w36qm-u3ojf-ildyc-iqe",
@@ -20354,7 +20354,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7r64j-zqmz7-krqtz-zetpm-x56et-wkege-el55a-nbgwx-dffso-lbtob-4qe",
@@ -20374,7 +20374,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7r7go-kuy2d-xradp-g2yf6-64ft4-tza2v-nbs66-jnxp6-37dda-d6or2-fqe",
@@ -20394,7 +20394,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "7r7kx-pfeyy-apl6r-7m3mi-nhuan-zy5rd-l4bxq-6x5ak-a4632-sqoof-qqe",
@@ -20414,7 +20414,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7ro4m-qawjh-yly2b-da2u5-ziwkm-vb7ul-kweme-sitth-fqtem-llq4p-bae",
@@ -20434,7 +20434,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7s6kl-ygytv-rqall-6j2ub-hb6ig-bv3wl-gn5rr-ddnmx-okxap-z6ctq-iae",
@@ -20460,7 +20460,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7tayv-2pmqc-gaiwu-3kd3h-fh4qh-3moqd-aawsb-4rq6o-ui7fp-dofcu-iqe",
@@ -20480,7 +20480,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7tqgr-ri4wq-2ov2k-hibgd-7qxvk-pwv3o-vfrq7-2qwfi-dqdvk-jzu2y-aqe",
@@ -20500,7 +20500,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "7ucvx-t6mxf-viej7-ils7i-k3aco-tqzsg-6cy3o-cakgs-zifaj-kiduk-cae",
@@ -20520,7 +20520,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7ugp2-u6cil-a7vsy-ggcbr-iqbhk-jzizs-ls7e5-gwvar-thbjs-sx7sb-sqe",
@@ -20540,7 +20540,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7up6g-ihrwe-e2at5-bi6e2-6rjeu-yk5mv-wabsc-qsu7x-ve6kj-2kyq4-vae",
@@ -20560,7 +20560,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7vdar-a327j-byc4q-kacxg-ubasb-6dwe3-te272-frjgx-zeny2-xvj3j-5ae",
@@ -20580,7 +20580,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7vhhj-2qrcv-n5spd-aiff6-pjrke-jetz4-trolr-icnee-yirwt-4pgtp-5ae",
@@ -20600,7 +20600,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7vmkt-bcdto-eclzw-srllq-xhavy-3ybm3-2fprz-k5jay-uqkdn-6vq3z-yqe",
@@ -20620,7 +20620,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7xvne-mrt6m-wiw2t-gxh32-4epji-7yrwc-f4z4m-aga2d-xnyqr-2rbfk-7ae",
@@ -20640,7 +20640,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "7zf3w-emnhk-7yhl4-sxvmx-wxgle-2hatv-hagfv-ybpxo-jglsx-fgadx-hae",
@@ -20660,7 +20660,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "a2e7m-evijx-geoc6-o5j6s-h45ye-f3hxj-w7dfi-25e2k-v5ylv-nf7ud-aqe",
@@ -20680,7 +20680,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "a3biv-gee7t-qsjnz-4hsb5-zmvds-l3tjb-bubn5-gevin-2ehtn-thooo-hqe",
@@ -20700,7 +20700,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "a3wja-dbv3y-fbh5w-rigbf-2wwwm-syu4v-7p7to-ax7ql-7ush3-ynach-zae",
@@ -20720,7 +20720,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "a3xcb-ezfy5-yib3b-5bo75-5nok4-kaolh-a6akg-ilxck-qdbph-pwppb-dae",
@@ -20740,7 +20740,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "a4dma-26x2w-ruta7-ctzfn-exzab-sp3vi-hg3sb-ncoq5-t3s37-he2nm-hqe",
@@ -20760,7 +20760,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "a5vyy-7bgw2-67pfa-cgt2b-dgi4h-3nxi7-q5v5r-yzenb-yv3xy-fdu6y-hqe",
@@ -20780,7 +20780,7 @@
       "dc_id": "sj3",
       "node_provider_id": "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe",
       "status": "Dead",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "a6t2w-sxcps-qmgvc-vlitk-kvrsv-pqpl7-hylkb-urlhs-gove6-ehq7x-iae",
@@ -20800,7 +20800,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aae5y-2ebjy-4j2u6-tsq5r-tzzhh-6wcr6-5kynp-nf5qd-rdb6i-u7rtw-pae",
@@ -20820,7 +20820,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aajth-ndp7x-ro5ok-yikyd-4i7xn-5k5ki-e3d37-hh4gn-s4opz-bnzxf-4qe",
@@ -20840,7 +20840,7 @@
       "dc_id": "bg1",
       "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "abg3e-zrvni-lab54-xuqtf-beh5q-lijks-zlbd5-wkpwg-xua7u-e4g7y-oae",
@@ -20860,7 +20860,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "adplk-g2snv-bygay-o2r45-72zgu-kzk4z-pzhto-5nhwg-zsryj-s4llh-wqe",
@@ -20880,7 +20880,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "af7s2-kkpvi-ganse-fu4ww-7lnj3-3ieig-m4y5w-v5zrr-ifhmd-567r7-lqe",
@@ -20900,7 +20900,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "afjfz-erkja-k7euy-yjjrk-tsvsw-hfad7-allt6-4lb3e-kscys-7uyge-7ae",
@@ -20920,7 +20920,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "afu64-x2met-w2vxb-4lzus-z4fhf-divej-q46gf-wvpek-dj67h-fptsd-aae",
@@ -20940,7 +20940,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "agmug-kfqq6-xoydk-yailg-mgajr-mpmxy-vrq44-ct45h-gmmzh-tkopc-7qe",
@@ -20960,7 +20960,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "agoki-54kg7-2fdfq-lmnvz-bj5lc-xrkvs-dqjnr-s5as6-7jj7i-2xh4h-vae",
@@ -20980,7 +20980,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "agtd6-f2qxq-ciadf-bterj-vpcos-7fapt-co3cv-ypvhs-zy6mk-ijrto-uae",
@@ -21000,7 +21000,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ahk43-rqgwi-lfseo-ocwl6-3jl7g-lrj52-qacyv-nqo73-tewxg-qdrvf-wae",
@@ -21020,7 +21020,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aid27-4kobq-rsaze-7bvbc-pwg2a-nrhj3-uhpne-yjdis-3rrx4-chcxm-rae",
@@ -21040,7 +21040,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aixb3-5ve5v-hrdiq-kqlsl-i4kup-fqup6-4qnah-s7wk6-vg3gb-3r4gq-3qe",
@@ -21060,7 +21060,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aj6th-bkul5-ehzbh-mylom-bf3uf-ei3vi-u5kqb-cpy3h-yegi7-cbzrx-wqe",
@@ -21080,7 +21080,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "akbo3-imbii-tzc4p-swdwz-hh2tg-i2ffj-tnzjy-zycuo-3xjcq-zxbth-aqe",
@@ -21100,7 +21100,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aknli-g4cdt-utkcq-eziqu-resfv-npzml-a4e7i-tryok-ncufa-t5zv2-oqe",
@@ -21120,7 +21120,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "akpwl-fouuj-clhyn-kjbq5-h2xix-hiirq-6tjxs-7w5ps-fhtdn-roxcy-2ae",
@@ -21140,7 +21140,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "alo6p-xfu2p-hz75j-z2has-64evw-zhsjt-4lhp5-ne56v-xifpc-cpq6h-wqe",
@@ -21160,7 +21160,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ami6p-hbo6h-zqoh2-lfqs7-44lch-tlkzt-skuxx-wyxs2-anezm-z2gxp-3ae",
@@ -21180,7 +21180,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "amy5r-rdfjn-cmkrz-pjjlb-dqwo3-lv3tm-4x23k-tu4yk-lkruv-hxtu2-2qe",
@@ -21200,7 +21200,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "anudy-m6vfi-lphxb-sazpy-la4ti-2hriw-c67ny-butfn-axcel-otvuh-oqe",
@@ -21220,7 +21220,7 @@
       "dc_id": "mtl1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ap34d-la2pe-wiwkw-jpe5h-vn4nz-h3z46-vm2al-gdcoc-h4f45-xfnn5-6qe",
@@ -21240,7 +21240,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "apit2-z6thd-bi3t3-m45hx-axid2-azz5w-3iorh-zyzmy-mdqfu-few4m-7qe",
@@ -21260,7 +21260,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aptx7-7loky-uwifm-phi4t-wjndu-yhp72-weofq-5zhd2-5n3hh-idaq7-eae",
@@ -21280,7 +21280,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "aqbno-vejst-3kuee-ksrrr-bo5p3-6nhht-z2coe-dg6he-ptywi-pzubm-bqe",
@@ -21300,7 +21300,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "aryg4-tcma3-ozqnh-j6rzl-lwlsh-fhgo4-2vhw2-zf4en-6a4it-spcrg-aae",
@@ -21320,7 +21320,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "asad5-qg3gv-p5hrf-7liwa-zkoia-t2imf-sztmb-okb3k-gc6ei-xzp77-5qe",
@@ -21340,7 +21340,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Degraded",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "atrq6-prjsa-w2b32-gyukj-ivjd6-kc4gq-ufi6v-yier6-puxtx-n2ipp-fqe",
@@ -21366,7 +21366,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "avhqm-o4ygy-mqqzq-xhanq-mkzif-xuorx-hxf6v-rp2uf-h2udt-onwu2-iqe",
@@ -21386,7 +21386,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "avrvz-tduah-oleb5-u4nec-ggmxo-cse6h-7bgd4-lhizh-tg5os-5fis5-uqe",
@@ -21406,7 +21406,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "awhiz-gcfjf-z7376-6sohx-tafjb-om2yt-wbneu-qhkqz-ukjcs-vj3uq-bae",
@@ -21426,7 +21426,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "awmdh-qwewl-6fgbr-dled5-2elki-xwucv-sslhm-awghc-dbxby-phz5e-wae",
@@ -21446,7 +21446,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "awpkn-yaohh-7l6ta-dvz7u-mxrqo-7ahi2-ag22k-3e3dx-vjnaf-mkbmj-sqe",
@@ -21466,7 +21466,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ax6zb-r4jnm-5aswz-ahoqx-ujs2a-mcvds-6gmdt-4ggxg-tkwdr-3323l-vqe",
@@ -21486,7 +21486,7 @@
       "dc_id": "bt1",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "axdtk-ibkoc-pu5eo-iia2s-taksj-v7l6i-erlc4-kls3q-yeiks-xbfgo-aqe",
@@ -21506,7 +21506,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "axmok-d4arr-sjcjs-cd56j-biooj-lo4fh-vfuoo-fextc-5iw2d-6zhq5-4ae",
@@ -21526,7 +21526,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ayf37-rq2hn-jiuvy-c2i3m-3kft2-v3jbe-c6mzo-f6yjy-sv52k-poii6-5ae",
@@ -21546,7 +21546,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "aysgz-pha2n-py2nc-nowga-sl2ko-yevb6-jn2ik-5r3bx-u4juk-o3qol-yae",
@@ -21566,7 +21566,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ayugg-n2ex3-azu4v-3sddp-mtbj5-k3ygp-tcmmy-pp2f3-3faes-hw77i-aqe",
@@ -21586,7 +21586,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "b37zb-apiex-wwlpd-ccbxn-yes6n-q44fy-jtz3j-mjxrs-ecw7v-lzmut-oae",
@@ -21606,7 +21606,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "b3knf-xg5xg-p3oyq-dgpdw-xjz2l-n35mj-pdoyl-4dgas-u2t5l-bndrp-hqe",
@@ -21626,7 +21626,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "b3ml3-v62hu-gdyb5-2raax-b33g2-nav6y-i5d3n-carmz-tosee-rbhk3-lqe",
@@ -21646,7 +21646,7 @@
       "dc_id": "li1",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "b44r4-u77ay-myhhv-d6d75-jusik-b7ry2-g6ms5-6okxm-tumyx-rjm4g-4ae",
@@ -21666,7 +21666,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "b5pgw-6wtjo-dzwgu-zkfz6-3l5f3-cw6ka-y4crr-dikku-fkjbe-lfzki-qae",
@@ -21686,7 +21686,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bafm2-xnr2g-ztwfs-dnc5i-gqygr-sne73-6nyu2-66x2z-qnax4-ec5ru-hae",
@@ -21706,7 +21706,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bayvy-p36kq-krz3d-o5lay-rxx3w-h35pc-235tv-mmhfe-b674r-xwfnq-mae",
@@ -21726,7 +21726,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bbagu-dnle7-gc3zz-7dqkj-aflcj-c5nvr-w36w6-zbk6x-mutkh-sj55s-yqe",
@@ -21746,7 +21746,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bbap7-dgab2-kcoth-ddzci-jzihw-gesc7-rugiz-uagk3-necag-k7kjf-mqe",
@@ -21766,7 +21766,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bc3ni-4ooev-32li4-xl33g-4jw2b-ebr4o-2cxda-daz3i-buumt-6noyl-4ae",
@@ -21786,7 +21786,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bcbz4-w2ogq-jt7xk-xd7b2-ylhei-ygp3n-pjpdy-253tu-fpn3s-f5asy-fqe",
@@ -21812,7 +21812,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bcc4x-ej7tr-amnzq-64fz7-3pnyv-7jl3u-d45he-midmo-niqwz-nigrl-2ae",
@@ -21832,7 +21832,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bew7t-tep7b-5hpwc-pzfcb-wvyfo-mhcu6-vnrkl-a2f6e-2aq4e-c4ezy-7ae",
@@ -21852,7 +21852,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bfbpg-wbgy6-vqu5a-bqnyp-bcb43-mp3yz-2t3sj-nkrnp-ac7ux-g2jj3-yae",
@@ -21872,7 +21872,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bfj6y-cmhcf-6fxs7-ku2u4-tucww-b2eej-2dmap-snurk-3yaks-ss7xe-rae",
@@ -21898,7 +21898,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bg6ol-uul6n-2bl4u-ayztf-drnzz-4eczv-lff6m-34scy-adxb4-ewhhi-eqe",
@@ -21918,7 +21918,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bgggq-a5733-6jz4w-tkokf-qrfch-2ihve-rhfzf-5popi-r5qaf-5kfqy-kae",
@@ -21938,7 +21938,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bhrbv-chf2l-tjjcj-mqryf-7z7ww-z6xi3-su7hl-idbfo-nnfpu-u6aju-nae",
@@ -21958,7 +21958,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe",
@@ -21978,7 +21978,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bkg32-x7k7j-t66jk-b4wqq-vul5w-qdtrw-5uefo-yuknb-fe54a-tp4lu-iae",
@@ -21998,7 +21998,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bkult-ic75e-xfviw-iyidh-tivyz-r7fvw-7r4xt-aawip-cp7vm-4iu2v-rae",
@@ -22018,7 +22018,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "blcw7-64reu-4kwke-es7l7-v5uel-hi4ll-a4oki-uw2n7-3dbdy-vdzgh-oqe",
@@ -22038,7 +22038,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "blwrh-vy7in-z6m26-cvugi-ra7fw-spp4m-rpuca-3xt7e-6srkk-qxlgi-rqe",
@@ -22064,7 +22064,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bmpar-rvlwh-dsdqv-3p53v-lje4k-lhhx6-thcfv-cph4c-kv3zg-svxuw-5ae",
@@ -22084,7 +22084,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "boilq-in4au-u5skr-4vogv-fnrj3-i7n5x-ubn4b-zkfya-zwszy-t6ync-dqe",
@@ -22104,7 +22104,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bp2my-vzxf3-qenrc-psiel-r6uox-7ckl5-uxfkd-plbro-fb2y2-uqdev-tqe",
@@ -22124,7 +22124,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "bptaj-nejw4-osqqa-zwrej-ysl2o-5ffgj-hkjr6-2w6fi-jczex-vjutw-iae",
@@ -22144,7 +22144,7 @@
       "dc_id": "ta2",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bq47i-nl3wp-zbsv3-juxt5-ptcqw-wfm6e-eqv5e-m3y4e-w6xgk-z7rmw-eqe",
@@ -22164,7 +22164,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bqplp-iejs2-2awcz-oiy6u-62jzx-rzp66-z4eba-m6nan-dtljh-bb4pn-rae",
@@ -22184,7 +22184,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bs2f6-hqzox-bkqoe-aw3jj-7lso3-hyo33-tiq74-kuinv-ucdez-vtt4a-3ae",
@@ -22204,7 +22204,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bs7jr-2hrlr-krdlk-qmuzs-hkphr-3jzx5-f5smp-6xwyp-inleo-xg4qg-iqe",
@@ -22224,7 +22224,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "buqsd-72zlu-hbgr2-hzjnr-mgvyj-6ldtg-2hdsd-igtpb-q7p2l-4j43v-5ae",
@@ -22244,7 +22244,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bv2x3-p2b3h-b23rg-aoq3s-kdzo2-pipmf-5y2me-jfa4w-tb7vr-qistz-2ae",
@@ -22264,7 +22264,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bwicx-4gcmo-yswte-eb3ec-mc4cf-3wdjb-ueiuh-2xdwn-qnpn7-luand-6qe",
@@ -22284,7 +22284,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bxczc-ao2x4-yzmq4-o2ezo-7mjct-ypeqs-6rcyl-ozl5d-j64m6-blata-iae",
@@ -22304,7 +22304,7 @@
       "dc_id": "pc1",
       "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "bydvi-usuoj-bhuak-xyt2l-gw5hc-j5o5y-plelm-p3uim-5myex-wmrrq-uqe",
@@ -22324,7 +22324,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "bz4m4-xsx2j-seecl-igygc-26lej-uhktf-hawf2-d6lof-2whss-3jobs-dae",
@@ -22344,7 +22344,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c23p7-qaedp-ceiv7-mbzjy-g5lwg-xiptr-mrrjw-va72y-qowkq-ftggu-sqe",
@@ -22364,7 +22364,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c2ewt-wic55-asi27-6eoeu-rn7bq-xjzmz-dzxg2-pxrfw-qeinw-yrj52-7ae",
@@ -22384,7 +22384,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "c37f7-3shrz-2mk6g-e2zvp-3z6xc-uuk6r-6yegs-53uzt-c3vtf-dacsv-tae",
@@ -22404,7 +22404,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "c3syk-l56ky-owcvg-y4ogf-3qfti-elv4e-2bqp7-k5v32-ibzm6-o4k6s-eqe",
@@ -22424,7 +22424,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "c3xxv-clwfo-3pfn3-srt75-3wxn7-twfzm-7o5g6-pfvhd-rvsuj-47d3c-2qe",
@@ -22444,7 +22444,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c4wpu-73dyn-hmm33-sfkz3-pioei-nylbz-loegx-up6uj-nvqvu-d7zsq-iae",
@@ -22464,7 +22464,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c4xi6-jnokz-uhpvd-lpwoe-hra3h-ph7ia-77clm-xfxf3-lskj2-4fohp-tqe",
@@ -22490,7 +22490,7 @@
       "dc_id": "zg1",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "c5q7i-ukcdm-tod3i-6v4ni-uwcyn-am6at-yuq43-pcw2v-lmodr-qs2uk-dqe",
@@ -22510,7 +22510,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c5w2g-uilsl-icq36-vonoi-4k42z-hiutx-4wdrr-3u5mq-pvb42-j5om6-zae",
@@ -22530,7 +22530,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c6kyc-37zic-3xhsz-smhba-moq5m-k6xqk-4355l-xtabo-jkeyf-aenq7-hqe",
@@ -22556,7 +22556,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "c6on3-qhvg5-k5v5v-wcson-2wek7-blvc7-xnr54-gyakg-6etp7-khw33-qqe",
@@ -22576,7 +22576,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "c6vcy-6g4me-zzd7n-kaylz-ujxmo-b27zq-us5th-w3t7x-ysolf-3mgpe-7ae",
@@ -22596,7 +22596,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cafm2-w5pj4-74zoz-e6ltm-daszu-hjgnz-v5gpi-ljqxl-q3sas-i6vkq-dae",
@@ -22616,7 +22616,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "catzb-pqs4z-h25rr-jwdtx-hutzu-qqw4j-kkqux-w53ey-mg56o-tb4ay-fae",
@@ -22636,7 +22636,7 @@
       "dc_id": "wa3",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cbtjz-aon2h-2hlj5-6sdzt-zrdfs-2tdhj-tzgpg-mwkod-ptfy4-hlqly-3qe",
@@ -22656,7 +22656,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ccosg-l4vd4-wl6t2-jmrbs-zai42-zctdm-svvgu-fb3zg-jmot3-cjn64-2qe",
@@ -22676,7 +22676,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cekdc-hmzri-3u3or-ei7ip-su7ck-3xt6e-zsse2-tgakq-rolmv-6crkh-hqe",
@@ -22696,7 +22696,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cfnj6-4cdzn-k26lk-ognvg-caesz-jogjw-5bvps-vunrw-gop5u-ibhs3-xae",
@@ -22716,7 +22716,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cfp6p-c4gii-urweo-a5d2j-euu76-s7o6f-vqjtx-zuxfd-wvcbp-qfzms-dqe",
@@ -22736,7 +22736,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cfvmx-z5jtt-mzlfj-b7aj6-fnsr5-c3svv-zuo36-tlscm-zdghq-ipxgx-5ae",
@@ -22756,7 +22756,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cgh42-4om34-lxkeh-wpu7r-7badk-rojad-7cysm-shbb3-xh3qj-rv6zj-uqe",
@@ -22782,7 +22782,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cgm5b-6rf6e-ut46u-bidiy-ik7tp-w6q5a-l3oo3-qplkv-q5ced-mev5s-wae",
@@ -22802,7 +22802,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cgpcl-dxgge-6t4eb-7zmxr-vnjyt-em6qb-czhdw-q44mj-cz6v3-ahjd7-kae",
@@ -22822,7 +22822,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe",
@@ -22842,7 +22842,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "chlz3-enuar-5oa26-wloxe-pat7q-6xxdo-v7ipr-utdst-s6y42-jczmb-6ae",
@@ -22862,7 +22862,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "chr5h-5ldod-rgonl-ifszj-cl2ax-dvztp-vfump-nl3md-dyyil-iwiq7-3ae",
@@ -22882,7 +22882,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "chzgl-n2hjh-3coyq-fozyi-tipv7-autbh-ei22q-hr6gr-rvdxz-2zh4z-aqe",
@@ -22902,7 +22902,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cihwa-v6cri-mg4yj-mnnju-hhyet-vxaut-ow3q3-xfscy-3zxbg-xdtso-4ae",
@@ -22922,7 +22922,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "ciii5-l4k7a-qf3je-6o5ev-tfudn-mjruw-b4r4o-2g4jt-upmwv-4oqx3-5ae",
@@ -22942,7 +22942,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cjgoh-vt4ur-x7byp-ri25g-ikqmh-prfa7-cd34u-7j2nc-ecdru-yaaqf-iqe",
@@ -22962,7 +22962,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cjiry-m7wev-s6adg-3oqev-2g74r-wmtlj-ttdbj-abwts-rtwlj-6lxts-dqe",
@@ -22982,7 +22982,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ckoby-tggxz-asw3m-pe42y-v3hde-6livq-rf5jg-ejuen-lvh7x-hbznb-7ae",
@@ -23002,7 +23002,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "cl43a-f4cfk-5bhhf-ro5s7-q7w6d-2vqow-3apn6-psfrl-i53ay-pykvk-mqe",
@@ -23022,7 +23022,7 @@
       "dc_id": "pa2",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "clecv-3ta7d-4ge5d-nrngl-bqcce-ygz5l-tbeeq-kyltr-k6pzd-gobcy-iqe",
@@ -23042,7 +23042,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "clfg5-ls62b-c54r5-sgken-xuwyh-p2coy-rsod3-2rvlu-cvbwn-whuyc-uqe",
@@ -23062,7 +23062,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "clfor-3la2h-lohby-tfriy-xfjkf-fnqpw-kkhjw-ctb2i-tscfx-ddwu7-bqe",
@@ -23082,7 +23082,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "clgez-cnier-zieyq-77d3d-njbsf-p34cx-pbzm4-stdmo-wy62k-d5ng3-4ae",
@@ -23108,7 +23108,7 @@
       "dc_id": "fm1",
       "node_provider_id": "hk7eo-22zam-kqmsx-dtfbj-k5i6f-jg65h-micpf-2cztc-t2eqk-efgvx-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "clhqg-zxyek-vija4-u6dfo-7ucbl-v7pb7-fgadx-ndkfp-rb54o-xiiqh-yae",
@@ -23128,7 +23128,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "clpy5-qdkib-dop3e-vts5k-btmkp-qncpk-kn4jj-zfiiu-a6b4m-nscgs-fqe",
@@ -23148,7 +23148,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "clto5-apr2m-kchli-74da2-eg5md-lnmya-blvu3-nxsgw-mygx6-ashjr-dqe",
@@ -23168,7 +23168,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "coaon-g3fvt-m4ylb-35ghy-q4ftv-vnprh-joe3e-dwyyj-l4vi7-jjbxh-4ae",
@@ -23188,7 +23188,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "coijh-thski-y2oxy-6plhk-3mvza-fgsjq-qkxzh-pb7bj-p5kd4-d7x57-7ae",
@@ -23208,7 +23208,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "coqzx-lgyi2-hizw4-nax6t-mshs6-y4ml6-xon24-ioon4-rer4r-qtuan-cae",
@@ -23234,7 +23234,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "covnt-jinzc-tezyn-anumv-iboot-y5ksq-63usw-mstsa-vaasd-rpb7v-xqe",
@@ -23254,7 +23254,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cp7d4-uiulo-a46se-yzti4-6qpmz-4rhug-d6rln-7aa5r-nc63x-6q7u7-aae",
@@ -23274,7 +23274,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cpywp-n4j5f-ja44p-oykxm-umz7h-fk6v2-rowix-bkwc4-ly4fw-tvu6c-mae",
@@ -23294,7 +23294,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cq4rd-bsq7z-gevtg-2pjod-jzxc2-iom7r-hw375-lqslx-ve6lh-54c4p-7qe",
@@ -23314,7 +23314,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cq5nh-ez2pp-dwce6-o5olk-bckwf-vxyhb-ahine-jsczg-6g5ri-uj3kx-fqe",
@@ -23334,7 +23334,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "csgba-555e5-qijlb-dtwhi-icdbd-kyeyn-cpi7v-jk5wp-nwn7s-5kd2l-2qe",
@@ -23354,7 +23354,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "csrkp-dimpe-7dybx-jmzjj-tjcjf-t57c4-tf4cq-cjeix-6tyah-qkyre-zae",
@@ -23374,7 +23374,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cszmf-llhve-eoz7z-wsgjd-q53ml-3mshh-plpki-jchyy-uziwg-jjq75-rqe",
@@ -23394,7 +23394,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ct3c3-aaohu-xben4-mbsjf-evtcb-bvf4i-qax6r-i4lm2-tcn6j-ybqpz-wae",
@@ -23414,7 +23414,7 @@
       "dc_id": "dr1",
       "node_provider_id": "trxbq-wy5xi-3y27q-bkpaf-mhi2m-puexs-yatgt-nhwiy-dh6jy-rolw5-zqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ctgsx-urhsi-pslxe-6p2vy-5dlpy-mbo7b-zdpht-zzbqt-j7hga-qsptm-4ae",
@@ -23434,7 +23434,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "ctqez-oqvmf-kkwto-wlehz-grh5a-l7enx-7e7ds-hcn75-mpdj5-pujdj-eae",
@@ -23460,7 +23460,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ctwsk-mtlet-rcsk6-p44am-6yabc-psi27-den2q-gaeg4-lk5zi-hr23q-6ae",
@@ -23480,7 +23480,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cupz3-ehtqa-su3yl-2shoq-7yxw5-25uhz-g5kew-73dpi-w4gpu-hsmoi-vqe",
@@ -23500,7 +23500,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cvic3-6mmjj-2zszr-mr727-im4l5-skwod-gzrg2-avd4i-bahw3-xyx3l-2ae",
@@ -23520,7 +23520,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cvryq-gpest-bfwqd-m6sce-7atse-publw-vcki4-yyny5-wb2su-yr44m-gae",
@@ -23540,7 +23540,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cvx4p-7vyi4-bfhkf-avoox-3pek3-yzlip-u4sxf-d3udp-nzzsu-equkg-oqe",
@@ -23560,7 +23560,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cwaya-vbbgq-uch26-lqqm6-zrfhz-4edlc-3tytg-cstua-pykwr-f3vme-2ae",
@@ -23580,7 +23580,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cwftn-crfgv-mhytn-tdjrf-xg45p-bqowe-b7lmz-r46vz-ii2ev-kr3bl-rqe",
@@ -23600,7 +23600,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cwnuo-ytg7r-g2pjy-kjmx6-4qh4m-fsklm-jkx5a-6ju76-6nxgm-f3kez-lqe",
@@ -23620,7 +23620,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cxuqe-ou4rp-y6vot-zzuar-x3qwp-3jj5s-abhs4-yxacr-nxl4p-2cgb5-jae",
@@ -23640,7 +23640,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "cxwof-lkaco-sgluf-7i2kf-m4czh-dykip-hjbuo-3k62z-olmn2-rkylq-6qe",
@@ -23660,7 +23660,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "cy6j6-mp2dj-me3i5-gepup-rtq4t-yoprx-hl65n-3dm2k-qjnac-cyuuz-bqe",
@@ -23680,7 +23680,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "cziiz-muz4r-kdzen-vpgct-ysmov-pevqh-ixjw6-5rmnr-s7y2x-6voiw-gqe",
@@ -23706,7 +23706,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d2ffc-r2mqq-yx3u5-f5j47-davp4-lske5-57oal-ilwph-o2hex-tqaz2-7qe",
@@ -23726,7 +23726,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d2hzh-j3wzi-mkmcx-ufb6u-5gft4-ta7yt-xq4qo-dncvt-y6dov-xbujm-hae",
@@ -23746,7 +23746,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d46vh-m3zki-yvo54-bbb2b-rejve-nhgiy-6cb5m-amog7-25mpn-dnua4-7ae",
@@ -23766,7 +23766,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "d4bgb-fhurc-bbdvo-ipdyx-mhb6t-ggr46-2qo42-tksma-svhyp-3ue4b-6qe",
@@ -23786,7 +23786,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d4ndk-jxgud-mf7j2-63lqc-2f64s-vouw3-l6k2k-akpwd-b4t4d-vur7h-jae",
@@ -23806,7 +23806,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d6pkw-im26h-clrwe-332o4-yqgxs-mwnak-hiyfa-vmw5v-thiuv-svhef-pae",
@@ -23826,7 +23826,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d6thv-qf4lw-o3n7c-rfg5q-zupjh-25a2d-kaxkp-y5wr6-nzjly-w2bcy-pqe",
@@ -23846,7 +23846,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "d732t-exzjy-lo3r4-vzxtz-nldaw-v7azx-4nktr-klpsx-hxfhj-2tsur-7qe",
@@ -23866,7 +23866,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "d7dyc-slisa-nrkkz-hrpee-2xbpi-xjido-shkjk-vrtob-cmfxd-6sevt-5qe",
@@ -23886,7 +23886,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "daawl-5c7hb-iltb3-rkphn-d272x-kkpu4-vb5nr-4qxzp-azreg-47okd-gqe",
@@ -23906,7 +23906,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "dapyz-46k2p-hgf2n-zxdjl-mq4ek-jgbvj-6xlfz-srm6z-dmfvj-wldgk-aqe",
@@ -23926,7 +23926,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dauyx-6xjun-aweji-gud6g-m4t45-uhxal-bd3zt-dt7o3-h5cwo-5nw5j-vqe",
@@ -23946,7 +23946,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dbdiq-igutu-o3uss-y7ms7-xh7du-cta2k-ar223-ms5cr-mjej5-vbxvc-qae",
@@ -23966,7 +23966,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dbpb7-eze6y-jdemh-2zemb-nuwhl-75ia7-xpwbf-26quj-2q4ok-u4ado-tqe",
@@ -23986,7 +23986,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dcbkk-imyhf-imyqt-ezzv4-g6krm-m7taq-l6mne-pqbmu-3ichw-y7x4r-2ae",
@@ -24006,7 +24006,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "dcl2k-pc3rv-6fia5-dfcla-qovea-3nhkw-6w35x-ee4tm-ss6zm-zmeqe-fae",
@@ -24026,7 +24026,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dd3ye-qncdq-jvghc-iymve-55lbp-hf6mq-6a3pa-ms5yj-espcn-n32jm-3qe",
@@ -24046,7 +24046,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ddbl6-37efl-b75e4-jpfsb-zioa6-ilvzo-tldwy-fnbhm-nbuoy-66cza-uqe",
@@ -24066,7 +24066,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dfcny-caobt-j247e-73ira-s3ubk-3wmbu-ghlkn-5rbej-gn2t4-xenzr-xqe",
@@ -24086,7 +24086,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dgfn4-5fo26-vlsjo-culqq-3gres-zrmat-xstpb-ejd5b-dqcmy-oidwl-mae",
@@ -24106,7 +24106,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dglrt-kx5oa-24g75-iu54b-t6ssv-nbsg2-cehva-tmutw-wro3v-ti7so-wae",
@@ -24126,7 +24126,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dgul7-oxqwq-uvafn-evmwt-mjrzb-okeie-rykhk-wgrmv-o6kkb-kpco3-qqe",
@@ -24152,7 +24152,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dh4nc-xdofs-5bsqf-zny3q-zjfhj-sn76b-vizti-sjzmv-5jvqc-sjhv2-iae",
@@ -24172,7 +24172,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dhnjd-aemdm-qq2fc-lacqo-fwerg-tc3g6-xsbkg-pbwgf-y2rez-mh5ef-jqe",
@@ -24192,7 +24192,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "di4du-s4hw5-kzawh-bxx77-tqu6b-5fr25-dnpdn-idrz3-6qrkd-qjqf5-hqe",
@@ -24212,7 +24212,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "diz6c-cfgpz-4itzw-ufwi2-zdc5d-uwcvx-gfhcd-7pjnm-526lr-lyuh5-6ae",
@@ -24232,7 +24232,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dl74z-6vpps-k6bpu-5hjsj-fb6lb-34tsv-ue5gt-bdkjn-35pt5-fdu2a-rae",
@@ -24258,7 +24258,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dmdz5-lpxiu-4e2az-i67sk-phdbq-ndf6z-mowlo-wchbw-unhn4-r2c2w-qqe",
@@ -24278,7 +24278,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dn3cd-kjiio-niru5-d2nez-xzp32-conl7-wkfwm-gd6uq-lhvpn-s7h5r-qqe",
@@ -24298,7 +24298,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "dnorv-obqlt-6fl2s-ylxsf-o6pwv-fssdj-63kdj-jjw5d-luhdg-xe2zn-2ae",
@@ -24318,7 +24318,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "dnt7y-wwa7a-6kdko-zjtn6-nkahd-cfcn4-yw5ai-pc6jg-6g46r-qq6jr-uae",
@@ -24338,7 +24338,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "dnxq6-e2xox-dtmag-4ofwe-xfyko-iqr4i-zewbt-raveo-dipyk-zbjqq-rae",
@@ -24358,7 +24358,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dnzlh-asluj-sy4zh-brf5z-datjd-xilz7-myh6s-2rbr3-pr224-qmip2-vae",
@@ -24378,7 +24378,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dofld-ghkjo-hynoo-myl2n-mgqql-vsbou-5sowc-bcwtw-u4sr7-4w4dy-nqe",
@@ -24398,7 +24398,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "dpxqr-vscc4-sslft-6b6hn-gk344-rqsok-j65xm-3lrh5-p622q-ezrbs-bae",
@@ -24418,7 +24418,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dqhdk-ebgsg-zvcgz-wbwja-xdmng-li73v-yrkd2-mblw5-li2wp-blgx5-eqe",
@@ -24438,7 +24438,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "drzg7-h3kkr-xhdkp-4lxzs-2fxkt-a4y6t-vlhwz-syroq-qm5bc-fti7s-wqe",
@@ -24458,7 +24458,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dsnjt-rnuu4-vcgrm-wacun-da4y5-emipr-6bw7s-rxogu-7o2f3-a6zwb-yqe",
@@ -24478,7 +24478,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dtf67-kbgf3-apiap-nxgwu-wtt3w-53scu-ep2yk-rfqm2-ccwod-jkdsh-tae",
@@ -24498,7 +24498,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "dtils-hheoo-rdblu-kev3g-qhdea-mb2oq-zgl2c-osrlf-nkimi-5ws23-dqe",
@@ -24518,7 +24518,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dur57-qqxpo-wmql5-bd7cz-atitx-5ivxi-ht3ni-lvb43-ms4w4-uyep4-iae",
@@ -24538,7 +24538,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "duvf4-lt2kx-alax2-hgno7-qwwxf-pkuxt-fgwwd-m6tmw-3krjd-mqdzn-2ae",
@@ -24558,7 +24558,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dv3v2-2mdnd-4ftxk-pahkk-ljuoj-jxafe-6acsz-c4xds-plvg7-635u6-uqe",
@@ -24578,7 +24578,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dvdas-vs7fs-trmi5-fz2pa-bl3uc-ivkd7-r36gh-d3qza-4wms2-7wpth-zqe",
@@ -24598,7 +24598,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dvjhp-rndgl-zxrkg-aspaw-2iaif-r4t5j-u5pg2-qhzqh-vspzd-dqzr5-tae",
@@ -24618,7 +24618,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dvtqe-tiij5-cthxl-ccixf-7fymg-2iuh3-dbdup-zfnmc-5myo5-vjdm3-nqe",
@@ -24638,7 +24638,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dw4n2-nufrb-4gava-m77lm-eg2wh-vpxjt-pztrr-el3sc-g7yp5-wkpmo-zqe",
@@ -24658,7 +24658,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "dyycg-wc45f-jwks2-abddo-m3n5r-o5kxy-g5xhm-7ve4u-3tlk7-i7xec-oae",
@@ -24684,7 +24684,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "dzol4-3eqco-5b5ag-ritui-tyl7u-i3iwz-ex2qo-cbfjx-5fmxw-yfgwo-tqe",
@@ -24704,7 +24704,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e3l2o-4iy5c-43qaf-uvxbg-5slee-26j3w-iwdn3-ynwq3-z3ykg-kfzmo-pqe",
@@ -24724,7 +24724,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e4lrn-efnhj-r3niy-vyxey-rp5mc-mfjf6-flk7a-q23ir-dcy56-6tmsh-mqe",
@@ -24744,7 +24744,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e5xk3-7dbi6-2zaxv-7ng3v-if5va-yktmq-roase-rqvx3-dii3z-2kh3r-vqe",
@@ -24770,7 +24770,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e6334-h54qb-rfmfa-kktez-s5tjs-q2ihe-fazyk-ybuo5-leln6-v3cfi-dae",
@@ -24790,7 +24790,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "e6qmp-abz5d-6xvm2-4knuj-s4nph-cs3nq-2vwbp-ht7up-tui5u-jolgt-oae",
@@ -24810,7 +24810,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e6yck-mgdes-xulju-46dpm-7ve5p-ffyxn-rh7je-sbfca-62rfh-he5ju-gae",
@@ -24830,7 +24830,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "e7kni-7gwhh-5hzoq-uhpvf-fia4z-fxfnq-dnmz4-7rwrc-ytmxi-penyr-hae",
@@ -24850,7 +24850,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "ea7i6-qcgpw-gmyki-6ihrm-uhcp7-i3hkc-7jct6-wifor-zyzz4-tdxcy-aae",
@@ -24870,7 +24870,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ebtzo-pas2n-2vl7g-fewl3-gbgvx-ixnvi-fqud7-efxx7-cawfg-xqjli-5ae",
@@ -24890,7 +24890,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ec62l-q44va-5lyw2-gbl4w-xcx55-c3qv4-q67vc-fu6s7-xpm2r-7tjrw-tae",
@@ -24916,7 +24916,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "eceha-hucmg-fkxaj-2dvzr-vg2xi-jpacq-rqczr-wf2fk-gc2zw-hy73j-cqe",
@@ -24936,7 +24936,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "ecxbl-3dp33-mpskv-yvs6f-674ct-tpr4d-dhzdg-jfgf4-gzhny-n6zzx-lqe",
@@ -24956,7 +24956,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "edmjn-npvdy-gn3rw-jix5y-da2ae-qb5dh-th3p3-2lkrb-c6prf-tnx7r-zae",
@@ -24976,7 +24976,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "eexw3-cwz3z-6antd-yoyyc-radeu-jmt66-7p2r7-kjbkn-cij4b-kwqrb-tqe",
@@ -24996,7 +24996,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "efdju-ef2ce-a5jdn-obybl-x6ema-h5lwv-nc2sy-v4hvc-7nltm-aldtv-6ae",
@@ -25016,7 +25016,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "efnid-smcmg-3orkr-3csy7-yo6jp-4vejo-zo2xa-zobrf-qkez7-5y3ui-3ae",
@@ -25036,7 +25036,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "efwaf-xbg25-6hqec-pjsqp-fon6d-hdljb-5kxeh-qjzku-yxaiy-6jwim-sae",
@@ -25056,7 +25056,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ega5w-ekfo7-lejfc-fve6j-vnml3-2nmxj-flw2p-564o4-rhier-bz73x-aae",
@@ -25076,7 +25076,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ehorg-uqvqd-ddlfa-nep3y-kq34u-j7zpx-ukwak-j47hn-x4az2-zzsoo-hqe",
@@ -25096,7 +25096,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ehshg-qtj5n-d5cdz-vaaec-665ol-7akv5-atlvm-jmdkw-5lo4t-rqiac-qae",
@@ -25116,7 +25116,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ek3yy-o3qk4-xivlj-qik4h-tgbwt-kmyyv-po3lm-hhwll-o7p3w-qrc4s-hqe",
@@ -25136,7 +25136,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ek6px-kxr47-noli7-nyjql-au5uc-tmj3k-777mf-lfla5-k4xx4-msu3j-dae",
@@ -25162,7 +25162,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ekb3g-ilkro-nv4is-grig3-7islk-ne3mg-dug4z-yic2v-bavr2-eoht2-bae",
@@ -25182,7 +25182,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "elons-ke2ex-4ykad-warsf-bi7zm-oskxc-un44b-phznq-sovqe-ko6u3-nqe",
@@ -25202,7 +25202,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "elru4-sjdrj-2rqqx-5lxfv-3i5dw-ktzok-7kr5v-un3y6-pubcf-7x47m-zae",
@@ -25222,7 +25222,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "engai-flho6-5z6nk-4eirk-ozvgk-z73wc-bgayv-lbnls-djvfe-lheum-jae",
@@ -25242,7 +25242,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "epwlh-zpyza-66uqs-7zrr5-hvtpz-srxfs-acqqj-or2oy-zvky3-3eo2q-6ae",
@@ -25262,7 +25262,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "eq4pj-hov4w-yqrfn-dcmqu-4vhge-ehqcb-2jwk4-xlj5x-6wiiy-fq34w-zqe",
@@ -25282,7 +25282,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "eqe4v-xnyd5-sqimm-7qxav-sxmuf-c5jjj-bpqq3-ccpso-g6jqf-2a4yo-bqe",
@@ -25302,7 +25302,7 @@
       "dc_id": "rg1",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "eteye-hwqyn-n36jd-isvcm-qxddm-jyai6-r5zvb-xnmd4-p7gye-x6cyz-7ae",
@@ -25322,7 +25322,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "euo2x-vl67u-3vtja-yrovf-oah6r-pq43e-pn522-j3zq2-pnly3-ad7wd-lqe",
@@ -25342,7 +25342,7 @@
       "dc_id": "pc1",
       "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "euxfw-h5vh6-yanrn-zmii3-367tl-mg6ts-miwr4-mw4vn-piokc-cpadh-eqe",
@@ -25362,7 +25362,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "evzjs-isno2-z6ieg-4uvkn-bo7py-6sqvy-imluo-zaysi-4za6p-b2kol-yae",
@@ -25382,7 +25382,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ew5us-dwxat-fg6sp-opp2j-fjjg7-rcmyj-d3saj-vyych-f3keg-5kor5-yqe",
@@ -25402,7 +25402,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ewqex-k3sni-u76lw-fvby2-5wrnp-xiutz-mk3lr-ij6i4-cxitd-i2i7j-lqe",
@@ -25422,7 +25422,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "exehb-mlnhg-4x3cl-xqupj-hkj5q-ospee-g5qu6-sptaj-cpgro-4o5pp-yae",
@@ -25442,7 +25442,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "exk6f-v2scl-a77ea-mmykb-rmogm-66rct-usltz-x6pdc-5g3y5-yiw7w-3ae",
@@ -25462,7 +25462,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "exztv-hm2d7-ewdzm-5chfw-ej7vw-asjxc-ch63f-27j7c-ydije-kd3fs-hqe",
@@ -25488,7 +25488,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "eyptb-kcbkl-xpjgi-jwkwk-65t5f-43n6h-heu3x-yz4ua-tovg4-dmnzu-2qe",
@@ -25508,7 +25508,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f3t2w-pzmmm-65xb6-u2afi-y2ewh-gwvto-f7qtr-2xhv4-awen7-m3cdg-lqe",
@@ -25528,7 +25528,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "f3wp4-qtj2k-tbqy3-vnqsc-gs5cr-sle5o-5oqt6-egtd5-wzpmj-5eett-cae",
@@ -25554,7 +25554,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f3zwq-g3ap2-42acw-twrar-6wire-5uhtr-qyu2e-v7vl7-43e3b-kdz7g-yae",
@@ -25574,7 +25574,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f4xs2-aejji-yt4ks-7sjyb-g7zxl-ayuc3-lw6tv-khrii-nlh7j-ttbqy-zae",
@@ -25594,7 +25594,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "f5oio-ueraf-qy6r5-3t752-nnvzx-ejpjp-lifky-7iosb-3ygx3-n6jsp-sae",
@@ -25614,7 +25614,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f63hs-lnxxy-icsqv-j2wkr-aly5f-piig2-ptkk5-c6x4y-px2tp-gx67m-jqe",
@@ -25640,7 +25640,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f6etz-5w6fg-ho2uo-gjklb-7oxto-i2z2u-udqih-6evln-4tb5s-iliw3-7ae",
@@ -25660,7 +25660,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f6t7n-kbwd7-eubkb-2xnum-jazbs-p7b6f-ki2pd-3zr3o-uug4x-am7ct-wqe",
@@ -25680,7 +25680,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "f7hyn-ga437-hpalr-zqueh-4v4fr-zvt7s-galuf-fspe5-fnd6w-rao5b-gae",
@@ -25700,7 +25700,7 @@
       "dc_id": "mtl1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "f7sy7-pxmea-oeadk-3zrl2-wuqox-l34w4-bd7bv-qj2gf-vl3ug-2wfc3-bqe",
@@ -25720,7 +25720,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "faagt-367l7-6h7sq-fqen3-2pn5m-cvfbr-dsfme-zv5jv-p6fj7-owatn-oqe",
@@ -25740,7 +25740,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fabpy-po455-j7im4-iisoo-hrsvg-4nk6z-srkn2-yzxba-vmeoh-wmg42-kqe",
@@ -25760,7 +25760,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fdqs3-2kjnz-uhrfj-hpkj2-mkhj5-jx4oa-l5uod-yfdxc-xuzap-ke2lj-vqe",
@@ -25780,7 +25780,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fdunq-3nknr-3nex5-eravm-bauyc-ry3fs-mncyc-nzp4b-4prvk-4grhz-yae",
@@ -25806,7 +25806,7 @@
       "dc_id": "fm1",
       "node_provider_id": "hk7eo-22zam-kqmsx-dtfbj-k5i6f-jg65h-micpf-2cztc-t2eqk-efgvx-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fe7vt-yjpwr-js7dn-62rht-w46qq-kbxls-ujd3f-bgotr-hjdzy-wu5kq-vae",
@@ -25826,7 +25826,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "femah-ntebg-2txyb-6ixyr-kl62n-aoqmx-pxu7y-imzup-o72wc-qfosh-kae",
@@ -25846,7 +25846,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ferrg-aq26k-t2qpp-56xzc-tmf53-i3bif-ktx4a-axdhj-ecykc-77zwa-hae",
@@ -25866,7 +25866,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ffwq3-4qc6n-hqj33-q3ei4-fqhki-y6n7f-gva4p-mr727-jdk4u-g47va-eae",
@@ -25886,7 +25886,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fgia3-griks-i7sua-ejuw4-gcknm-45oqb-j5sgc-u6fpm-32lac-qypz2-pae",
@@ -25906,7 +25906,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fh6lp-xtfi2-7aa22-dsx64-hs42f-hc2a2-wfqsu-5rvnk-7wcf7-yu6cm-kae",
@@ -25926,7 +25926,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fhg3q-muslh-pp7ur-hcivl-q3kof-mju7a-kjyyf-hjifg-nsa35-nqjv3-7qe",
@@ -25946,7 +25946,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fi2eu-lgaic-n73rv-dsfr6-52z3t-7eto7-pmdg7-r7o7n-agotm-zw6o5-tae",
@@ -25966,7 +25966,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fistr-5k762-tgmcm-jfqay-35nkt-nbjvg-3kta3-l74fi-2qr7j-tqdez-5qe",
@@ -25986,7 +25986,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "fjk4e-wq2k5-67aco-gje5i-fvjwe-7jgcd-hgf4a-25kq3-ojhps-wzvsu-yqe",
@@ -26006,7 +26006,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Degraded",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fl2ks-flv23-luwoe-t3tza-xmurj-aa3ts-bcuda-gpz53-gnnfn-xzm7x-4qe",
@@ -26026,7 +26026,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "flc7j-p6oyd-c5hbs-f5h3s-2lgxj-ryled-d534j-wd4em-jujlp-xpno2-jae",
@@ -26046,7 +26046,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "flwxw-xfnwf-rrx6p-zz3p4-eewsc-cm47m-cnjsa-qxn5x-obwat-rzfex-vqe",
@@ -26066,7 +26066,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "flzwv-lslut-uvzxu-nrlrj-64b4q-om4c6-amsu4-nswej-io3nd-4gkkg-6ae",
@@ -26086,7 +26086,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fni34-xs5zz-z6t63-2gkxo-2fzxa-zery5-guujj-fbixf-lnqsd-ixwjs-bqe",
@@ -26106,7 +26106,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fnopq-cvgfn-6d32v-y7n5g-kkq6x-kpmce-7tqx3-esaht-b2ovh-qhznv-5qe",
@@ -26126,7 +26126,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fnrbk-fcjhe-lasnr-pkoim-w7quz-i7nfr-pv4tz-kl4jz-homax-6towj-kqe",
@@ -26146,7 +26146,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "foa3b-mjkuu-3qlgu-6o64i-2omzt-x6suc-5gzcq-6j2gz-bftru-j5idg-gae",
@@ -26166,7 +26166,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "foasq-jql3g-5njm3-75iv5-5zlx3-lbods-dnsbj-k7srs-3isgp-k4wlo-tqe",
@@ -26186,7 +26186,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fopwg-cu6ej-o7qfl-zuon2-ia7lv-qre7y-hotf6-bs7wk-aj4we-nf646-dqe",
@@ -26206,7 +26206,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fpjx3-tfebc-csio2-hxi4u-7jomj-p4c4q-b66xe-ngut6-yi63x-keuhl-6ae",
@@ -26226,7 +26226,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fqczw-cfksr-xl2d4-5bubi-2am2s-znzzk-k6tma-5o6dq-hmvnc-rjhfs-wqe",
@@ -26246,7 +26246,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fqsoy-ydsec-w36cf-sc727-7ll46-pbdbk-dn4d6-lypyf-p74lq-6wzlz-lae",
@@ -26266,7 +26266,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fqxyo-ua4oa-73v6o-gwpwj-pd4vt-eb276-bjjab-4vfhi-7izzl-yhqod-2qe",
@@ -26286,7 +26286,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fr3jr-74qz3-jzmga-mpt7c-eipd7-numir-hpczg-egnrw-lrrrh-2f7ws-qqe",
@@ -26306,7 +26306,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "fsm34-pu4a7-dpo5w-efe3l-s633z-wfvua-sbzid-nsoca-4mrrt-23ice-zae",
@@ -26326,7 +26326,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fsqi5-jxy3h-7enjy-d3734-zqvvu-s6nmh-o7xyk-6ahom-ecorw-o4oro-mae",
@@ -26346,7 +26346,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ft44n-3qcdt-c47xp-npyvd-uhufm-2eplp-ntxee-wewmy-d5sun-7wr3r-dqe",
@@ -26366,7 +26366,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ftgel-apwfx-aqphw-6itlw-as5il-53hfx-mtpy5-djn6y-7a6fa-3nqrs-5ae",
@@ -26386,7 +26386,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ftqjb-3dzjl-p7eht-uto3d-chaan-ei76y-ledfe-4suow-izc2c-qjddu-5ae",
@@ -26406,7 +26406,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "futx7-t4jgx-gpahv-3qlcz-kccjv-q5jeh-a3uji-47hu3-j7arf-yzkat-uae",
@@ -26426,7 +26426,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fvy7i-ux7is-cuvfm-2n2zh-5lpb4-oe2vz-bfnhz-oi5s5-jkzhk-phlj2-gqe",
@@ -26446,7 +26446,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fwnqx-jxuot-uycx5-pyah5-zy2cu-zy6n5-ppthe-d5gp2-shzri-lsxf5-kae",
@@ -26466,7 +26466,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fwpkp-tbgp3-rhl4h-njm2i-ebtn2-5susq-o765o-hjop2-qktc7-uo2kf-xae",
@@ -26486,7 +26486,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "fwtil-kx6r2-uijg5-u4sc4-mijm2-tdtov-kwopr-bhbm2-ksk2d-c6l47-iqe",
@@ -26506,7 +26506,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fxdqu-epq5z-kmnok-ch46f-jxujv-of7ws-3ec4b-gszap-gtklj-sxfiv-wae",
@@ -26526,7 +26526,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "fyiyj-zcwb4-frfxo-g6ocs-bddkp-lb5il-mlk2t-zofuz-rizw5-azknq-iqe",
@@ -26546,7 +26546,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "g2cpu-evuez-tk76a-n54kf-nxeik-c5b5g-hpdxo-sqlq5-st2ov-4xgzi-hqe",
@@ -26566,7 +26566,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "g2yrq-l6heq-ztxzm-fd6aa-piqxh-wno3t-q3bhj-5qvd5-vukzm-z4bjx-kae",
@@ -26592,7 +26592,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "g3ug2-wz6kb-unyk6-6mj4f-halk3-kkfvi-k33iz-fftob-qipom-t4kzr-qqe",
@@ -26612,7 +26612,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "g4avo-ecrmg-ki3ol-dxah7-zksar-suefa-26fco-fudva-ajioq-xvhmq-4ae",
@@ -26632,7 +26632,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "g5zt4-f3nhd-aquto-6vecp-tnrxe-gexie-kk7fk-znuxf-45cav-zcnlz-zqe",
@@ -26652,7 +26652,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "g6qhu-4qwhq-w4ccl-5355c-fbghd-xlo4o-4h5lv-wkfrn-gxd33-6elc2-pae",
@@ -26672,7 +26672,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "g765q-rteh7-xio4e-vtyea-ww46p-beylc-3e3s3-yhvuy-in6jd-hj5qo-3qe",
@@ -26692,7 +26692,7 @@
       "dc_id": "ba1",
       "node_provider_id": "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "gbsw6-cw2nh-vwjir-vkmwb-x5vgm-24o4r-7umgj-noeim-zd2pq-esiic-zqe",
@@ -26712,7 +26712,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gby4c-h4c2r-r6kl3-uecfq-itfw7-muowp-e5imq-d7w5o-5hat7-zuwya-3ae",
@@ -26732,7 +26732,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gc7j5-ullnt-he62c-pzbe6-bwvba-2jh7m-g5f5a-u2haz-nhwif-52nfa-bqe",
@@ -26752,7 +26752,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gcvdm-myudq-43jn3-cuumr-ci6cb-p7swf-hk2d3-wz7ei-dbgbu-gpc63-3qe",
@@ -26772,7 +26772,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gd2vp-cewud-bap4i-b3vb4-jbxhf-3ojbk-d2n6l-wg46d-vcovk-bjwyz-tqe",
@@ -26792,7 +26792,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gd36t-bwrnm-qq6rg-sas4p-6uabz-qki2e-nrq2k-sp6dj-l2lxa-5tavx-7ae",
@@ -26812,7 +26812,7 @@
       "dc_id": "wa1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ghmoa-vaks4-tubtk-z3wml-wglax-lrfzt-6lh7y-uwgzg-ly4iv-zubjh-iqe",
@@ -26832,7 +26832,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ghwbi-m4ch3-f252p-czcmv-ppibh-52ucu-e3rfi-6bjib-izssn-jeh4q-eqe",
@@ -26852,7 +26852,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gig74-6ptil-h6yyp-z45so-whc45-6czqc-sodt4-7ktp6-yvjou-3pnfq-yqe",
@@ -26878,7 +26878,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gj6gc-mbslq-bt63y-72b7h-xs2xw-6vyuj-frvp3-tx375-dsqx5-wem6o-vqe",
@@ -26898,7 +26898,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "gl7lj-56i4v-i22vw-lzoqk-pbojj-xg7lt-7vxow-c3hi3-amsop-hfbog-tae",
@@ -26918,7 +26918,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gn36d-h6lnl-aojm5-5bztb-pm7nm-sha3f-a7lui-epylf-dpvsw-hz6mc-qqe",
@@ -26938,7 +26938,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "gnagd-f5kwr-7d2i4-e36x7-4tj7p-t4oki-4kvlc-pvnqr-annsa-sgawm-6qe",
@@ -26958,7 +26958,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "go5zz-xs6yg-mylwl-v7uob-7bg4b-wjzhe-vmrwe-uy7mz-ckaz2-idm33-rqe",
@@ -26978,7 +26978,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gogli-5653n-elex3-qlpqt-57upc-ahqpe-jel3r-jks5y-yy2ak-5zcgu-hae",
@@ -26998,7 +26998,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gojj3-3h3jg-rm33m-ces4z-bzops-c42hx-kwpjy-vm2ev-bfpzk-ednuh-gqe",
@@ -27024,7 +27024,7 @@
       "dc_id": "fm1",
       "node_provider_id": "hk7eo-22zam-kqmsx-dtfbj-k5i6f-jg65h-micpf-2cztc-t2eqk-efgvx-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "gp2km-rzw5z-latpo-vp2m3-jdfqv-khn3m-i7l3z-nygeu-q2bfb-7aw5i-uqe",
@@ -27044,7 +27044,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gpoip-fc6hu-hodbr-dketd-laeng-pcr2c-mmrdx-6bv66-3yre7-dbqsd-4ae",
@@ -27064,7 +27064,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gq6yf-rrosa-rjsoz-djf7u-dvbef-n7cey-pbta2-ayksv-ztr3o-46vah-iae",
@@ -27084,7 +27084,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gsrhr-kwp6h-y6ibc-yftud-fzi66-vg5df-subl3-wiren-uzza6-rb5fc-dae",
@@ -27104,7 +27104,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gsvxv-tou7p-drlxw-rnldp-m7z3n-e42j4-nrsp4-dzsfc-7wuqr-2qwpf-pae",
@@ -27124,7 +27124,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "gta2q-oossu-kbd7c-zopt6-exsos-n6ozf-rp3bx-k6g2m-ehgov-m3vk7-7qe",
@@ -27144,7 +27144,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gtc2a-34z6k-mld77-aucld-n6l4v-yv5hz-mon2d-narwo-b2z2k-thpyk-uae",
@@ -27164,7 +27164,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gutgu-ny3sz-dcgfv-ejg4j-myln6-oafpl-zex4x-rofpe-nmb6d-5b24k-hae",
@@ -27184,7 +27184,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gvm7l-ds4n6-vkyjn-gwalp-3vdo6-qfmq7-pxhu4-zvqcu-ozvb7-qz3gr-vqe",
@@ -27204,7 +27204,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "gvqb5-b2623-3twpd-mruy4-3grts-agp2t-wgmt4-hspvj-5oyl6-kje32-aqe",
@@ -27230,7 +27230,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gyty5-impo7-5uugu-2ocbi-ekcg2-eloni-cj67g-vasbq-i4z74-2bhpw-7qe",
@@ -27250,7 +27250,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gyw3i-vkxuq-lgxdd-su6xx-5bzyx-ywbu3-omtb5-mjweg-cisfs-kskwh-gqe",
@@ -27270,7 +27270,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae",
@@ -27290,7 +27290,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h2cfd-cqlyj-nu7rj-irpvy-ybq4h-x2nxr-zlelh-en4s2-f36vy-oa3it-rae",
@@ -27310,7 +27310,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "h3g2z-jgfid-7hvbw-jyfw7-4jiza-iyy4w-bvx44-nizgh-kct53-ffjtz-lae",
@@ -27330,7 +27330,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h3gd6-r6oc7-om7g2-2rlvu-dxqc5-moweq-tu63n-ffdcp-5kobp-mvdin-xae",
@@ -27350,7 +27350,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "h3iv6-ezskc-3ij4j-zd3le-hld6d-hkuxx-dj6zq-w7rrd-gziap-a23ob-dqe",
@@ -27370,7 +27370,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h46do-f3rxf-puasi-4uipi-5ymgk-s3rrv-yazcy-darzs-manii-si7hg-gqe",
@@ -27390,7 +27390,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h4f2h-szkhd-6bdx3-r7z3i-dtcd4-nked4-6a7v4-43uxy-mffxx-lyunt-gae",
@@ -27410,7 +27410,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h57j6-72adp-jfeng-6xb5w-mqsgt-srmsc-gny3c-unzsx-fqrvu-ggao6-yae",
@@ -27430,7 +27430,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "h6f4o-rlx45-6w5m5-posbc-btmsn-ffrp7-nzc3b-unl2c-sfjof-4a2x3-oae",
@@ -27450,7 +27450,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h77ez-pu3yg-ykizd-disqb-55kzm-ag6ot-iggcn-7vxlt-vpzdt-kj7ac-tqe",
@@ -27470,7 +27470,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h77iq-mcl3p-2cjof-guum7-6cr2e-hwfie-rrps7-osazu-f2kox-e2kfg-lae",
@@ -27490,7 +27490,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "h7ovn-6wnuo-lcloj-v4qnh-p6rc3-dxscl-sxgtz-z36fp-io463-xlm7w-wqe",
@@ -27510,7 +27510,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "haeka-mchv4-zwg3j-d3sz2-k5z2x-ulfmb-kflyu-ezzlz-ckc3d-ako5j-uqe",
@@ -27536,7 +27536,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ham46-r7u4j-yoyrk-mrnxu-utzq3-c37he-vcns2-gc5yg-jxyv5-mvlhc-gae",
@@ -27556,7 +27556,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hcjwo-3h7be-ds4ff-dasid-xbp6i-4uxxq-s4dmi-kwf5g-yzvyy-wakil-hqe",
@@ -27576,7 +27576,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "hcvph-gzlqc-5ogrn-seple-vyr7i-gzgzo-eencn-dq2bp-kr4hx-4cujp-lqe",
@@ -27596,7 +27596,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "hdi6e-jygh7-ybnp5-vysoj-ppbtl-z5y3b-uguly-zi46v-7hufk-3w4x7-bae",
@@ -27616,7 +27616,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hdkxy-jonbm-voico-5u7px-6vet6-6i7zx-xm65d-gdswt-2uvss-5o73g-aae",
@@ -27636,7 +27636,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "he6uv-j2zgd-zw67j-p7znr-6qbcd-nf2ce-unue6-6arrl-l4cc4-b3md3-qae",
@@ -27656,7 +27656,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "hes6w-pmcrp-mml4m-mgtqo-25yxp-x6nwd-oygpv-i23gm-l3clq-vsm4r-rae",
@@ -27676,7 +27676,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hgbum-72ne6-onsua-rjul3-siwu5-da4zu-wkqro-rm4el-52osh-bhkgi-dqe",
@@ -27696,7 +27696,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hgvcj-xdftg-62bcj-s66dr-rsshe-rmj6x-mzlvg-65ytj-3wapx-ig6js-mqe",
@@ -27716,7 +27716,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hh3fs-nqx2d-wp422-ln2me-chxi5-o2tkd-7zqxj-ev7zz-a33pz-zjfqz-yae",
@@ -27736,7 +27736,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hhau4-uativ-guor2-rm5ip-omduw-lunoa-lfbnf-kwxm4-4h4lc-edmhy-4ae",
@@ -27756,7 +27756,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "hhixb-o5xrj-s5pty-esitz-m6s46-wgsez-c7thd-6h27w-7hikq-ae5n7-pae",
@@ -27776,7 +27776,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hho73-ab64i-p5e6m-fotpu-gnbzo-hnytq-4ptxe-3uovn-vkii2-ammf6-aae",
@@ -27796,7 +27796,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hieqj-frwxa-nqiem-krmuw-yvstt-wpmrn-wdeys-6mafh-o77rv-gxc7o-dae",
@@ -27816,7 +27816,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "himck-kjpb3-eih7e-knfcr-tkz7f-qzx45-i6xwm-obvn7-fw2hv-2zuy7-aqe",
@@ -27842,7 +27842,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hizzw-uvqcw-rvn3v-hculj-rrsc7-fvq2c-nzsjr-jvymi-5ilat-bvvci-kqe",
@@ -27862,7 +27862,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hjyoa-cp5ty-2tgzm-faroj-kqucq-y34ll-udlth-3bb54-vyohg-vi3uh-wae",
@@ -27882,7 +27882,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hkxdh-3szbn-azhfo-lnd5g-5d2bm-oqvbf-bzn73-ou6bv-g5ykp-63xwd-uae",
@@ -27902,7 +27902,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hlc73-cklhu-zo4mt-waxb6-ew5tx-gm4or-coy2j-xnwmy-xsycn-j6f4e-iae",
@@ -27922,7 +27922,7 @@
       "dc_id": "hk3",
       "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "hlja2-v6mq2-sevzz-6xis3-jz4pf-ruv4y-agyxg-amoof-4q4rk-5af3e-mae",
@@ -27942,7 +27942,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "hm6f7-as4t3-33b2a-msirw-hhcc3-eq6yq-uoamo-eif7z-5d35z-u3pqd-yqe",
@@ -27962,7 +27962,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hm737-i74rh-gzhn3-2zcgc-wmxxp-2jnz4-67uix-jhfal-dcvme-waodk-jae",
@@ -27982,7 +27982,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hmawz-c25wh-ym2ei-c6idk-gkxvl-ndkvd-cipd2-a4rzi-xdlmx-nzw2t-4qe",
@@ -28002,7 +28002,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "hober-6po5w-o6flx-nxc4v-pr5j7-g423z-i72ls-rxwtl-ghabg-p75vf-iqe",
@@ -28022,7 +28022,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "homco-ylwly-a2s5t-jfqqo-jtmkk-igkpt-txr4x-7q6ec-wzehg-nrv2j-wae",
@@ -28042,7 +28042,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "hpzzc-k3fx7-axrfu-a7rvn-7wyg2-ht3iy-kvo56-35mql-enlzd-zokzs-sae",
@@ -28062,7 +28062,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "hqae2-pa3fc-ono42-wr7zv-wmkhx-cte2t-ehh4m-6sd3m-lzy4e-2iuu4-kae",
@@ -28082,7 +28082,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "hr3lj-x426p-5hbqs-7yezn-5xyz2-bovpo-zc4rd-4rkhd-urqct-ksck3-4ae",
@@ -28108,7 +28108,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hrdy4-ydse4-sko2n-rnvds-5ng7t-nc7ue-ivcxo-umbu5-zed7s-z5t3d-xqe",
@@ -28128,7 +28128,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hrhn3-gzwom-ni6br-ywxaj-55bk3-gkh2d-ckb5s-4max7-xpnep-7kafw-eae",
@@ -28148,7 +28148,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "hrwre-w5bau-c6kvt-cvwez-uj3lw-heogn-6tm36-x4fw4-drqon-pogfe-wae",
@@ -28168,7 +28168,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hyaqw-7b5n2-3w6is-cwxcf-7zszi-mnpzl-kegxn-mc7qk-6vz5z-ig62w-hqe",
@@ -28188,7 +28188,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "hynox-ylkrb-t5vyu-lxjrl-mqq6m-jzrur-dnlon-jp32u-j6lrz-ugzrx-oqe",
@@ -28208,7 +28208,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "i22yb-niksa-7n5xn-7i6ha-6duwj-kneqt-gikln-auy4j-tjk2b-lms5t-hae",
@@ -28228,7 +28228,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "i4cms-qfadk-cu43m-ifv4n-6s3oy-h5uwm-gsheq-jvio6-cs3sn-7mzcs-vae",
@@ -28248,7 +28248,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "i4zve-soi3o-vqbql-gklv5-dbklt-g43ha-k3ju6-vdlrf-5t6lu-pyl3j-xqe",
@@ -28268,7 +28268,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "i5kts-s424n-xg4np-i2wnx-lbb24-d7imi-veczd-l5dwq-4bvi6-ltdpg-7qe",
@@ -28288,7 +28288,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "i5xgw-uzqkn-xrfkd-7nqdz-3yvas-lujhr-mvs5w-sxv5u-m7zrn-hrd2k-pqe",
@@ -28308,7 +28308,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "i7zdo-qrk2t-phjla-2unbd-p76z5-eg2m3-yko4n-5dclc-rewwh-t33gv-wae",
@@ -28328,7 +28328,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "icbco-xw6zg-wlhyp-juqf4-h5gbs-jjein-nmc6n-itoxd-o52q7-q7fjz-gae",
@@ -28348,7 +28348,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "icl45-5n6st-mi35c-d5w4w-xyrww-chwnd-qbsqd-fztab-xeu6a-wck2c-2ae",
@@ -28368,7 +28368,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "icugg-43t2k-gtsxz-ky3fe-yfwpx-h7fi4-5cc52-ru5gu-ivho3-a6pnj-7qe",
@@ -28388,7 +28388,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ieaic-obdck-f2vgl-nouey-jjh4k-oy7tm-3g6yo-l6uuc-y2oot-nytkj-hae",
@@ -28408,7 +28408,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ieou2-4zpdp-4nkfc-nloch-f76bm-e6e2g-cfwv4-mbsdh-twzth-piqyp-cqe",
@@ -28428,7 +28428,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "if4w2-pekba-btwrw-6rlcx-erlgo-fdvuq-qlaa7-en4bx-iedqt-nrdo7-pae",
@@ -28454,7 +28454,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ifjiy-lj3rd-oxu4i-24bwr-tavxd-ga6iq-fjvne-gmeqr-krifm-r5aas-qqe",
@@ -28474,7 +28474,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ihb24-7542u-a5hwt-le3wd-ion4f-wbduk-yawte-kaxrd-bv5kf-7jyld-bqe",
@@ -28494,7 +28494,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ihoip-fmbnl-mm4fa-pu7hu-2sbx2-mzl2f-tgzje-unnjg-bgcac-3apmo-gqe",
@@ -28514,7 +28514,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ihom5-j3jpq-6a6k3-rjajg-hualw-yhs3j-k7xot-hg2qh-ud3ix-rgvte-zqe",
@@ -28534,7 +28534,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ihttm-45oz5-an5mg-i2jtb-fayst-s47j6-vmuwr-fqotf-mp2il-n5s5x-cae",
@@ -28554,7 +28554,7 @@
       "dc_id": "bg1",
       "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ii5t4-bvjp2-sypuy-pqz6v-v44yf-lzox2-ja3tp-m7gtj-7pszo-fk66d-cqe",
@@ -28574,7 +28574,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "iirmo-i6vu4-jmbkl-pvgwx-zjcft-c2bq3-xg27t-de7bm-icdh3-wfsys-yae",
@@ -28594,7 +28594,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ijend-azski-eod2m-d2lqp-a3y3u-x44xl-7mapp-bjr6r-qw4v5-okx55-cae",
@@ -28614,7 +28614,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ikdvw-5ohcj-bucuv-m2gp3-56pff-ridwp-nvq5u-edpdi-idqzy-qyko3-wae",
@@ -28634,7 +28634,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "in4qi-poj7g-j5gvw-34xys-4cf6k-uki3d-exjzf-th4cu-c5my6-sdht2-cae",
@@ -28654,7 +28654,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "inlh6-ii3uy-bpasa-uzngo-xle3x-d2p2a-ylu3h-neikw-tnmwv-wep5x-nae",
@@ -28674,7 +28674,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "innof-igqna-w2xyu-nzbwo-3ilyf-yxldi-lk426-e2eta-w5iio-lfg5y-gqe",
@@ -28694,7 +28694,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "iqnlc-oy677-m524v-tisrn-3v44n-2eylu-bclq3-fqjtg-4ab7z-ycrie-mqe",
@@ -28714,7 +28714,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "irpwa-t65vg-ellmb-rg37m-ge5or-g3crz-3vbri-m4spq-eldkq-v2vs7-pae",
@@ -28734,7 +28734,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "isct2-mjmjr-ignor-cu6xd-gcxgk-gzf3p-afdwx-x53qf-a2czp-4qhmx-oqe",
@@ -28754,7 +28754,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "isegs-i4akf-kb7st-hnqjn-4col7-qxpph-pncbs-25hiy-5pwsu-nyw3x-xae",
@@ -28774,7 +28774,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "it7l2-t3pdh-odejb-4dpqs-2osfr-w3vc3-42oso-xvzie-dujkr-pnrjb-yqe",
@@ -28794,7 +28794,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "itbwd-42ljt-6wwrt-w4vt4-xbgnu-m32zi-ex3ss-j6df4-doach-da7bq-kae",
@@ -28814,7 +28814,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "itcju-qgal4-v2k63-llj7k-3ntsi-jmhdg-tlkhw-zz4kk-gwfkq-whb7w-aae",
@@ -28834,7 +28834,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "iyujt-qhexa-fsvxv-js4up-di5y2-ezymp-blaoa-on5eg-3jg3m-nlwii-bqe",
@@ -28854,7 +28854,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "izmdg-yz3l4-jp5vr-rva2j-5btpc-bzgt5-7snt4-wwy2g-jaq7v-rzpsv-oae",
@@ -28874,7 +28874,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "izs3i-wcyvp-s47c2-enas5-77nmz-eib7t-3psjt-dsgr3-afgel-3hmkn-wqe",
@@ -28894,7 +28894,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "j3pcf-ielts-wwr24-73hhq-flvsq-d7yh3-ly5li-r6csx-5tczk-wkpc3-5ae",
@@ -28920,7 +28920,7 @@
       "dc_id": "ns1",
       "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "j4et3-lkqhr-32t4q-3o57n-nm7u3-hvgsd-7v574-3z7mj-eyks5-twtxo-zae",
@@ -28940,7 +28940,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "j63cj-up2z6-xh7m5-m2t5m-t4xi6-6tqz2-ibj4a-mmm2s-7o2bv-ynnc6-xae",
@@ -28960,7 +28960,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "j64fo-oy64x-a46se-3kryq-qnx6i-cvqpf-pnxjo-scr4z-la6r6-jthgg-sqe",
@@ -28980,7 +28980,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "j6uir-h4bk3-chdqr-hxnkr-3jp7o-yb3el-skdsd-7oejj-eubk5-5onvy-zae",
@@ -29000,7 +29000,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "j6wmh-nipzs-knprf-tdle2-lwxs2-6vkya-pswqw-zs5wy-ulabv-7vbat-aqe",
@@ -29020,7 +29020,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae",
@@ -29040,7 +29040,7 @@
       "dc_id": "li1",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "j7xyq-edeef-uxics-7sljd-mqq66-u5l5o-d73sc-yybxs-rjawv-muuj4-oqe",
@@ -29060,7 +29060,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ja4ju-swqtu-qpw52-y45ue-qcqev-5fmrj-4shc4-roaqq-owp2c-rbtlc-2ae",
@@ -29080,7 +29080,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ja5ya-ok3gd-d5wwp-3qqfa-vt2b5-gr4ty-d566b-q4xxv-ruva3-ovqtx-dae",
@@ -29100,7 +29100,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jamsd-hvypj-w56fb-4cwvt-tqbmo-6652c-eaw2u-3njxg-5nfe7-ae6ht-bae",
@@ -29120,7 +29120,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jbgo7-cqnq6-mkd2d-fnqf2-6neke-h5zep-jtcmr-ahpnz-5vxox-z7saa-rae",
@@ -29140,7 +29140,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jbriu-rwv4a-4pvxu-grmsy-2lnbj-7t4o2-j2lbe-gkf3c-i73ir-klskz-rae",
@@ -29160,7 +29160,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jd4tu-jujfx-r4jhd-64yek-3s34j-3qw73-443cu-um6ng-6me6p-r5jwl-3ae",
@@ -29180,7 +29180,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jdqro-ad2ju-bncnk-igcfw-u4z73-bckrs-kg5s7-6gxey-ijnzx-vxoir-lae",
@@ -29200,7 +29200,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jemyk-uhint-w6ftv-s3xpy-ne4hr-xbcpu-aqskm-6a4cy-orm5q-aqqwd-gqe",
@@ -29220,7 +29220,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jflaz-mzldr-usxsp-y7vfd-vrdh7-gx3wc-r4ef7-zwowh-knxsd-zuyec-nae",
@@ -29240,7 +29240,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae",
@@ -29260,7 +29260,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "jgetp-jxcos-7t7xy-nhxmv-pgf5l-kbmms-e4wk7-xxtaw-ohuwb-cpqew-xqe",
@@ -29280,7 +29280,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jgpzk-km6t6-aazlm-b2l4j-ky4lv-45ffg-h25ad-dn3vt-ieudg-yqn6x-hqe",
@@ -29300,7 +29300,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jhyyx-r3gnc-cfgnx-ze4bf-sjuef-g6sez-ppjq2-owpid-4meqc-v4lun-zqe",
@@ -29320,7 +29320,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jj7si-b7rs7-nq7sv-npame-aec3y-2anip-ol5s6-gxbh7-kjbg2-a5u6j-rae",
@@ -29340,7 +29340,7 @@
       "dc_id": "ma1",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jk3km-afmc3-lk6bk-ej7aw-4e2md-56ywu-uvolh-trr2p-vs3wf-f6fo4-vae",
@@ -29366,7 +29366,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jkyha-q7dtw-snt4t-w5luy-6bgrk-qnazs-omg2h-4gsy7-plexq-fti6m-fqe",
@@ -29386,7 +29386,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jlb2x-vto3e-r2yf4-adrqu-3gult-4fpun-besaz-4nynm-gcmht-nziru-lae",
@@ -29406,7 +29406,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jlifv-mddo3-zfwdc-x2wmu-xklbj-dai3i-3pvjy-j4hqm-sarqr-fhkq6-zae",
@@ -29432,7 +29432,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jmlvm-7mvpy-zggo7-bke4g-hdt4f-ksch7-jrheb-dupkq-ab65v-xak4a-yqe",
@@ -29452,7 +29452,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jmuoq-7kbey-cbtmm-zlz6t-chwt6-dk7ly-d3jim-5nuu4-y5tou-l5egg-7qe",
@@ -29472,7 +29472,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jo2yf-gx5k2-jtuer-bx6n7-izy7m-nt2hd-bj3gu-oasnv-3uksz-jtze5-lae",
@@ -29498,7 +29498,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jognp-ct5lo-tobx4-fpaio-gwwh6-7aybl-cmmlw-x4oo4-zut5y-rdrfj-6qe",
@@ -29518,7 +29518,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "joich-t5ted-j3ibc-n7ytv-bomzl-jqimt-7gc72-xujql-xahtn-grunf-dqe",
@@ -29538,7 +29538,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jpsem-tybuu-eized-rjwfx-nfy3n-d6mzn-mnbxj-nvd65-25q4a-iem2s-2qe",
@@ -29558,7 +29558,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jpzm4-cwml7-pzodt-xb4sk-qk5hu-m3j4j-ykkhf-3zwww-4dcr4-z3vqi-kae",
@@ -29578,7 +29578,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jqii7-aej7l-ikqzu-tjqof-lejhw-c4nmr-apol6-alysm-koc3u-hwk4t-qae",
@@ -29598,7 +29598,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jsnfc-hogin-macy3-lfird-pfijz-d5jcg-woonn-sbtgx-gzh5h-jjvst-yae",
@@ -29618,7 +29618,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jthcr-uruul-ytxuj-qbvv2-byyz2-tyyo4-yy4ku-2fu4d-aufm7-d5k6l-7ae",
@@ -29638,7 +29638,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jtisj-zmlaj-jkjk4-5pwui-c3mni-esb7z-j2azx-inxow-dxx53-ycrac-5ae",
@@ -29658,7 +29658,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jtvnx-kem2o-icln6-b4oy6-n5ru5-dmksj-dfk5i-4ejvq-k3unp-47gjb-mae",
@@ -29678,7 +29678,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jtxt7-4zrbu-naeyw-kor5w-seylc-jdrgg-xftz5-eo4fa-cfmhm-gs2hy-dqe",
@@ -29698,7 +29698,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "juekk-gtlvt-w4pn6-m526i-w3iya-5p526-ln6dx-tbife-e63eh-n7d7i-cqe",
@@ -29718,7 +29718,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jux3z-ivwyz-ury64-jth4b-rrbfi-sx5af-ci72l-j4ot3-nl5jk-z4ilu-6qe",
@@ -29738,7 +29738,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "jvqnq-6jnty-tr3ml-izvma-e5w6e-s3rfx-w4wir-mwcsf-x5yok-nc4uz-6ae",
@@ -29758,7 +29758,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jwdjd-axlhs-bwg2t-7pesl-56vqi-7yakz-6jthw-4y7v2-ysycv-w4j25-jae",
@@ -29778,7 +29778,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jx6y5-u55cq-nwk3i-niahw-ogiah-vy46i-vq4oa-b7azf-27wgi-v7hhr-sqe",
@@ -29798,7 +29798,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jxgxw-ublpi-lmhwt-jhiwe-fzsnm-md7ni-i4jfx-vitgi-ojusx-vcwxx-lqe",
@@ -29818,7 +29818,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jy5ib-ko6ym-6nbvt-64fzf-2pftz-ggdt7-glldh-oqhoh-jn5zo-schhh-tae",
@@ -29838,7 +29838,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jyh32-azcnn-mwosu-urewl-m3pyx-6pmlq-lu5fu-vqjyl-gwx3j-zqrjr-gae",
@@ -29858,7 +29858,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "jyjmn-pp6dh-2fapa-l67th-dcga6-awrsr-pguqa-yb6e6-dkrfi-izgy6-sqe",
@@ -29878,7 +29878,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k2dew-yan2e-q6mzr-flizg-jqndd-3zcln-zg35a-ejv2j-waiff-le2rt-6qe",
@@ -29904,7 +29904,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k2ovz-ptdmz-hzmkh-ntfqn-evhux-ktxz4-26jg6-qjjsa-rpgal-wkdjo-kqe",
@@ -29924,7 +29924,7 @@
       "dc_id": "rg3",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "k2wtn-hjnup-deyrd-5kvgt-sylmf-jkxjy-efdg5-vedn7-egukh-f6rt4-rae",
@@ -29944,7 +29944,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k3a3l-fnzw5-qc7e6-l2cz7-z426y-7noxj-4yk42-kmsmo-tvgcn-fj6jw-wqe",
@@ -29964,7 +29964,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k4ecc-uo6mt-3jzeo-axsrf-fm4s4-2v2fo-f2hai-nhbm7-ktblp-aixvz-iae",
@@ -29984,7 +29984,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "k6zrw-n3gr2-3wb3v-ejowh-5tw2u-kqbr6-ucttf-hayoz-ebxvi-3wiib-bqe",
@@ -30004,7 +30004,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k7ffp-zum3t-rtcce-kuexb-xloxn-dfp4x-b5i2j-jrh6n-jitao-xm2o6-nae",
@@ -30024,7 +30024,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe",
@@ -30044,7 +30044,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kajie-lx37k-yqw6l-pmzhm-xlkw7-svttg-ju2gr-2yox2-ee6rb-kzx5k-qqe",
@@ -30064,7 +30064,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kaoz3-4okcl-24amq-v5y4k-vim56-4njvo-fwvyk-v4grq-kuqum-7zm3p-4qe",
@@ -30084,7 +30084,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kax7o-5oyag-q7xbn-lpm4d-wkngc-dhbig-ca4sz-kdzkk-kgkln-khtsk-dqe",
@@ -30104,7 +30104,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "kc5j4-yilq3-6v4m7-5ongj-rzlki-t7srs-m7pjb-fa77e-icyep-ptouc-uqe",
@@ -30124,7 +30124,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kdkp2-wa6ak-urj7z-rcaq7-htloq-662lb-3ncuv-z2frg-l6ig5-zqw23-5qe",
@@ -30144,7 +30144,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kdldi-idcju-r7agw-nm3au-un5cc-2zxtu-mtnlv-tzvmt-c5alf-yjqld-cqe",
@@ -30164,7 +30164,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kdowl-chtwc-lkojq-lfb2l-p4w77-35pmk-3ixsh-hqhj3-uxi4k-jh7ge-mqe",
@@ -30184,7 +30184,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ked4e-syml2-ao2ub-xgtxi-awdfd-2vkf6-lbol5-prycv-2vpb5-ws5jp-oae",
@@ -30204,7 +30204,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kegk5-wu5c5-xpe2p-athmd-4dzq6-4gucp-n4ne3-uj2zk-e2jjl-3253l-6qe",
@@ -30224,7 +30224,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "kehk3-dpd75-txcgc-plazi-gsgws-h6krw-lnflf-dr6zt-ly7c7-sohhp-6qe",
@@ -30244,7 +30244,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kgjee-jikca-iirc3-fzwae-v3xy3-fszyp-ya2xc-7dqux-fuvvb-vc5i6-pqe",
@@ -30264,7 +30264,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kgo2t-vidyw-yw2g5-pqwrt-nr227-rbq2o-pog27-zarc2-dfrlw-vvjge-4qe",
@@ -30284,7 +30284,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kj6ep-ztbpa-wppyw-hizv7-pee65-cqmxb-dcdus-bqqnb-wdwrc-yuyt6-sae",
@@ -30304,7 +30304,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kjip6-h5gjt-ewvon-gmcgq-kntdo-4cmbu-krjmh-4vljr-cil44-msizt-bqe",
@@ -30324,7 +30324,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kjxi5-4t256-464kk-mjnxq-vfhje-rjhz5-jamh3-xxvca-unoxi-b2fqh-tae",
@@ -30344,7 +30344,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kjzcx-5a22v-gcxvx-ilfil-mp54w-hlcsh-r4k6n-t36ia-vzoy4-pvedu-cae",
@@ -30364,7 +30364,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kl6gp-pdkf7-w46mu-ndlyt-zxx43-633hw-vwwmp-jfayn-ieo4a-lgfvz-mae",
@@ -30384,7 +30384,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "klluj-vrtrp-k27jr-cb2fm-oyw2o-hrksz-lbojt-xv3ts-off62-cdcbz-iae",
@@ -30404,7 +30404,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "klqlw-riebd-glykt-erwn2-eq4d4-jiupb-w2wyc-4rww3-aiy5p-mbmxg-3ae",
@@ -30424,7 +30424,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "km5kr-aafyx-5dlbb-cl5wq-a5w6a-smv3u-dybbo-i4hv4-w5iru-ey5jf-qqe",
@@ -30444,7 +30444,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "km5ur-yacty-d2nvm-sitx7-zvnw4-bdjuf-lm3qv-vtftj-fv4vz-3d5y7-kae",
@@ -30464,7 +30464,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kmacz-mfqny-43kep-qlrlo-42bgp-njieq-a3jdr-blf6m-6xjtr-c6ula-hae",
@@ -30484,7 +30484,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kmez2-lipof-3kjdn-nt35r-ai7oy-gvxxb-5hkv4-lk5ci-vtjya-hpd6w-wqe",
@@ -30504,7 +30504,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kmy7y-fabcb-mkpuf-4svks-7c7jx-e4zhz-376m4-yhoa6-nps6w-zpm2q-tae",
@@ -30524,7 +30524,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kno7y-tdoxx-da524-svbxm-wt7xn-nyit3-vtsd4-nimle-vahxa-q65e6-oqe",
@@ -30544,7 +30544,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kow3e-amtig-nig34-yagqg-gvpq6-notwj-v4go3-3qnso-ysylr-7zdb4-mqe",
@@ -30564,7 +30564,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kpvfz-zg5cs-5ofal-k5zng-uop7b-gjm4v-z4ug3-sggef-4zu7x-ihvcw-yqe",
@@ -30584,7 +30584,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kq3sv-bziyq-im66o-5jrzn-6uexa-gyj3b-n7z2x-nvdqh-ffxhn-dfrh6-wqe",
@@ -30604,7 +30604,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kq46u-pbywp-uxlqx-uahrp-rfwz3-b23sg-axiro-uotuy-fjmch-lp67q-xqe",
@@ -30624,7 +30624,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "krw4e-sr2h7-2yry5-6mrco-peytk-k243g-dya4k-vz6ye-i2woc-ar4s2-cae",
@@ -30644,7 +30644,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kslge-tbuk3-k5gds-yusun-ujkkl-qvtj4-tvf6g-xmaq3-knv6g-lbbsf-gae",
@@ -30664,7 +30664,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ktnfa-jeqqe-262gv-tazya-3pn6k-q6eps-wfnzy-kvo4u-nhmw3-nfcjo-eae",
@@ -30684,7 +30684,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ktqjk-r6yho-cqgxd-qaqqn-yhxvl-ez6ax-jk3n4-bfa2f-vprkh-eigf5-5qe",
@@ -30704,7 +30704,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kufe4-ruvgm-q7xhl-h6l7x-tsu7e-ffnvu-znaju-kahr3-ofhjk-hnjnz-rqe",
@@ -30724,7 +30724,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "kvaxj-3yjic-s7izd-sdhz5-nm6di-nvjtc-piqnk-nofeo-32hhh-h5z2f-fqe",
@@ -30744,7 +30744,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kvdbt-szs6k-fzqh5-irvw4-uedgt-yx3kv-ij7mk-vl55l-mrtfe-revug-vae",
@@ -30764,7 +30764,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kvj4i-xw67n-f673e-7unem-npgcc-ag7ya-f46sk-g7qq6-ep6l4-brrkt-tqe",
@@ -30784,7 +30784,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kw5qx-snr3r-32j5u-hts7v-pi55m-csovj-k772l-nlroa-jfuby-eavw7-gqe",
@@ -30804,7 +30804,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kwict-ujiu6-u4ss3-nlwqq-dchsd-2h5lh-nzkke-24ij3-3otqq-rswre-vqe",
@@ -30824,7 +30824,7 @@
       "dc_id": "bn1",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kwlys-46pnx-4t2m3-wqrly-q5qg5-lzr6p-75c77-celqe-rbtan-oclkg-5ae",
@@ -30844,7 +30844,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kwryq-ezysk-c4ono-aet7a-hh6h5-4o3bb-a33et-ef4g5-42tot-zaek6-fae",
@@ -30870,7 +30870,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kwuqx-fwxpf-a7364-qonnr-wz4lj-ycyd7-fvnif-ntsfd-5flcn-plozg-tqe",
@@ -30890,7 +30890,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kwvji-wy64v-ttxji-c4bqg-iyrv4-mffn2-snbl4-okuzl-zqy4t-lsghe-kae",
@@ -30910,7 +30910,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kwylh-u7itt-vwqn3-vskq4-ftpcm-kgyqr-23ibw-tgbw2-jfg64-fqwi6-oae",
@@ -30930,7 +30930,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kxmey-hzsm7-7lfch-yfrbq-ereis-e2t7b-ztii4-7ib5t-fljrs-kjkey-kqe",
@@ -30950,7 +30950,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kydvk-tokwg-vqxwp-xszgh-5reys-aprlz-jpyjd-uwhlz-rnii4-pijvj-yae",
@@ -30970,7 +30970,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "kypym-3au6k-2nil4-oblfm-ujn3m-vodgz-mogrk-ldh22-nhmrb-ggwno-2qe",
@@ -30996,7 +30996,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "kzqmb-at6mu-giydk-zo7dx-pbcpg-bd2h6-v5w3u-p7jnu-ihalm-feqx6-4ae",
@@ -31016,7 +31016,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "kzsja-igfls-ihfxr-ug6yc-7ut6v-pmsbq-jqfty-lnoiy-tiv7r-364bt-tae",
@@ -31036,7 +31036,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l32px-puzwk-e335e-3fm2p-wdzer-oxjyv-lsc6m-2l27u-u7phk-4sj5y-wqe",
@@ -31056,7 +31056,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l3lkh-cqtvq-arpfg-6wewu-sp5fq-i3xgg-k7xyh-ufx7s-gjcbk-g4hr2-mqe",
@@ -31076,7 +31076,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l3m3j-bzfir-r3ld2-kri7q-obwcx-lix5j-7oxey-pbb6q-5tije-krocc-2qe",
@@ -31096,7 +31096,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "l3uqp-kuy6u-q7og4-oibsy-aisla-vu46q-hh3jr-fkmcb-cwthd-hymfj-cae",
@@ -31116,7 +31116,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l3v55-pc5xy-ee2mn-xdaat-xijfl-kecfg-rod7w-33huw-ef5kl-euqqz-wae",
@@ -31136,7 +31136,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l4tph-sjzvn-2577n-igj5r-n2mwu-wqz5r-rabgw-xphul-dxpey-uwxnh-kae",
@@ -31156,7 +31156,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l57yq-ottrc-3clfg-uxx42-wvw6s-znzbi-swx2r-sbhhb-ge5gw-rvy3u-3ae",
@@ -31176,7 +31176,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l5hsg-kdjfp-auxg7-3vd6p-d6pdj-iuzrl-zpnof-5lnaf-t6hu2-kgjdt-fqe",
@@ -31196,7 +31196,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l5rwf-r56jp-hkigi-pbynl-f7smv-gtu7e-mmwwv-x4lfb-kjpg2-nlmn2-aqe",
@@ -31216,7 +31216,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "l74v6-bcojh-ldmdj-xdotf-mvwlb-fsmor-u7wno-sp3ys-aum5z-xnug6-6qe",
@@ -31236,7 +31236,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "l7nbu-afo7y-adwcg-m6ivf-cooqw-v3pwd-jf4w3-kgsbr-tek3p-7n3dh-3ae",
@@ -31256,7 +31256,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "laeit-abiku-vm7d5-xnwpi-lf3ti-yfdjy-nunxn-ktpyc-gmpyl-idvtj-fae",
@@ -31276,7 +31276,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ldqxr-qdliy-howvj-2tamr-3fwul-liakv-7523k-tmhrz-5geyk-jlu7b-uae",
@@ -31296,7 +31296,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lfque-cnxjq-mq7nk-tcmti-tm2bn-sgwin-uclrl-kdkmt-y6epr-ltweh-zqe",
@@ -31316,7 +31316,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "lh2af-66zso-76kqu-d57ag-jca5d-yvmfo-rcabh-ptlvj-ltfdf-kyg6q-lqe",
@@ -31336,7 +31336,7 @@
       "dc_id": "li2",
       "node_provider_id": "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lhviu-zgyzg-ikpci-wjd5t-aia6f-wtp72-tso2f-gm7tc-32imm-mdr2w-7ae",
@@ -31356,7 +31356,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lilkb-wf7hu-iv6gp-gbbv6-f6bpj-amtp5-v2jyi-3s7jw-6dysi-yzm4g-hae",
@@ -31376,7 +31376,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lim7b-klnkx-adypc-pmet6-66zcr-zmhmh-t4zch-wlqrl-pnclk-qoadk-vae",
@@ -31396,7 +31396,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lj3ve-ztk3f-wbkmj-garra-gm3kk-f2kas-zq6cw-6url4-ekmls-5vlm5-hae",
@@ -31416,7 +31416,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "lj6xb-t5tcb-dol3s-ay52b-dulse-zyezk-25qyv-l7yqj-4zrc2-hp5qz-sae",
@@ -31436,7 +31436,7 @@
       "dc_id": "zh5",
       "node_provider_id": "hzqcb-iiagd-4erjo-qn7rq-syqro-zztl6-cpble-atnkd-2c6bg-bxjoa-qae",
       "status": "Degraded",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "lkq7d-2ephj-zfh25-lgc7c-jvene-3k2cu-a7z36-46fz2-ngrl2-vojne-gae",
@@ -31462,7 +31462,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "llbvn-f4hq5-tg7bl-tdvr7-zs2cb-7uwfz-dhshp-aaomw-urgqo-gyll2-tqe",
@@ -31482,7 +31482,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "llhn6-zkkb5-atd6n-3du2j-v3jvs-lx65d-chuhh-7ydhs-jf7by-fjul5-2qe",
@@ -31502,7 +31502,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "llwjk-sgobf-vxycz-muu34-oyozz-lkxak-pzc67-ek4pt-kqmfh-b2b6k-3qe",
@@ -31522,7 +31522,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "lm2xj-taqth-26gdl-2jdjh-gkmwx-souof-xhx6x-bqooh-rz53c-3smdz-kqe",
@@ -31542,7 +31542,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lmfy6-g2wta-3pp67-cjv5u-qws2j-kf3ci-tkze3-iqucl-mscsw-3u7bx-jae",
@@ -31562,7 +31562,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lmn5j-j7gfv-ktncs-h7ws3-i57yi-7jn5a-p25mh-chqq2-kksgd-wmcbw-jae",
@@ -31582,7 +31582,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lokgu-wck7g-zmqg5-4okel-a2hxf-7mjli-cbuue-z3pz5-jbnoz-gt4dw-uqe",
@@ -31602,7 +31602,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lovrr-efema-wp7pq-cfp2q-clwvx-c4vvp-7zb76-ixxoi-7jtke-joyqp-aae",
@@ -31622,7 +31622,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lpkij-6jgir-sukcx-6kplx-qddla-ufncr-e3m2p-kikly-bcwzd-mtslj-4ae",
@@ -31642,7 +31642,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lqn3t-6owaa-5y7lz-yjvpu-wt4tz-ilcnj-bdr36-mwc27-54szt-hspos-yqe",
@@ -31662,7 +31662,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lr6qv-kty5w-b6qye-6nog2-leujy-6szil-3toje-lykox-oxgce-z6zik-kqe",
@@ -31682,7 +31682,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lsew2-tmjjw-ytiyx-st6sx-qo2wi-cxu3e-sgidd-i34jd-okjsn-rtli5-cqe",
@@ -31702,7 +31702,7 @@
       "dc_id": "bt1",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ltav6-3lsov-3cp5a-lswi6-dwyes-nyery-l3in3-tqcj2-6o4cc-pnqit-jqe",
@@ -31722,7 +31722,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ltzjy-54bkf-bwynr-rcqst-ncpe6-qlg4x-tvhmp-73bm5-75e7u-t7c7s-eae",
@@ -31742,7 +31742,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lulpw-ndk7u-pllzf-houff-chpou-tiith-rk2pj-wchxn-uqwif-bur3e-uae",
@@ -31762,7 +31762,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lus5w-zk4cf-asgto-epkw2-ec2l4-djm6h-zywzq-qeg34-fxhf7-go6fb-jae",
@@ -31782,7 +31782,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lwxeh-xayoz-wu5eb-hwraj-a3pew-yeioj-cnwat-5uow4-ugxkc-kx44o-4ae",
@@ -31808,7 +31808,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lxgqb-dlqzi-schn4-i2mha-qh6re-eq3c2-3k6cn-oqumg-jkmgk-d4gex-3qe",
@@ -31828,7 +31828,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "lyhuu-ljnh7-ba3zz-g5ftu-xepo5-a3bqy-sggtx-6wgu2-5sw77-cxnfk-iae",
@@ -31848,7 +31848,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "lz3ap-rjo2a-ilqjt-jkyhb-t4ewt-b37eu-gl246-ltnyu-jrkec-6bi5m-cqe",
@@ -31868,7 +31868,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "lzjli-4do6u-xcbtx-co7r7-35gzq-5mmqw-k4jb3-3s63m-facun-6riew-lae",
@@ -31888,7 +31888,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "lznu4-p5ytf-od4bl-grhpc-kfovt-sla4b-kng2p-ab22m-4tdlq-bxtfj-wae",
@@ -31908,7 +31908,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m22uy-ch26x-ymd7q-n3stg-kyoel-t3zdn-4uwqf-zu6sb-pezk4-swax5-yqe",
@@ -31928,7 +31928,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m23z7-mk7ap-ppgvt-3ijq4-plmvx-gocl2-727gg-so5gf-gm2oa-eqjse-gqe",
@@ -31948,7 +31948,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m2g5i-bmomq-dyjao-k642i-fsfxg-trxki-6i42q-hm6ec-xu5cd-n5jhq-sqe",
@@ -31968,7 +31968,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m2hxm-2nono-agspa-xjiq6-igu5l-6wrym-2xone-gifis-sjcg6-juft5-oae",
@@ -31988,7 +31988,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m345s-atzkk-etodt-4bssh-cxcit-aw5ou-kozs4-5bipl-i46aj-uwnnh-bqe",
@@ -32008,7 +32008,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "m34r6-l2rj7-deohw-yrkjp-sretm-6tadf-xnwqy-3flhm-nqj4r-wwcoh-eae",
@@ -32034,7 +32034,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m3ju2-x3nqm-fcrha-zbyll-tl7no-7iwen-ph3y4-5xxwa-cniii-yu2ti-zae",
@@ -32054,7 +32054,7 @@
       "dc_id": "dr1",
       "node_provider_id": "trxbq-wy5xi-3y27q-bkpaf-mhi2m-puexs-yatgt-nhwiy-dh6jy-rolw5-zqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "m4e6a-3t7oi-ooshc-2b2vq-56xpu-pyo7q-qafn2-3sem2-cvtck-6xfqy-vae",
@@ -32074,7 +32074,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m4mgu-gzf3s-4hwzh-7laf4-664rq-m6lu4-qs64b-yqrua-gfzdh-lmuf5-xqe",
@@ -32094,7 +32094,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m4z2g-kmsdn-ryakd-hbfuo-wpcmt-tjhmh-66nym-6bohu-jwafj-erzf7-vqe",
@@ -32114,7 +32114,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m6pbx-6q64u-443wl-43j3t-tysy5-bb3f2-dtotm-hd6zq-qbemu-dizp5-zae",
@@ -32134,7 +32134,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m7fhy-jb2rv-5b755-7ysgo-a3v7i-37r2h-jpkkl-acrqc-ft5cz-i4hgl-jqe",
@@ -32154,7 +32154,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "m7naf-qlqxu-f55kw-g3dq7-ngxfc-w2nfp-dvlmo-n4vw7-tu7nj-ucgon-oqe",
@@ -32174,7 +32174,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mae7q-ggnbj-xb52f-hvest-dgqoc-whvsq-yui5d-5cys2-zeold-l5ydx-oae",
@@ -32194,7 +32194,7 @@
       "dc_id": "bn1",
       "node_provider_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mbsyf-dtlsd-ccjq4-63rmh-u2lv7-dwxuq-ym6bk-63i2l-5uyki-zccek-mqe",
@@ -32220,7 +32220,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mcm3l-mvyhz-i32tz-6paad-boywz-djzxf-jcku6-qxqj4-hdydh-e4pm3-wqe",
@@ -32240,7 +32240,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mcmqr-z4yrw-7wnwf-au7wv-5f7az-fco3a-vuxx3-7lol5-sigpc-jtnqq-aqe",
@@ -32260,7 +32260,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "md37k-cke4n-6hc7v-3dupn-5u64p-m63tw-imur3-fuchg-qlgqm-lqd4l-dqe",
@@ -32280,7 +32280,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "mffl6-6nqi4-rlxxy-rf65r-6tcnw-4btxq-mvugh-zbrsr-suvbk-sklqi-mqe",
@@ -32300,7 +32300,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mfkgh-d27bh-3yri7-xidqr-obad6-j234b-tjbkl-o5vyk-upoqn-4qktt-pqe",
@@ -32320,7 +32320,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mgsm4-dtqz6-qjrcm-46lrl-525hm-zysjr-5awdt-pn56a-5fegb-sf6nk-iae",
@@ -32340,7 +32340,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "mhfef-zbxsl-rocpc-ovqeh-jg3ct-7nvmi-gzpnm-xjmm4-uekgj-rquls-uqe",
@@ -32360,7 +32360,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mhwuz-qcw22-7uxip-wmnc5-kv2wb-ttehc-pcy3g-nb65w-622zg-rgkks-lqe",
@@ -32380,7 +32380,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "midzy-g7zyz-id6w5-tk7at-455iz-wgta3-pqbo7-6k353-qukdx-w7472-aqe",
@@ -32406,7 +32406,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "mixej-rcrlt-h5vt7-2lqkx-b47jo-rv2ax-eywge-xfgd2-ro2oe-dhmrm-kqe",
@@ -32426,7 +32426,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mj4qw-5oxqx-5jgpn-66re3-gzgjb-rphz5-hmwhc-ahaa5-vespc-s4maj-vqe",
@@ -32452,7 +32452,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mjc5v-75pmb-xdt54-niplf-j53mn-5olz6-ejsob-puggq-lz6eg-j2vvl-kqe",
@@ -32472,7 +32472,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "mjkwh-xxebg-fyx3a-ys5tw-eivjx-54ctf-perkn-ytc6p-h32yq-57f6p-lqe",
@@ -32492,7 +32492,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "mjte3-dopva-7tttu-5hnnu-q572b-p3wwy-b56of-4q6h7-hbtf4-f3m32-tae",
@@ -32512,7 +32512,7 @@
       "dc_id": "pa1",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mlbpy-pvy7z-gfwcb-5bakp-cuubm-prmi3-dppq6-rlepq-nkyvb-u7acf-fqe",
@@ -32532,7 +32532,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mmftj-tccvp-x36s4-7cpyk-c6vo6-rtqxn-glvfw-nyne4-tveuu-x3z25-mqe",
@@ -32552,7 +32552,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "mpg3d-2cuer-sgdo4-gqny4-5cfm6-73sx5-yococ-lhvwn-mnydg-4qzfa-vae",
@@ -32572,7 +32572,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mqgpq-lthkz-rvqkm-i4anw-pkjz6-wpaup-qrhuc-2itwg-xf42r-tbtbi-eae",
@@ -32592,7 +32592,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mqriv-hkd6f-wety4-rbjcl-ibf7a-i7kpp-62jsh-6yrie-2ahci-aql6t-dqe",
@@ -32618,7 +32618,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mrsjw-u74gy-ucqkk-74ehf-3scxq-cvpuw-opqco-mlx4p-w72pg-m6pea-xqe",
@@ -32638,7 +32638,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe",
@@ -32658,7 +32658,7 @@
       "dc_id": "wa2",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "msxnb-pfmsj-qojcl-rokaj-gbi53-csict-otggw-ajt75-deeof-dnq2a-fae",
@@ -32678,7 +32678,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mt54u-t6z4l-fkx5l-2xwfe-g3u34-kzd44-2d3f2-xu6ty-lpc6z-pex4y-5qe",
@@ -32698,7 +32698,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mtr6i-a7lue-qnbje-xizsv-z3v55-atzbw-5xzbk-yto2x-v5ynd-lsmqr-mqe",
@@ -32718,7 +32718,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mtti3-fw4qf-27www-bah3o-ctlkw-lebmb-3m6e6-eesv4-l7onf-4db2y-qae",
@@ -32738,7 +32738,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mvq4c-mbmpm-2u2mv-h74op-kekjk-6rudx-jl7qb-rpxuu-zicsk-o25td-4qe",
@@ -32758,7 +32758,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mvsqq-rkiq2-fuint-an5oz-eqvhk-qu3vj-hesjn-uhn52-z7f37-wxucs-eqe",
@@ -32778,7 +32778,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mvx7r-gcjs6-emuc5-ijos2-5egv7-ic35n-ocbfd-tjgvp-kydc5-5tshk-lqe",
@@ -32798,7 +32798,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mw6i7-sdtdc-m4rdr-mdl77-rqrdi-r3onb-lk4np-ojavl-i4sng-rnnz5-pae",
@@ -32818,7 +32818,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "mwrqx-e25kz-tchcz-quxpv-jhwdn-rwxeg-au4ci-xv5ko-s44pv-dmu6g-kqe",
@@ -32838,7 +32838,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "mxqle-wpz4z-kbwgu-csf2l-nyjyt-xaqdy-sfolv-igh4b-aokrj-g2wq4-bqe",
@@ -32858,7 +32858,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "myguv-fs4u6-jl53y-vk4pf-6xojw-4umwc-r55jy-jyy7q-f4gmu-wvliw-2qe",
@@ -32878,7 +32878,7 @@
       "dc_id": "zg1",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "mzcnj-vnzbp-sjmlf-bmjcu-3qim4-7ouxc-woglo-vyqma-q7sxt-v3nez-rae",
@@ -32898,7 +32898,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "n2atp-ct3so-2to22-4e67s-25y4o-naiht-5croo-lq7qj-m23gm-iav4p-3ae",
@@ -32918,7 +32918,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "n2h7o-alfdb-7upvh-ulvn4-m4khz-yx5gq-3za3b-c4xiy-wxu34-3suzk-bqe",
@@ -32938,7 +32938,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "n3bme-h7h4t-3jqiz-t4li5-en2va-5o54l-34wet-hv5zt-njbnc-uiwsp-mae",
@@ -32958,7 +32958,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "n4d4s-hgx3a-nwox5-tmfqw-q2gu6-mlzhy-deyzq-zu6r7-wryv2-napyl-qae",
@@ -32978,7 +32978,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "n4yvn-ac55a-ixjvd-7h7xc-dan5u-ksjzx-zsi74-emfwt-dsfbo-ortnj-hqe",
@@ -32998,7 +32998,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "n6zwz-reuil-fdhjj-bvsph-rsnvl-ru3jg-2ywjx-bxt4w-j3jkz-vlheq-wqe",
@@ -33018,7 +33018,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "najnj-to3ju-pl6pl-5yjlc-6vdqi-f7tht-qd7tt-fenyr-f3tjc-tfj37-uae",
@@ -33038,7 +33038,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nbela-otrcc-dakmr-4ljx7-igd2t-3ge3b-xskv7-cnj65-co4r7-cjxyd-vqe",
@@ -33058,7 +33058,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nbkmo-z2yx3-l4tjn-vvx4c-qj5ck-maicu-o7o44-ztlm5-5nm6d-it36c-hae",
@@ -33078,7 +33078,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ncr4b-rasb7-tueb3-n4uos-5nxou-3wbxv-xmyt3-wfdsd-vu4b6-5x3cp-aqe",
@@ -33104,7 +33104,7 @@
       "dc_id": "ld1",
       "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ncrki-fugy2-kmcnn-k3u67-ezjsz-6s76c-2iucl-xc63o-vn2lk-yebq4-jqe",
@@ -33124,7 +33124,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ne7tg-d2fcq-mlxl3-2ljre-4op5b-oyx5m-lt4ao-ctx6y-4vxiy-56ep3-4ae",
@@ -33144,7 +33144,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nf5ha-6wgiw-jhlaa-rs7hh-3k66r-mou6j-wudlt-pckzu-7goiz-yyfcc-gqe",
@@ -33164,7 +33164,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nf7qq-vkm72-lttne-dsnke-3x73z-ofybh-ogahy-vyvta-dgbny-s5dr7-qqe",
@@ -33184,7 +33184,7 @@
       "dc_id": "sj3",
       "node_provider_id": "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ng56n-tx2si-rxkmq-bkjnr-3fx6p-lw5pi-5pvsl-kdcg7-6ts24-m55dx-tqe",
@@ -33204,7 +33204,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nhkbm-fqj7r-jdjii-spvcr-to3iu-ccrkm-pils3-6io5l-ahtry-qhlly-4ae",
@@ -33224,7 +33224,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nioyi-lxtpk-fnexd-5ib4d-3x523-uu4ve-ro2tv-z5yuq-sf3dk-fdhrf-4qe",
@@ -33244,7 +33244,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nj7re-dvkal-yq25a-opp2g-5y3qy-3ena4-opd5j-22uir-eaakx-ljk7k-6ae",
@@ -33270,7 +33270,7 @@
       "dc_id": "nd1",
       "node_provider_id": "pa5mu-yxsey-b4yrk-bodka-dhjnm-a3nx4-w2grw-3b766-ddr6e-nupu4-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "njrl2-xk3tb-n662s-ckjbn-a6nrw-efzr2-o2352-su2lq-csj4k-pjlgs-rqe",
@@ -33290,7 +33290,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "njxw5-wwjkv-fe7pn-573wu-qdvk6-n7nug-supvd-txyla-pefzj-erqsu-oqe",
@@ -33310,7 +33310,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nnrw2-jsoru-y6nao-advtq-jb3xe-rwml6-tplfi-2nlrj-ofb2x-6ione-nqe",
@@ -33330,7 +33330,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "noil6-vtxju-xxtvs-y4jbv-ke7k7-erdq3-rad3q-iubb7-e5gfq-dizbp-fqe",
@@ -33350,7 +33350,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "noos2-mfe4u-r4gp3-jrjow-ancs2-ncakm-zi72z-zzcbg-uam7p-d4s6s-6qe",
@@ -33370,7 +33370,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "np33o-vcmlt-zvs5o-wfwgf-l2qcj-htqw4-vdp4e-5vcki-6edum-ejtqz-jae",
@@ -33390,7 +33390,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "np4ih-n24tu-rdhck-pe4wk-b55zi-6teik-a327g-kjh7q-plk7k-zkhnh-iqe",
@@ -33410,7 +33410,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nr6q7-lhbao-gj6jo-5nfem-lttds-nammh-hfc3u-zjv2a-g4tno-tslx5-sqe",
@@ -33430,7 +33430,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nrz3y-3qhvi-mhz6v-zlvpg-wvwn3-fsmom-wtkla-p67ly-fgsl2-sf5g4-bae",
@@ -33450,7 +33450,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ns7kv-kp2mu-mw7yi-krd4z-eqcvq-qeeej-mxtwb-c2ujq-xtq6x-orzoj-3qe",
@@ -33470,7 +33470,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nsdff-ph6rj-djikq-3otxw-yeolw-4dwf5-ma6xt-t2bwf-st2h7-qkbw2-dae",
@@ -33490,7 +33490,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nsozt-jaque-635ut-ormlt-kf4x4-cfmno-tm6dg-awyfx-aexbn-t35wm-4ae",
@@ -33510,7 +33510,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nsphz-ldqlm-3miwx-7dbuf-xj74o-44zvd-xhnzf-lpfsu-edhof-gscrd-4ae",
@@ -33530,7 +33530,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ntk4m-3jwml-24enm-akwhr-gps2m-xe36d-qlkd2-scgcu-qmjik-nrk3b-wae",
@@ -33550,7 +33550,7 @@
       "dc_id": "ct2",
       "node_provider_id": "py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nto5n-yff7l-mwmhx-ltx7u-oo5td-zizuo-vga6s-cyly2-vksce-77bdp-nae",
@@ -33570,7 +33570,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ntq7u-kxblc-32ree-ydtce-6tj56-wcwsi-4zrce-orxlv-kgty7-expjk-6ae",
@@ -33590,7 +33590,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ntu4j-zshsg-z6tnx-3veep-eajqc-dktjf-nhogl-j5aot-rqnk6-oawt3-tae",
@@ -33610,7 +33610,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nu5cn-l6rgt-kqeyj-daqss-hfdzc-hduqr-vqio6-j2mwl-4hhto-gw3po-mqe",
@@ -33630,7 +33630,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nuass-yihti-wszdr-r7qze-32dgz-osovf-pracd-hg5tt-mwlhf-rvuyq-4ae",
@@ -33650,7 +33650,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nusc3-gza5p-4iw7a-ea7xu-b6afg-r4sd3-saik7-io6zs-c36mg-q47ut-qae",
@@ -33670,7 +33670,7 @@
       "dc_id": "sj3",
       "node_provider_id": "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nxeqo-y6jk3-5zpcu-waryv-lz3ha-c2iuu-jljee-yzew7-jo5dk-6dgr7-3qe",
@@ -33690,7 +33690,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "nxl2k-m56rt-jfc2x-fmsfv-tkvxg-b4t54-ppyp2-ryjrg-aaawz-evqzn-dqe",
@@ -33710,7 +33710,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "nyjdu-xbr5p-dykx4-yolkz-zriw5-7yorm-ldg6b-p3t5d-4v557-7ugym-nqe",
@@ -33730,7 +33730,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nyo3z-asy7t-jxc44-z4cvr-tts4h-2ipvj-aawbj-37xkl-7lcfq-psuoe-uqe",
@@ -33750,7 +33750,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nywvh-lpkhv-6oyp6-vmbxg-ibtbv-yekno-sgdvn-ipiak-aha5o-b4nef-oqe",
@@ -33770,7 +33770,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nzkwt-lgmdg-k3yav-efgz3-2fehw-36t4z-moaz2-ou2bl-ysnrp-rdhlm-5ae",
@@ -33796,7 +33796,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nzq2v-s4w3x-du7op-2rnfv-dqo7s-w7a2f-cueqh-ofx6b-aacag-hn7m7-cae",
@@ -33816,7 +33816,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "nzvxp-y3yxh-ba3vn-4wta4-ztt57-pvf6k-whfrh-lui77-4fxln-qfqd4-sae",
@@ -33836,7 +33836,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o2ejh-i3l5b-tawnx-6vane-ek7hi-apzj2-d2vid-j5dro-xityu-sszcb-gqe",
@@ -33856,7 +33856,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o2q5i-kszma-radgr-fdzu5-iqfps-w6xfc-aka7m-fftq4-2lpar-wj6xc-mqe",
@@ -33876,7 +33876,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "o42ny-ab3zt-iknyx-eo4ji-utgbe-xmae4-ybmwp-wdkzt-efffe-oq6nh-oae",
@@ -33896,7 +33896,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o4dpm-sepp3-6t6vc-b7pcu-hryjo-szzou-hnks6-cuoux-gys6n-3iaou-yqe",
@@ -33916,7 +33916,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o4hgt-rauck-wxubb-yrhv4-besk6-7q2sg-jb5rg-4ysmy-n5ssf-ctzgh-3qe",
@@ -33936,7 +33936,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o4yks-m2wss-gvcbk-sh2tp-pxdm6-vec6m-bd2in-kznc2-r5rhk-waxtm-vae",
@@ -33956,7 +33956,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "o7jhq-4dniw-6nzel-kye3v-qpsq4-c24ek-nkyl5-grlrs-qo3qw-qfmjj-qqe",
@@ -33976,7 +33976,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oad7l-2irg4-2s3uk-7j3pi-dmrnu-33eit-jd6zb-slf27-uecbd-ayrko-vqe",
@@ -33996,7 +33996,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oagfb-76ct6-ns5zo-u4qvr-u7lzo-y6gsz-hfkaj-svxzm-bmpcg-t3wfn-bqe",
@@ -34016,7 +34016,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oaxev-miabf-nxzvk-inhz4-67wdw-urlun-euywx-656kk-iffmy-3gdp4-2ae",
@@ -34036,7 +34036,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ochxw-hoyfu-vxj3a-nxfik-dp74k-hfv7r-hfu2u-2e2cv-act65-jb6pd-kqe",
@@ -34056,7 +34056,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ocony-vhzun-3ygcw-3mck2-2knqd-d47bv-hi7jq-kbfc5-xf6ui-ou5c4-bqe",
@@ -34076,7 +34076,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "ocvcv-56eg5-gxibh-dcgpo-unhwq-4bwmo-x7q3h-stwf2-ycfex-gdr2a-kae",
@@ -34096,7 +34096,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "odayk-wqaee-55i4i-ddk3v-o7cbq-liz56-g7esn-hnye4-5arcz-nv522-dqe",
@@ -34116,7 +34116,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "odqcr-b52dj-r3jrf-eddmn-txfwh-vtupz-3ygx7-zwoz4-ruupc-h7ftb-uqe",
@@ -34136,7 +34136,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "odqd6-dviku-lsu67-jdbyh-qzdgp-4a6kw-c46gw-bzkgg-wgbz2-q24vw-5qe",
@@ -34156,7 +34156,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oe52f-su776-yflut-ihohm-rm7gp-47fvy-alweq-ndg3i-g5uci-qzcvo-jqe",
@@ -34176,7 +34176,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ofdd3-yoprc-tnvr7-tslrz-6rtn7-xofz6-kkoyi-ncfhd-aupek-kmtii-sae",
@@ -34196,7 +34196,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ofemt-rbrvy-o6hne-hqs4p-xbhmf-go5aj-3gbs4-gj3it-akve3-2kklg-jae",
@@ -34216,7 +34216,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ognrk-q4exl-3wf25-yrrsy-mtezk-e3qww-k6s5v-2pikz-gto6z-dyl2y-eae",
@@ -34236,7 +34236,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "oh5wh-qqgpq-brv22-hsr24-jsgng-iiuew-gs34v-tgavl-e5wgu-vzany-fqe",
@@ -34256,7 +34256,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ohfub-kko7t-ry4nl-w27qo-xsegj-f4fgo-2p5ff-n3nzq-5ucqc-36qat-jae",
@@ -34276,7 +34276,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oijdr-tw52e-rxqz3-jqz3p-svaqt-xkl36-uwesu-rlfgq-b6ztg-7r7no-kqe",
@@ -34302,7 +34302,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oimru-7xylm-5ndhq-ggeb4-okdx4-4s47u-cndgm-vln2l-5vfwr-qulvi-3qe",
@@ -34322,7 +34322,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oirv5-oatly-ra7gr-dswc6-67xg6-2yvmi-zrjm6-2erp7-fls6r-xlu43-tqe",
@@ -34342,7 +34342,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oiso5-hxkkc-elqlo-iyoqg-7oux4-5mscl-zkvoh-b2432-ohrir-b5fcm-gae",
@@ -34362,7 +34362,7 @@
       "dc_id": "ma3",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ol4bj-6dyey-ofnit-6gr7a-wfmfk-jpyqi-7gbfv-ks2yp-3yhri-63mnd-nae",
@@ -34382,7 +34382,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oll7v-lrefb-cjchd-b56ws-7sbig-ylq32-fbger-ljyg4-dblew-nsfcf-zae",
@@ -34402,7 +34402,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "onc5z-2bkny-x2rr2-2pgyk-kpnj3-i4xpr-7sz77-pmawv-ncyte-rviz5-nae",
@@ -34422,7 +34422,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe",
@@ -34442,7 +34442,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "oo4np-rrvnz-5vram-kglex-enhkp-uew6q-vdf6z-whj4x-v44jd-tebaw-nqe",
@@ -34462,7 +34462,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "op35h-4dldg-dm6wm-ufq5k-geg6h-3iivc-vfiy2-makou-iqgez-4ou7n-oqe",
@@ -34482,7 +34482,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "opoix-7igin-plsuk-hlcsr-66s4b-bn4ut-i4hts-prw25-fgjep-wdtlv-tqe",
@@ -34502,7 +34502,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oqcfk-k6z33-f24ov-draxm-eco5i-yo4ev-mi36k-56s5q-rtx4s-tesjz-hqe",
@@ -34522,7 +34522,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oqqmz-u5snh-o2oeu-jtjdt-24zgb-ngtya-grqjt-jpvs3-rt24g-e3vr5-6qe",
@@ -34542,7 +34542,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "os2wv-dchv6-fjwdg-nichf-3cra6-wccb3-57glq-xqgen-zwobp-aonve-lqe",
@@ -34562,7 +34562,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "osjyf-kklfv-qou3l-2evlh-sxi3v-t7wbn-hijrw-24szh-s5hws-m7jbu-kqe",
@@ -34582,7 +34582,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "oswv7-a355p-a5jlp-ko7pj-arrs2-rghho-dti4z-xgptn-szn55-jjr46-uqe",
@@ -34602,7 +34602,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "otjix-uov33-zlilf-77him-mcnun-fbnwj-voya4-axinh-4vu4o-bw53l-6qe",
@@ -34622,7 +34622,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ou6hm-55t2q-vpvyv-njatl-mjdtd-bkwar-uw2se-nybra-pseo3-5m23r-rae",
@@ -34642,7 +34642,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ouffe-miylc-6zcwl-afv2d-lai62-qwzns-xtlji-p7pu2-qkx2e-x72y2-sqe",
@@ -34662,7 +34662,7 @@
       "dc_id": "wa3",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ouote-hbhpd-kjyk7-z2b3y-tq4bg-b7q6o-hflib-r7nqm-hegxs-qqs44-nae",
@@ -34682,7 +34682,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "oxevh-yptgl-yzu2p-w6dyn-lr6jc-b2xaq-aatz2-yyfot-hm4pr-ucvh6-gae",
@@ -34702,7 +34702,7 @@
       "dc_id": "zh5",
       "node_provider_id": "hzqcb-iiagd-4erjo-qn7rq-syqro-zztl6-cpble-atnkd-2c6bg-bxjoa-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "oxfpl-mnall-x64st-zzj56-r2c6n-6lcyo-lvlth-yycxr-ct54w-fio3c-lae",
@@ -34722,7 +34722,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ozim4-dez5l-gk24c-m7phw-e6i32-c7vxe-m6you-mkprj-moxq2-fhtyw-uae",
@@ -34742,7 +34742,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ozt53-z3dnp-udkif-5iqi7-flb57-vr2ev-vxe4o-nq7fz-d6oro-go7mq-7ae",
@@ -34762,7 +34762,7 @@
       "dc_id": "hk4",
       "node_provider_id": "cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ozzf3-fgu6i-zazyu-53tna-6zxsi-6vh22-fvvuq-omtpr-hjrqn-n3ufz-cae",
@@ -34782,7 +34782,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "p2pul-jegs6-knwfb-ujuzn-d5hba-cttvp-ytc4b-m57nu-eaab2-bwckj-pqe",
@@ -34802,7 +34802,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "p3wi6-xvpmj-6zjye-564xs-zwglx-5ixeq-faeou-pbfna-64ezf-5znrj-aae",
@@ -34822,7 +34822,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "p4bbm-vsvx7-wyy6y-ujroq-mufah-hai5l-6xnkx-2a225-3bqgb-j65mj-iae",
@@ -34842,7 +34842,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "p4khz-nv35h-omz5j-3lflh-f473a-nwumw-yi74i-xwozx-ykk5t-heidc-rqe",
@@ -34862,7 +34862,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "p5mal-pvcyj-n27tc-w2yur-pm6fo-vc2xl-m2r2e-6yzde-rrw37-ujojf-2qe",
@@ -34882,7 +34882,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pag4q-7rwln-li5b5-puamk-xbxv2-dhwkj-jndlb-egt5t-dcpfs-of2mw-sqe",
@@ -34902,7 +34902,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pak5w-tullm-az6nw-t6c7e-gmzhg-p4ale-m3hgo-qr334-7gy45-kkwtg-lqe",
@@ -34922,7 +34922,7 @@
       "dc_id": "sj3",
       "node_provider_id": "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe",
       "status": "Dead",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "pbken-vny4r-j4a2m-zlvt2-kjj4i-pwehn-ftsa4-ne4xu-yz72s-fk6nz-eqe",
@@ -34942,7 +34942,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pbva7-4kbrk-oyagu-q2y77-izb74-bqzmb-xrpil-nfjxu-qzzpk-zgzid-bqe",
@@ -34962,7 +34962,7 @@
       "dc_id": "ma1",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "pdfrf-zywq2-z7k4b-6qw3p-cgiui-rwsrc-dbnvp-lgc6c-gzd6b-azpnw-4qe",
@@ -34982,7 +34982,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pdo46-iehoo-x2gfu-t5qu5-y3e64-cdymo-eioop-h6f4a-zebwa-fenb4-xae",
@@ -35002,7 +35002,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "peo4s-7bgcl-3qkkf-sxwqn-j6usn-726la-pm242-aitqh-5iuz7-ukc25-vqe",
@@ -35022,7 +35022,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "pfjuo-a2ayv-2rfom-6sgkq-3wgsb-dop7k-lu6hv-jwir6-ujgq3-gwbeg-aqe",
@@ -35042,7 +35042,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pfmqh-xphm4-h4wkn-nafsx-aix6u-h4gbl-owfhy-wnm4y-vkqyu-nmlhl-aqe",
@@ -35062,7 +35062,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pfnmc-ov33v-tkcb5-k664n-jhq7y-pwfnh-q2iei-itamd-a5rsk-3gwon-eqe",
@@ -35082,7 +35082,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pgjz5-43cqv-cgeef-xbnyk-5alxm-4nq6y-wrpf3-dz5qk-t3dbg-jr7p6-oqe",
@@ -35102,7 +35102,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "phgey-5cyzw-2ype7-y5q7w-yce6j-3yvg7-tlkfe-quvvy-pqpt4-252od-fqe",
@@ -35122,7 +35122,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "pk6jo-5oauw-yubar-gifh2-zhhkd-erh4g-2wagj-5zh7c-saq7w-pb73t-dqe",
@@ -35142,7 +35142,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "plbgg-2silg-344nm-n7zqv-lpy4j-uktsq-darh7-shrma-srui4-xrcgp-dae",
@@ -35162,7 +35162,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "pm6hc-2ghis-xwera-jdcuf-xo6mv-ura5k-aurmb-xzoip-lx6nn-2rtew-aae",
@@ -35182,7 +35182,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "pm6ke-wvyar-p6h3q-nuj2u-xnquc-rovab-63n4c-mvvrz-2m4q7-yxde2-oqe",
@@ -35202,7 +35202,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pmlsj-nmtc5-6pm7r-di22w-6ftne-5wjyw-xeivl-bzthp-fx7q3-5cgmo-hae",
@@ -35222,7 +35222,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "pojjf-vh65n-rephu-6rm4t-3zdx3-5pnon-csrf2-wlm32-z3tak-qyefb-fae",
@@ -35242,7 +35242,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "popmv-gccw7-zincv-gtcgo-jxfby-ar7zq-odvna-4jcs2-cnovy-qiha6-yae",
@@ -35262,7 +35262,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "poyg5-cbmcm-a372x-j72lt-zm4rz-4sf5v-ajtle-hyqkt-rdgaz-eqzmi-5qe",
@@ -35282,7 +35282,7 @@
       "dc_id": "rg1",
       "node_provider_id": "3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "pqtnd-vqqrq-gdswk-4cyzv-vsjwq-ib6g5-ynsih-7iaqj-mqyh4-telzp-tae",
@@ -35302,7 +35302,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pr7ix-hbaga-z42km-fqni4-qmteb-2p5q7-v5ynf-5ith2-7en6e-yijtv-tae",
@@ -35322,7 +35322,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pri5a-une2z-drxdd-pjg2y-chwiz-hsuhx-xe4l6-gnio4-cgjvm-virtb-3qe",
@@ -35342,7 +35342,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "psfos-cul7d-luvsj-7er7k-oahxc-qx2qx-etnev-glh4c-5bybz-ivnlh-kqe",
@@ -35362,7 +35362,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ptxxp-fechw-m6taf-lrkaj-hwtas-rxq6p-o6tko-yho6t-cjfzc-zkgdd-sae",
@@ -35382,7 +35382,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ptzzn-jphjl-476ql-lgyrk-37oa6-zxhat-ynn4f-fm2ry-r3cmf-lx7e6-uae",
@@ -35402,7 +35402,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pud2o-rtmqx-ym5vr-3isia-wojnu-xwqmn-qcsxu-ktsva-udz72-m3pkg-zae",
@@ -35422,7 +35422,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "puggd-3j7aj-monfd-okbqi-f5dqx-i6ckc-3vsu5-qvsgt-pazhj-hdccn-zqe",
@@ -35442,7 +35442,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "puppa-avznx-ho7nk-muv3g-ngesq-ywt2f-4d4bb-zysye-tgytg-ejp66-tae",
@@ -35462,7 +35462,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pvo54-4ykmv-7iumz-jxrld-qma55-wtgck-jmdui-r654s-bdjne-db7lf-kae",
@@ -35482,7 +35482,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pvpfo-d5my7-pje3z-ifust-invna-6vtfa-w3vaq-muxgg-5ngfq-aoice-iqe",
@@ -35502,7 +35502,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pxxcj-h2sa5-q2yql-4j7od-jwtvq-uisnw-w2ox6-xtfqi-noxva-nlgxx-wqe",
@@ -35528,7 +35528,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pyeyr-5jtop-v3f4l-v23v4-5v3gs-2jdhq-3bvwo-fu3to-kehj6-iae3e-yqe",
@@ -35548,7 +35548,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pym4f-y6zlv-feua6-7y7ao-cbvlp-hkwfn-hqzjd-5sdiu-rsv33-y7245-nqe",
@@ -35568,7 +35568,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pyvbi-zticj-4qqed-h4no4-t6a57-km4pc-ehniz-gipvy-d5ymz-h7x3t-yae",
@@ -35588,7 +35588,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pzdyu-3fz4j-jukm5-pimui-aqzjl-dlqxo-mpe42-ihxtg-rjzxt-ibdb6-aae",
@@ -35608,7 +35608,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pzhdx-bue7v-bemr2-zkw4b-bpije-pc2jc-wrhwo-hfrwj-p646g-ibscz-dae",
@@ -35628,7 +35628,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "pzuk7-f54ar-77de6-nkxs2-ybva6-dpn63-blie4-rg2no-vtyl7-pvviz-tqe",
@@ -35648,7 +35648,7 @@
       "dc_id": "ar1",
       "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q36yu-tbutb-rdwfe-oyda7-gregz-3speg-zemom-hhjpt-ow74s-p5tyw-tae",
@@ -35668,7 +35668,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q3sji-7croe-uqcsz-rva4e-orlkf-c4y44-b2sl4-shnns-l57fz-fn2wa-xqe",
@@ -35688,7 +35688,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q3ums-xaeuo-t73ww-ojrns-lcpa4-2hf37-re7ho-zjspe-zrggb-2el6z-jae",
@@ -35708,7 +35708,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q3vac-kcwo2-ruiht-nflb7-ifoev-vkjcw-quybi-ugvgn-pqfwp-jntxi-dqe",
@@ -35728,7 +35728,7 @@
       "dc_id": "zg1",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q3w37-sdo2u-z72qf-hpesy-rgqes-lzflk-aescx-c5ivv-qdbty-s6pgc-jae",
@@ -35748,7 +35748,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q4ksz-lpvfy-ikkem-wyuaa-abopq-nmu5k-ovh6h-xfoqk-hx3x3-g2bk6-4qe",
@@ -35768,7 +35768,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q4mjg-ahyte-ffbko-kvp2t-fjlub-nprnf-ttxza-yrkhp-7xo5g-c4e3x-iqe",
@@ -35788,7 +35788,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q4xko-bigm5-fkgyt-kk2je-26rbi-jssog-nikwx-ldgdc-qjjt5-iifl4-cae",
@@ -35808,7 +35808,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q5nwx-7i5tz-xoxyj-baxhx-i4pu7-u645x-d4cpw-ydiqe-vlr4u-pqbxl-jqe",
@@ -35828,7 +35828,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q654n-n2u4q-spico-lpel4-ixfuj-m74mf-47yyv-gzwj6-wc5tu-maluy-zqe",
@@ -35848,7 +35848,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q6bkk-dqhlg-orvwk-4lfjk-3fbpu-y3s4e-v4ivs-5ys2a-v6ok7-yqolr-iqe",
@@ -35868,7 +35868,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q6hk7-hplmv-xsedz-5bv7n-vfkws-rjyel-ijhge-hx2zg-nk7wb-tzisp-xqe",
@@ -35894,7 +35894,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "q6i2a-r2jyo-qvchx-fx2eg-5vz74-tb674-au7zd-cy24h-wvywl-zbyro-7ae",
@@ -35914,7 +35914,7 @@
       "dc_id": "hk1",
       "node_provider_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "q7fri-m6ysk-lck7n-a6go2-lnjok-iyzck-rss6f-zbi3c-kpnil-bmcla-pae",
@@ -35934,7 +35934,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qae5l-hlpw3-yh3ge-uomfd-moqa5-txavd-fcu7s-n52vq-cxk5q-r4rhb-gqe",
@@ -35954,7 +35954,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qbij2-wkp76-ewolj-xsyp5-flevz-5kvx2-4hvgg-q23hh-43hbe-bxntn-xqe",
@@ -35974,7 +35974,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qd2x7-pikqr-gsiqz-uwzwd-w4tz7-zjqn3-qvh7d-itbtb-5uqso-5pj6i-uae",
@@ -35994,7 +35994,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qears-fr54p-hj5zq-2x66a-x4i47-nlg3t-uspft-qwz57-nbsvs-nddkl-wae",
@@ -36014,7 +36014,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "qepub-grdmh-34oin-6eus4-r47jt-t7enf-g4yyz-fbvpt-isn4q-vdg7f-dae",
@@ -36040,7 +36040,7 @@
       "dc_id": "ct1",
       "node_provider_id": "optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qesyc-24tqz-gjcqa-3n6vo-qp54l-7rkzx-t7pbg-6eacb-6ayrp-fweew-4qe",
@@ -36060,7 +36060,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "qfzgd-yz3fi-2fzre-km42i-ssgnl-fub7k-o5mbk-gsypk-eoh34-dhjvp-xqe",
@@ -36080,7 +36080,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qgbme-g6fmi-gks7d-gorcj-xtytv-cq5c7-yaahr-z2m3x-v76qv-fdw6l-kae",
@@ -36106,7 +36106,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qhfut-l6rgw-kkbjn-iglum-tgn5d-pb36h-rlus5-f6uhu-fgv5g-5nqyc-nqe",
@@ -36126,7 +36126,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qht2j-y3ztk-p4acr-rveul-kn37n-xc466-auaby-crl4s-cs5ki-vj27v-vae",
@@ -36146,7 +36146,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qicnz-k4irc-lorep-ymp33-kx5l4-hnh6u-scxtx-rlwdu-remff-ubqb3-gae",
@@ -36166,7 +36166,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qkcyr-pk3wb-n4w54-hofnn-mf6g6-uvhhj-lwzir-rw737-3ji4w-hqynu-vae",
@@ -36186,7 +36186,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "qknkg-ssedm-jiaaw-dst4j-reyue-zaymp-b3b4a-yk3gp-ix7ch-ibyhm-sae",
@@ -36206,7 +36206,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qlk52-xi45d-fpbsj-epcof-uoghd-xkmb2-woudx-aci7c-tpglx-rq5mj-vqe",
@@ -36226,7 +36226,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qlvmn-xucv5-o6qp6-nmhaa-mfm2g-x42bb-6sisq-wrytb-wpxkm-fser2-dqe",
@@ -36246,7 +36246,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qn3td-7zle4-jyne6-ai3zz-5z3iv-7ik53-spomh-3ruab-yvgqx-5w6z5-lae",
@@ -36266,7 +36266,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "qn5jg-h2if5-pw342-jegq5-fzrtg-n3gvv-e2xj5-47vpe-c7nyw-q6mwk-pqe",
@@ -36286,7 +36286,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "qnfu3-oknbg-uzr73-lj6dq-2hmmk-32g5r-3fhf4-tlqhs-zhtkh-oyc6v-2ae",
@@ -36306,7 +36306,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qnn43-fomt4-663kx-fqetc-54jan-ccsww-j54nw-quf3n-vudjb-qsfg3-pae",
@@ -36326,7 +36326,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qnyzg-n5ukt-uqt66-cw3qu-lnufk-kxxkd-4rqtk-o5cn3-y5ace-reh2p-kqe",
@@ -36346,7 +36346,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qobom-nt626-4n6jf-nrepv-xpdez-m4s66-fch4n-tdwdg-mibua-pq5xc-rae",
@@ -36366,7 +36366,7 @@
       "dc_id": "cr1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qowce-hpatx-sz3de-t6iwa-6keak-jdxmo-5gmmw-iohme-ngbmx-wegof-jqe",
@@ -36386,7 +36386,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qp3lh-25yxy-dlk4t-ay73d-frr4t-3kmi5-35kqg-3vvbq-26qhh-6xrdr-oqe",
@@ -36412,7 +36412,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qpt6h-7m7xq-4crv7-pml2g-2jsxx-vxgv4-eka6d-hq4xj-73u5v-bsaki-zae",
@@ -36432,7 +36432,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qqf2c-pemme-z3jjj-4mary-242f7-t4jwr-fqyqj-plih4-2ctly-l532i-fae",
@@ -36452,7 +36452,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qtcl6-k4m2v-zr4fp-2jvwf-2h46j-l3mg5-lwlxy-3wsh7-hghcp-afdsa-6qe",
@@ -36472,7 +36472,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "qtf43-dij76-6vov3-3eunl-va54q-6wal6-xnwsf-j7eiq-jm64l-pits5-fqe",
@@ -36492,7 +36492,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qvguz-cfp5f-otty5-v74o4-6ys5b-t2h5p-r6b5y-7wnaq-yi4x3-yazqd-hae",
@@ -36512,7 +36512,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qvn2y-tzm7h-gk7qw-n6jou-thzxu-xnnpn-4mdlo-asjxd-eps6v-3dmiv-lae",
@@ -36532,7 +36532,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qvskl-y3tsp-bnmtl-k4duq-vdcnn-zb4f2-vea23-x2vz2-jpv5d-jzwzx-eqe",
@@ -36552,7 +36552,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "qw55j-mkn6t-m3oks-fbzdh-fyzy4-v33ut-yhwo7-uwjvm-qliaf-urnkz-eqe",
@@ -36572,7 +36572,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qzhuj-nrvb7-pe3j4-qe2td-jfgco-xfkln-7zmcr-wopiq-pb3jk-dchd4-6qe",
@@ -36592,7 +36592,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "qzoiw-a437g-36thd-lkgpy-qnzo3-devgc-a3rp2-wodun-qmvp2-j37fr-2qe",
@@ -36612,7 +36612,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "qzvif-vpece-l4rga-6l6v7-tdegr-ycnty-p3zgo-qzghb-v5hmq-edjbv-lqe",
@@ -36632,7 +36632,7 @@
       "dc_id": "wa3",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "r2epf-c7xxh-tv5iv-x4dzq-f2sr3-6zmxd-wjb24-7fle5-s55wl-zz6yp-4ae",
@@ -36652,7 +36652,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "r2ijy-htif2-j4xyp-ahqs6-ugxn4-tulc7-3bljc-jyobr-lt2kg-6i3au-6qe",
@@ -36672,7 +36672,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "r3tow-ua4wa-qsco2-qecc7-u55qh-pbne5-ezbk4-3qggb-kjcvy-s33bq-3ae",
@@ -36692,7 +36692,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "r4642-fjh73-ltnlt-qhdcr-kfujl-v3up4-5pnci-o7zqi-set7a-pvi3p-5qe",
@@ -36712,7 +36712,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "r4dbq-jplty-hxb2n-yx4pt-dm2vf-m73ro-sqgq7-onnzn-zenvp-dleaz-mae",
@@ -36732,7 +36732,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "r4n6c-jrhs3-sk7hs-b4ach-gimkm-7adf6-tg53h-tajj5-goqip-76bja-cae",
@@ -36752,7 +36752,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "r5isr-snkha-pplwq-qorll-ovvea-rr7gz-efiq4-kabay-27hwo-jbcij-4qe",
@@ -36772,7 +36772,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "r5zha-ytiej-livta-dgmfr-j6kma-rdl4t-hldjg-hbydh-ogyjt-fow5r-4qe",
@@ -36792,7 +36792,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "r7few-pljgn-iynmr-iprtj-p66dg-qpc5m-2tx4m-245oc-6dzgk-pu2wy-dae",
@@ -36812,7 +36812,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rbq63-rtl4m-m27wq-eddoz-obith-vp3md-4qru2-ixpdn-ll66h-flbxc-pqe",
@@ -36832,7 +36832,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rcxhc-af5ln-myck4-qrbsj-aelzk-l4hy4-o4fws-7kx57-ajldl-v6pmo-fqe",
@@ -36852,7 +36852,7 @@
       "dc_id": "hk3",
       "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "rdjal-day5j-ugo65-7mfyd-6phlv-wppu7-7w3rl-3kjif-6tksn-pbeu2-pae",
@@ -36872,7 +36872,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "rfe2u-pdp5u-frzdb-r2ga3-5jept-24323-5pere-7lerg-toh4w-cwdsl-cqe",
@@ -36892,7 +36892,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rfkza-27bii-6jan4-u4zll-lkvmz-snmao-irmlj-arpdd-kyxrg-xnq3a-7ae",
@@ -36912,7 +36912,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "rg2yy-3or4h-pllvs-aczz3-dgf2k-3m3d5-oresl-easzv-2xa6h-7eoda-zqe",
@@ -36932,7 +36932,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rhy7d-pjsmu-5ljz7-vuaio-ihiaq-iysyk-np226-tirem-kuw7n-v2i2w-iqe",
@@ -36952,7 +36952,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rkfp2-lrkrf-t5dsj-qufu7-75l37-zqskd-aqivc-sim4o-3kwpp-ksudf-kae",
@@ -36972,7 +36972,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rkzu3-pcime-656cn-67oho-rkmjy-ko335-tjxqq-cd3cc-zmv4f-3kgug-pae",
@@ -36992,7 +36992,7 @@
       "dc_id": "at2",
       "node_provider_id": "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rl4ec-tk6gm-5pc5u-2vtnm-vim5f-xgjik-iolpy-lhjof-yvnu2-mwixm-vae",
@@ -37012,7 +37012,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rlmqf-hky3o-yeebj-bonzb-g2bdz-gj7bw-5gxdy-ykzm2-l6ado-yh64c-nqe",
@@ -37032,7 +37032,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rm5ia-lmctw-ylpu6-j7sx2-h7zgv-whmjk-4guew-6n3li-mwdjx-clfg3-vqe",
@@ -37052,7 +37052,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rp2ka-fxcyf-ghmgv-rgi3q-ugpxs-t2xfv-an2zj-yjzfk-kkpuu-pbha5-5qe",
@@ -37072,7 +37072,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rphlf-rfstt-sg5fi-ytcie-gnuwt-osv5d-fg32b-stlgf-5ajgi-tiw2i-eae",
@@ -37092,7 +37092,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rpmaq-iinj7-yufzr-4ekre-4sbok-wzkzu-guxeq-sxmvi-5rqm4-3kfe2-oae",
@@ -37112,7 +37112,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rs6nl-3tgam-nozcx-g77tr-hcslf-hpnhd-zl5ah-p4aei-pwqyr-rebml-vqe",
@@ -37132,7 +37132,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rtjw5-ja7cv-j7nyl-jc5mc-t7lol-wjouh-nh6tm-baoba-wzra6-toyp5-iqe",
@@ -37152,7 +37152,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ru3ys-qfe4z-5qljk-k2t7y-gcwso-uqkno-hwqtu-lms6f-xbw67-54skw-gqe",
@@ -37172,7 +37172,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rukdg-aswl7-rj4ll-qpnza-vhmtw-qooxv-zf5kk-zhvnu-o5bxa-ftekj-dae",
@@ -37192,7 +37192,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe",
@@ -37212,7 +37212,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "rv6cf-76ajy-qgcld-d7gil-e7v22-3sqfv-yc2zs-sn5r5-465el-pbym3-xae",
@@ -37232,7 +37232,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rvizw-rkeqq-2z72o-ppdql-zs3s2-nu3nb-agb2s-tmeld-phy5m-prebd-kae",
@@ -37252,7 +37252,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rwze6-4mvpx-o5pdv-3sujg-2szcx-223oi-f3jnl-jx27g-2qs22-dmt2j-jae",
@@ -37272,7 +37272,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "rzm7j-37ied-ynlvt-zma7n-r4bjg-wxg2d-kr4me-ss4yr-3p5se-n4sry-wqe",
@@ -37292,7 +37292,7 @@
       "dc_id": "zg1",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "s2p3k-c7zfo-3ogmz-esx75-id6pg-6xv72-kifmd-gp46u-ay6vt-d7i5d-5ae",
@@ -37312,7 +37312,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "s4nii-ep5vi-2fps5-3gs6i-3twfu-pbreo-kalps-k26wy-ivkau-5u2qf-uqe",
@@ -37332,7 +37332,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "s52il-lowsg-eip4y-pt5lv-sbdpb-vg4gg-4iasu-egajp-yluji-znfz3-2qe",
@@ -37352,7 +37352,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "s5waw-pnvds-kpwqg-n6bly-r45vy-ax64x-sltbe-bbzl3-74npl-u4sos-mae",
@@ -37372,7 +37372,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "sa67b-rto5p-rvyts-ehk7m-dpsnk-2c3w2-pmcx7-mzvgr-4p6co-ampd6-pqe",
@@ -37392,7 +37392,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "saw4q-px4st-tqivd-luwao-njxl5-hjiuy-7j365-mvphm-a5g5x-zkooy-kae",
@@ -37412,7 +37412,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sbae7-ta24c-4nofs-6bn35-iqzta-tmvbk-wtdef-f44ky-2j3bl-grgog-tae",
@@ -37432,7 +37432,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sbjj4-mggba-56ihm-lf4hg-mjzad-sg6up-lv4os-56vvp-vagid-ieawy-iae",
@@ -37452,7 +37452,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "sbjjw-fjmj5-k3qoq-dcty5-ndu4p-jyubh-jsjiz-v4pct-qpagz-uybjw-kqe",
@@ -37472,7 +37472,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "scjri-zcrz3-27aoo-a2ggm-alu4o-fcu4t-r5jy4-7hdeh-prukj-4cols-qae",
@@ -37492,7 +37492,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "scrp5-iiht5-iwgac-u36ff-jou7l-b7udy-mbim6-5nlte-5ki2w-6wyky-qae",
@@ -37512,7 +37512,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "scv23-prca2-pcw3u-t4eed-b44ts-2pb5q-gooim-7mmmu-sbixv-wmnf7-6ae",
@@ -37532,7 +37532,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sdytw-krjjp-mac6s-wnde7-sulf2-zxzdx-dpoan-4r5fn-qdgol-7buz3-mae",
@@ -37552,7 +37552,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sfjbq-jejm4-bxl7a-n3gag-vs6cf-xb5ty-xeagr-js35n-w76yk-di4sk-rqe",
@@ -37572,7 +37572,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "sfuvc-ddail-b7u54-5sthn-rk6vg-yvuf7-qjcv7-fxmgz-uqhtw-cuc3a-6ae",
@@ -37592,7 +37592,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "shg6y-mwjc2-rqfxr-7pi76-x3jed-yfn4p-v6gue-jbai7-uraz4-i35vp-eqe",
@@ -37612,7 +37612,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "shtwt-kuy74-afhyd-sivzp-nj3vl-vh2zl-hdsvv-yunlj-k3asp-zsigu-cae",
@@ -37632,7 +37632,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "sidaj-ga5xc-mraq7-deg3t-jdl3m-jrapt-eknlv-f7ys2-rglhz-ngedj-hqe",
@@ -37652,7 +37652,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sixq2-rmzuw-wsqrr-2ssrr-nxxyp-nnm2t-kykkx-tbglx-7urv4-z6ow4-vqe",
@@ -37672,7 +37672,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sjtwn-kupfb-fmu5p-twem2-vl6zm-uhqim-ahuup-pcwvi-g6v6g-qyybo-tae",
@@ -37692,7 +37692,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "slvlq-vbkem-g26gq-ttgb7-zkvqq-3k2hu-ij4bo-axmcj-texuh-tu76u-wae",
@@ -37712,7 +37712,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "smftg-i42r4-gjdo2-j5zsp-rnagz-jleds-scddh-2iloh-66uso-ttq2b-rqe",
@@ -37732,7 +37732,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "snaam-n24at-yjwgu-o62mf-y2cry-lsxfm-nilrt-mgyat-kshvj-rlhlm-fae",
@@ -37752,7 +37752,7 @@
       "dc_id": "nm1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "snwzs-jy7bs-y6t3i-kegus-3s5xm-ob7yz-bcje6-qjb2m-jgndt-5dvbl-oae",
@@ -37772,7 +37772,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "spr2z-4kaf5-2dxlg-hatfo-obp75-b6vwh-ts2z5-eurny-rbun2-z6m4h-kae",
@@ -37792,7 +37792,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sqlgm-qgcls-wjplr-obzev-6jjvo-svlxn-vb56u-2xdpu-c7hwm-hsp57-4ae",
@@ -37812,7 +37812,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "sqw45-bb5aa-rsstr-3lqro-2asg4-jqzqp-lp6az-2a2dr-tzil6-df7tw-gqe",
@@ -37832,7 +37832,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "srgrm-5pwg2-225hn-fxwdd-zphpu-wwxgu-uxako-avmlx-epw7e-zwkhf-sqe",
@@ -37852,7 +37852,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "sspbf-fne25-z7m5y-imq3z-ihf3v-qbyhd-ohrqp-zzfk3-dbuu3-zs7se-pqe",
@@ -37872,7 +37872,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae",
@@ -37892,7 +37892,7 @@
       "dc_id": "cm1",
       "node_provider_id": "eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "svosx-fbhms-fim5d-ndicw-6jxxm-xazvs-nq7m5-cvdfj-4fqnj-e6k52-vae",
@@ -37912,7 +37912,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "svvvx-7wy6s-l7mkh-ewfob-usdnp-dii3m-gfqc2-g67bp-h435b-d75iv-bae",
@@ -37932,7 +37932,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "swzzz-nct4o-kgh2s-fezeh-luamk-chexm-jsk4r-ks2qa-au63y-jtc7r-pae",
@@ -37952,7 +37952,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "syebw-myb4b-izq4l-onwhk-lujlq-yz5vj-4mbhd-jm6jf-2v2tu-xgl54-2ae",
@@ -37972,7 +37972,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "szmjv-e6ob4-glql4-ece2i-mo6uz-3cihz-mh35d-27dyb-3mac6-c5rcr-oae",
@@ -37992,7 +37992,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "t3d5h-mcdqm-lt7jk-b7nk2-nkxfi-dl4ew-pn776-olxjd-eyott-3hpjb-iae",
@@ -38012,7 +38012,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "t3fh2-surtx-hjh7n-dmwzv-rsj56-krypw-yh27v-lad6d-xughx-xebse-iae",
@@ -38032,7 +38032,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "t6xlc-k5t5m-5mf5p-yh5kh-ffsfs-qdm7n-lqsa7-zgmqe-wwrud-tgofh-xqe",
@@ -38052,7 +38052,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "t7ih7-rbewm-ftxuo-pw3gf-3dobc-lcryh-ew4wz-rwexh-667xe-a4yox-kqe",
@@ -38072,7 +38072,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "t7sk6-y3axm-g4po3-75th5-rov4b-c5xaj-uany7-lvs5x-e3iey-rl3l6-hae",
@@ -38092,7 +38092,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tacq4-bm63j-csjzs-oqw3x-ko3gh-oxk4x-e6odx-ir7um-xvuog-2l366-7ae",
@@ -38112,7 +38112,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tb2hm-euu7n-4z2ux-jgzrg-qhiob-4c7qy-sx5ss-7fsex-iak65-lpn6s-cae",
@@ -38132,7 +38132,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "td2et-sj5tw-njhtp-uw2ly-zwmwn-g4frd-off2d-5adoy-ybkoa-lj2ns-5ae",
@@ -38152,7 +38152,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "td5qx-fiwi4-mssne-56n7d-2fx6t-ccol7-t2ubd-3djlf-owwus-jgnoe-nqe",
@@ -38172,7 +38172,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tea2w-5lh3t-hsu2u-i5psv-bwpcg-tfbi3-54oej-wzfe2-gpbra-zqixl-cqe",
@@ -38192,7 +38192,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tetdc-mvyld-p3miw-jdreb-5apjz-w73pk-3y3jo-3w6qj-2lrsc-6d2bq-nae",
@@ -38212,7 +38212,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tfw5b-kpj3p-bniym-lllfz-fzcuq-4c65m-xqv3y-dy44l-fvmsn-yebii-pqe",
@@ -38232,7 +38232,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tg4ec-b2g4p-h42kd-k7zvb-6rls2-i2q7l-gtr4h-ymr6v-rrez4-w6fao-oqe",
@@ -38252,7 +38252,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tgmtp-wy3f4-hqron-bnvc3-scclx-b7fgg-gdnc2-dwvks-dn6ao-gbqso-5ae",
@@ -38272,7 +38272,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "thrb5-5dcyh-sdaja-dyupv-j3mau-sb5ts-3jczo-ar5bo-gi6jr-7gg5k-2qe",
@@ -38292,7 +38292,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tjg3r-ffr6q-hu7rb-4wevn-e4tlr-brdq3-zvobk-t4aof-5zix7-qfi2w-vqe",
@@ -38312,7 +38312,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tkdjq-rhpgw-7ubus-5w3nx-jrsdi-w4q65-e457d-yt2pt-hsz22-yehmk-uae",
@@ -38332,7 +38332,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "tkoxk-7juao-nynai-s6dt7-mpsfm-alwl7-yg5md-2zsbl-twivd-xbdae-4qe",
@@ -38352,7 +38352,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tlrvk-uwtes-ghpse-oekbm-jsrow-lf5kk-gqff7-c27d4-ozpou-xugiv-nqe",
@@ -38372,7 +38372,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tmevu-x7kon-mdgqs-552gs-e3gwf-wdeqd-egoxr-wn3av-v3vy7-ul7ca-tae",
@@ -38392,7 +38392,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "tn2ne-tskw6-dfk3n-urdmd-krtq6-tcebq-dx2xr-kokq7-eood7-fadkg-5qe",
@@ -38412,7 +38412,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tnjj3-xy6c4-ftk6z-kuhrs-zijli-xlbfg-j5gqt-qa77l-ehjkq-yxlua-2ae",
@@ -38432,7 +38432,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tpz2t-27cno-fbljl-lczc6-qjxrc-6fiby-naauq-3o6q3-fsxdf-yqg2v-yae",
@@ -38452,7 +38452,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tq3rq-mnjxc-3szli-4qntc-2nojp-telh7-kav7a-hjlyy-odlqr-lp2ie-pae",
@@ -38472,7 +38472,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tqkdx-4m6y2-avyzo-hkd6d-jqwka-3ys6i-ju6do-2auph-gb4bj-o7neg-bqe",
@@ -38492,7 +38492,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tqkio-anuek-ru44b-h5yvh-xst6p-mlo2v-evhb3-ov7hg-z53m7-sj4mt-fqe",
@@ -38512,7 +38512,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tqxq3-7iqja-lw5nm-mnvmv-bzmi5-a6evu-o7637-qr77e-rx7ca-dtnnj-oae",
@@ -38532,7 +38532,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "trupz-4o3zm-6itr3-6fjf3-ipbci-r2scy-pvycg-xlh4x-vtokf-avpr6-oqe",
@@ -38552,7 +38552,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "tsbrx-uiuyw-pf3h4-bx5i3-daxya-ygait-mnedj-kj574-vsw3u-fwuuz-5qe",
@@ -38572,7 +38572,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ttcnb-jbjt6-ho6id-7x33v-feaba-z254e-vfkcs-3nafl-6anc5-eurpf-yae",
@@ -38592,7 +38592,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ttjeo-6vece-x2hpb-lzmdg-b2fwl-7osa4-r5vb6-n4dyc-ocg5r-rztx2-eqe",
@@ -38612,7 +38612,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ttjma-2i6x2-e7nan-fmldh-po4oj-nfksl-czde6-gddrj-22ace-3oq36-uqe",
@@ -38632,7 +38632,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ttz5n-knkix-uo3jx-ue4uq-yd276-5w5op-heyhs-22eda-eaq2p-7vnow-hqe",
@@ -38652,7 +38652,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tu7cd-aljf3-56j73-xdusu-fyjps-sgkoi-5w3fx-p3vvd-tusca-w2vyl-bqe",
@@ -38672,7 +38672,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "tun2n-sml7l-zb2qs-pytga-kx2qy-6gi7a-u6wzz-zu3ji-vnhql-7hzzd-uqe",
@@ -38692,7 +38692,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tws6x-33lmm-tptgb-v2tte-opnm4-fychj-thpve-x4ofu-cn4vo-6yuhl-qqe",
@@ -38712,7 +38712,7 @@
       "dc_id": "bg1",
       "node_provider_id": "otzuu-dldzs-avvu2-qwowd-hdj73-aocy7-lacgi-carzj-m6f2r-ffluy-fae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "txayu-urmo6-slpeu-jdtqb-757qt-wj6v6-eznxz-dcuow-lsei3-6z5sd-eqe",
@@ -38732,7 +38732,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "txh2c-fneot-jj3ys-cx355-22tvp-cw3az-ohxyy-rk7ok-d7ppu-efk4t-iqe",
@@ -38752,7 +38752,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "tyv4e-thhn5-svu3d-jvx3v-2hajh-st6i3-ytdnx-waozw-hwxut-jxajr-mae",
@@ -38772,7 +38772,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tyysz-7t5yp-ji7y6-7yazd-rvt6k-poda2-ttuih-5tcxt-rgexf-fya2j-wqe",
@@ -38792,7 +38792,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tyyya-fh3vu-ld3ya-ezkit-zgeze-42dwt-g52tz-m4pwe-ldtw2-rntai-cqe",
@@ -38812,7 +38812,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae",
@@ -38832,7 +38832,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u2odr-vwc6t-zdhjl-pbqhx-3jrf7-pbzsv-7w5dj-yrj6v-sevup-hbxi5-qae",
@@ -38852,7 +38852,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "u3ahx-ft3kq-pzlkr-imzus-aeqxm-cirqv-ymehh-xzctz-os4ud-3a74m-vae",
@@ -38872,7 +38872,7 @@
       "dc_id": "li1",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "u3aju-hchr3-tzfyq-si7ml-apkyz-agaye-6sua5-uhrgi-6j73y-gmakp-gae",
@@ -38892,7 +38892,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u3bgl-kw7h5-djuod-zigyy-xp3ux-l6y3z-e223a-wmaki-i3kbh-fmoib-sae",
@@ -38912,7 +38912,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "u3mog-24sa6-xaxdz-wsoeu-4snjf-weiig-robvj-q5wcp-g6qdr-d4qio-eqe",
@@ -38932,7 +38932,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u4ldh-zesgi-ulayi-3gcyy-vkjjz-df4wq-kuakj-an2eu-kmvjk-ruqmh-sae",
@@ -38952,7 +38952,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u4wm2-yrwzl-4774n-y4fkc-dgijp-woboh-5v4mi-7grjs-6z7th-zwrbm-fqe",
@@ -38972,7 +38972,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "u4zo2-i6nsc-mowwj-lf6az-s6rdo-caskt-a6yx6-fke5w-qyezs-lyqvn-tqe",
@@ -38992,7 +38992,7 @@
       "dc_id": "sc1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "u5ycx-4avna-dp4ca-svus4-iycai-cmcrg-do5ll-qmosp-segtt-5jmu7-dqe",
@@ -39012,7 +39012,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "u6e7b-mgtes-r5nay-mmrcn-p3rns-hj2fn-74dn7-cp2mu-kk24k-ljfnm-2ae",
@@ -39032,7 +39032,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "u6j47-wepye-qtjf3-vkvnv-q6nfc-a3wky-grxp6-wbjuy-xejgs-qalg4-4ae",
@@ -39052,7 +39052,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u6xbb-a7prr-3xylz-5zaq5-44ea6-plycq-z67jb-fardq-rsaop-ypkpu-cqe",
@@ -39072,7 +39072,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "u72ns-336f6-myqpk-aetio-fnywm-inebz-lg6ws-5mvdw-mjw6f-ezq2i-qqe",
@@ -39092,7 +39092,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "u7xea-i2nf7-uyfwo-r756v-dazwi-g3no5-aaylx-6dwmb-6jtm7-ezg75-3ae",
@@ -39112,7 +39112,7 @@
       "dc_id": "jb3",
       "node_provider_id": "mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "uafcv-c76tx-jzddu-wxygw-4yzkm-nyr7u-iwk57-bwind-wmupb-2wos6-4qe",
@@ -39132,7 +39132,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uagz7-wqv4y-4qaop-atron-s4syx-kmyrj-2wos4-qetmr-ppxpl-6z5lk-6ae",
@@ -39152,7 +39152,7 @@
       "dc_id": "lv1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uahck-pnznb-2ydoy-mjn63-dvsnb-m3ta3-d4pdk-wauml-eho75-n4lfx-mae",
@@ -39172,7 +39172,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uajv3-ocqku-n5d2z-kbw3g-mqsir-er7gs-mhsdg-27f6d-xbfjl-uugdr-cae",
@@ -39192,7 +39192,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "uavr4-iqlzz-7jogg-md4ns-myo33-65bge-dqvnr-z3d3m-r7oo3-qye3g-qqe",
@@ -39212,7 +39212,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ub4s4-wfatc-aqvyr-coedg-rddvk-ksrb3-f22x5-5rjei-qx2zx-qsawc-lqe",
@@ -39232,7 +39232,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ubipk-gibrt-gr23n-u4mrg-iwgaa-4jz42-y6gt6-3htxw-3mq2m-dwhv2-pqe",
@@ -39258,7 +39258,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ucf4x-3fk4g-j7zwf-6bigp-x4r4r-f2mca-tv7zy-cwl5u-cu623-eeczr-5ae",
@@ -39284,7 +39284,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ucty3-763du-zv55t-ym4zu-kpzvd-52x35-i5scw-wtujv-jc2ii-o2la2-uae",
@@ -39304,7 +39304,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ucumw-ex6s5-r7nyd-x546u-f4rcl-qllyh-waid4-xxzvn-25op7-gnsjy-bae",
@@ -39324,7 +39324,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ucznq-t6max-wjxsb-yryjd-qgrbu-5nn4z-qfwqk-chaap-lymtj-cktlx-jae",
@@ -39344,7 +39344,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "udlch-g42nv-er23m-bgpxk-oiymd-knkro-2dczg-hyv4x-2yiw6-q2jcz-hqe",
@@ -39364,7 +39364,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uf3xb-i4fzz-jtgv6-a5pga-i5cs7-ex4ck-d46lp-khsjr-3yzdy-xnjrc-xqe",
@@ -39384,7 +39384,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ufgcf-ppfyc-5b5ub-oeabr-x3ao7-icnls-6efbb-twe24-iuupg-4ly5n-6ae",
@@ -39404,7 +39404,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uhrif-ti26v-vaz7i-kjosf-e3kfy-qchtb-iuxii-3qxdo-3svyt-hhrm7-2qe",
@@ -39424,7 +39424,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uj5bp-c66bz-meslf-u4uts-q3njs-tgfnr-bueq6-372lq-yz7so-4fu27-3qe",
@@ -39444,7 +39444,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "uk2oj-boped-fna3m-jydna-gwq5y-2adis-g6ntw-ntvzd-2ranc-g5xlu-4qe",
@@ -39464,7 +39464,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ukmex-exflw-a4lyh-hrbdr-hjywz-v555q-cxq5y-md4as-2zt6b-fwxzt-aae",
@@ -39484,7 +39484,7 @@
       "dc_id": "si1",
       "node_provider_id": "dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ul255-qfm5p-l7vvw-snswd-7kbqz-bmusq-r6vo5-j55zo-vscwa-qfwcr-sqe",
@@ -39504,7 +39504,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ulco4-b47tr-dzsmw-unogg-pk6bt-5eikg-2do2m-epj3g-6w4bw-agelf-4ae",
@@ -39524,7 +39524,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ulcre-xbhsb-in5ny-xqhwy-nolvb-xzw22-fcp65-jutld-c2pjz-y7ydr-gqe",
@@ -39544,7 +39544,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "ulhxy-qlokv-5iual-yizlo-dtlmi-aavz5-bi7ez-kjwqz-la64z-cxjuk-fae",
@@ -39570,7 +39570,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ulsfy-bqajl-ktzwn-pgr2u-s4uyu-jipgr-etcjd-smsyr-ulind-u3nr5-hqe",
@@ -39590,7 +39590,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "um4so-2axl2-74745-lhyhn-afhgh-yog7e-pcsso-mxxho-7x5ev-x65uz-eqe",
@@ -39610,7 +39610,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "um5l7-ktiyh-sggql-murjx-27rjp-xw52j-gopyv-cvrl2-sc6ez-x34mv-7qe",
@@ -39630,7 +39630,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "umi6t-fnncc-uc7hn-ve6ng-6gefg-t2oxq-qy7zs-xcw4r-5uuh7-tlyn5-5qe",
@@ -39650,7 +39650,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "un26u-2rdxx-incuh-txlau-breig-k2ipi-wargx-73by5-prrcl-nnbdo-bqe",
@@ -39670,7 +39670,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "undrq-arehp-l4l4j-oglha-im5th-hwh7r-zki4m-ovfw3-54iqo-ukqro-vae",
@@ -39690,7 +39690,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "unlo5-hg3gz-fp3ql-ucags-rlskr-gauu7-h4kr7-cir76-amjwe-xnzzf-jae",
@@ -39710,7 +39710,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uouxk-c246i-dgxzd-ql3a5-koofn-mclrv-toplo-bg76d-l4dzk-ngb3c-nae",
@@ -39730,7 +39730,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "upg5h-ggk5u-6qxp7-ksz3r-osynn-z2wou-65klx-cuala-sd6y3-3lorr-dae",
@@ -39756,7 +39756,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "urqca-gpbct-5fhv5-ngvjp-7zfj5-jerf5-s5hc3-r2qlh-4s5m7-z53vn-dae",
@@ -39776,7 +39776,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uset5-ffvx2-tsfys-n35qu-bbx7m-d3x3r-d5fcw-7d44p-sefly-4cg4h-vqe",
@@ -39796,7 +39796,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "utfc3-bg7gx-7r6nx-iwf33-vjzne-bkcbn-jws7x-fgox4-pc4o3-pyzjb-zqe",
@@ -39816,7 +39816,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uuihy-aveou-6yfnj-alaq7-dsheg-5lfjl-ggw4p-qypqy-qqxjt-rjokn-2ae",
@@ -39836,7 +39836,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uutlq-cgsfs-t5h2j-cxpra-iokzp-kormq-kzur6-xzegu-76tf6-anmti-dae",
@@ -39856,7 +39856,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uvyny-tt2f2-rb743-fk6ia-qn6ut-c3qyb-ob3aw-6qcvm-qbktr-pco7n-2ae",
@@ -39876,7 +39876,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uw4qe-cjsp5-sfdvk-3d5y7-ufvcj-mi6x5-f3xtd-ovphb-6ipa2-aw3pq-lqe",
@@ -39896,7 +39896,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uwg6h-pczq6-tpue3-5tjxu-h3f76-kssha-24fbk-5qb7w-q5i3w-pctxq-oqe",
@@ -39916,7 +39916,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "uww6o-imb3e-w3kxy-feb2g-67bsc-ewq5x-big3k-6soeo-2qef5-eilfj-rqe",
@@ -39936,7 +39936,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ux7wu-iidyv-r5cth-tz6n5-4xryn-av37c-24lrk-ozfaq-7sjax-ohkd2-6ae",
@@ -39956,7 +39956,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "uzy2p-nvzre-vqaov-qj7vj-bznwn-mllrr-t25mo-lbody-dgyf4-o5rj7-sqe",
@@ -39976,7 +39976,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "v2664-lhs7c-zjjmu-7mxop-hbms6-btu7v-hsw7n-rspqg-l3kn2-tdfa2-7ae",
@@ -39996,7 +39996,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "v27at-hedf7-4a2my-tboq6-escdm-77krt-2qfuq-zjptf-z2sbk-vd7zs-xae",
@@ -40016,7 +40016,7 @@
       "dc_id": "ar1",
       "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "v2pkj-vpsow-fp24q-zqwfj-p3nek-m52xz-oz6ra-blmra-73voj-jvwb5-gae",
@@ -40036,7 +40036,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vaqrd-u6ayx-65ttp-6y5yg-touwv-dvpxn-uoxpx-n3bzg-wbq4b-7lwx3-jqe",
@@ -40056,7 +40056,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vavxh-wzhxn-jxxv5-cu57r-amggd-3e2mt-xeddr-iikdn-tyvdz-pxg7d-bqe",
@@ -40076,7 +40076,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vbioo-upfbh-oizoc-ff7qg-ff3ec-gj3lw-yzrmu-7n2gd-6f3m7-q6mhv-dqe",
@@ -40096,7 +40096,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vc3nr-l5jgn-gtc5d-mughf-nirey-h7q62-sx6g7-vgrad-kxezu-cd5gd-fqe",
@@ -40116,7 +40116,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vcad6-gt6le-nn42z-uazqx-eb2ph-bawz6-4jtzk-qd45q-volkt-hednk-bqe",
@@ -40136,7 +40136,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vcl5k-pctnh-iqitr-mg7h4-a3bb3-j5cpy-w6yvz-ak5tb-q4dgq-z5lgw-4ae",
@@ -40156,7 +40156,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vcwuo-t2lqu-wwsni-eujqn-4kg67-ofhgk-g62he-njsif-avlmz-nenht-jae",
@@ -40176,7 +40176,7 @@
       "dc_id": "jb1",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "vdovx-dl5sn-qiuh5-dltyl-o2yec-6warj-44mi2-slcbu-vvyj7-bxocf-pae",
@@ -40196,7 +40196,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vdvh4-bdy7m-gyxbj-7pt5m-ykhey-mtobh-ul4kq-mwozd-t6enu-3pcau-jqe",
@@ -40216,7 +40216,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vevca-ck7t2-xx3sp-brhvu-6ruld-fgfwl-epyfo-lyukz-fypcm-6ta5x-qae",
@@ -40236,7 +40236,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vgpqf-udio2-pndqt-qweze-okgmn-yzqh6-i7ym4-mospu-sxsn7-khoxs-wqe",
@@ -40256,7 +40256,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vguej-xvzwk-r5a4a-fkmbl-pxlxt-y6ser-ldurz-dbt7o-7k4fh-biuuf-5ae",
@@ -40276,7 +40276,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vhklp-t6h2c-rle7g-46vqy-gtpp2-gafj6-wuesc-o6dlk-u5dzq-tr6l2-hqe",
@@ -40296,7 +40296,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe",
@@ -40316,7 +40316,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vivoi-pgaro-d7j64-broi5-wf4ig-3n2jq-sp366-rgh56-yx6do-gcx3w-mqe",
@@ -40336,7 +40336,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vjoxy-gu5gj-5xha7-36uu4-rifa7-6dj2u-z2oid-lspfa-a6l3q-6t27d-mqe",
@@ -40356,7 +40356,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vk6nm-npifh-27nde-q4vxf-ezmew-3qczx-qyxnq-dzhzk-vza5r-oaz4c-bae",
@@ -40376,7 +40376,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vkswv-32qcl-ena2p-s4xyb-7my5a-uzh7o-xhdtg-cseuz-dydzs-nwf5l-jae",
@@ -40402,7 +40402,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vkuk6-hptcl-ywggq-w34f7-a3mnn-kxbkq-kaeo2-zp2u6-6rakn-wrdgi-pae",
@@ -40422,7 +40422,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vmzrz-weexa-xlaci-rs37k-ld6pb-xe7x3-y7ryv-qvxkx-syybl-t7pcy-nqe",
@@ -40442,7 +40442,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vn5yd-eiwsz-jdwpi-ox2xg-wlwob-bbq4i-s4l2f-sz7ek-nmjtk-vhoxb-hae",
@@ -40462,7 +40462,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vnpue-5fuxi-ohnuw-rfmcm-sah7c-n3rp7-czp6u-uqi7d-ainkb-4mq7f-vqe",
@@ -40482,7 +40482,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vodet-jwe7w-uo3lw-mzljp-orvu4-d3e2q-ymdga-kqlck-wgs5j-hmcyz-sae",
@@ -40502,7 +40502,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vp3t6-recv4-mu2h2-bjiki-5s2so-gpfsp-z5axz-hvkd2-swhcj-4jj7p-uae",
@@ -40522,7 +40522,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vrccq-gbv6w-ejqbu-kkput-4gggb-gcpnl-wwckh-3tug6-7xly4-sg562-6qe",
@@ -40542,7 +40542,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vs5lv-6h44x-qfalu-aesc6-uehxl-zlwiu-5z7ik-c3kjy-6vtxl-3yz7x-qae",
@@ -40562,7 +40562,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Degraded",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "vsuqg-6hald-hxxxi-bxr2s-e5af5-p5lsr-2sutj-pip7r-co24u-2he35-hqe",
@@ -40582,7 +40582,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vt5q3-2bev5-yhmxc-uxp3l-j26fn-tnlfb-sdstt-yoqf4-bio44-yyycs-vae",
@@ -40602,7 +40602,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "vtbf4-olrta-q4eso-47b2z-ncgrs-lksia-xohkj-slwil-m5xoi-uxovi-wae",
@@ -40622,7 +40622,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vte5d-zw5lg-axpbi-yrc6s-nm3mj-knu44-piwp3-ukrtj-xb4s5-mleiq-lae",
@@ -40642,7 +40642,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vudfj-wtx2a-hrx3r-rzc5m-dbuc2-hl5m6-b2liw-pxjzj-ugiwp-62frd-cqe",
@@ -40662,7 +40662,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vuizy-nfm5v-rapnc-rijer-hijfx-bvjrz-ccxdd-kte3v-awbnq-bdm6m-6qe",
@@ -40682,7 +40682,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vus4f-waxil-4f7jp-rpl6l-i4yj6-fv2xp-dwpbt-xd6re-ak4h2-hir4p-iae",
@@ -40702,7 +40702,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vw36t-lgksm-5cgtg-ait3y-sy25v-gdtsq-en6oe-md35y-a7cji-uiryt-3ae",
@@ -40722,7 +40722,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vwsvq-sp3z5-kjy66-srr2f-esws7-mzchn-oeqdb-n3qvz-wrzni-4pcsy-lae",
@@ -40742,7 +40742,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "vy6tj-7mw6l-hp4pv-ly5ez-dy23b-aqicj-5u7et-rlmyq-n2rin-7fck3-tqe",
@@ -40762,7 +40762,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "vysyd-tlwq5-f5vfi-kw2jc-ziylz-di2s5-sf4p3-iflm7-vyvjv-hz3b3-pae",
@@ -40788,7 +40788,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "w2sev-mtuls-aa7m5-cdjgi-5vipg-2jn7i-4awvf-o6suu-73ebs-sw5db-kqe",
@@ -40808,7 +40808,7 @@
       "dc_id": "pl2",
       "node_provider_id": "zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "w2zci-bq5jo-vzrng-42mks-hvytn-she3z-52pej-vmigw-tic67-4prc6-qqe",
@@ -40828,7 +40828,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "w3co4-z46r5-qgtqz-loljb-255rf-qtiqn-7nuck-f7kim-jaezk-5kdss-dqe",
@@ -40854,7 +40854,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "w3phu-4ihah-tqdl6-n32hp-e5254-l6ybu-kvmmx-thj6t-q7z7k-swvi4-iqe",
@@ -40874,7 +40874,7 @@
       "dc_id": "zh3",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "w4ri3-ytfnq-jg3z3-qseka-se4xe-b2fl2-km766-ruzwd-riw72-6bifs-4ae",
@@ -40894,7 +40894,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "w7ahu-lheyl-fxlh3-fcid6-ey4qj-7qjj7-yobio-qhb7u-jf5zg-6jp3i-mae",
@@ -40914,7 +40914,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "w7nib-k37s2-4fooz-7ywrw-xdu5y-rnr3v-t5n2n-pg63m-tnren-bmcnz-nae",
@@ -40934,7 +40934,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "w7v5s-nethv-crfsc-zzq5e-gibjz-dmmyp-mrl6e-vkvid-g56eh-iilcm-eqe",
@@ -40960,7 +40960,7 @@
       "dc_id": "ns1",
       "node_provider_id": "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae",
@@ -40980,7 +40980,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wazkf-2xehg-y26ek-2uq64-pkrbh-6frmq-4q7lf-5gaya-44q4p-v5r5z-cqe",
@@ -41000,7 +41000,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wbazg-vj5ii-5h3d6-jopmi-3zlpk-kitkf-nbf7f-fvfbg-emg2h-sz763-oae",
@@ -41020,7 +41020,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wbopa-jneat-aqzgd-gvnf5-bwok5-dyxaq-s6wls-obkm3-xqltv-l45vb-xae",
@@ -41040,7 +41040,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wbz2k-b6che-eckjw-vdwro-gyxhj-276mr-lxijv-wvk6b-kdmqn-s7zzh-6qe",
@@ -41060,7 +41060,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wc3ak-klemd-6cflb-ekdoi-ygdnp-5fomb-oy2j4-3o53i-qdfyj-yvcqz-5ae",
@@ -41080,7 +41080,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wdg4t-afemy-nttou-sdh2u-b6lik-2cuxv-frfoy-wjige-z4qy5-wheg6-kae",
@@ -41100,7 +41100,7 @@
       "dc_id": "gn1",
       "node_provider_id": "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wgigf-asogz-mx7ne-27hly-zynet-2ly45-q5pq4-wtmbb-yidjg-ctidi-7ae",
@@ -41120,7 +41120,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wgxbt-4e5xm-lsyc6-kazar-7kvzj-7biff-vzt52-2hddx-h3ddg-pfd3n-iae",
@@ -41146,7 +41146,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wh2dv-njrdv-4xdwd-dflb2-mjoel-l6pkz-e37ap-pkcjx-jyasn-hawsc-wqe",
@@ -41166,7 +41166,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wihnn-o5yix-kkneh-33pvm-ybil3-4rdf3-vu3w2-6lmg4-76yu3-feyyd-cae",
@@ -41186,7 +41186,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wix7d-hb2a6-2pcsi-xwm54-gmlxk-gfh3d-dtfog-h7o35-vzm56-w7h34-6qe",
@@ -41206,7 +41206,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wjwzb-q3ogf-fi3po-kf6y6-wzuuj-3ac3m-kjvab-fufsm-z2skq-kthkx-xae",
@@ -41226,7 +41226,7 @@
       "dc_id": "kr2",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wkw34-wwzzv-nfh26-sf4ad-b44dc-eip6h-iunfu-dbkdt-anlru-ozyfy-dae",
@@ -41246,7 +41246,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wl27x-2kxme-etw5x-2iuy6-qrkna-uxfoc-swvej-o3jh2-xccz4-warv3-cqe",
@@ -41266,7 +41266,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wmoyy-drk3r-otwke-cikkn-cyd7x-v62ys-uijg4-mqtmn-3jm7g-crtd3-jqe",
@@ -41286,7 +41286,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wnslx-ruako-qg3bc-j2gyu-w5ywn-6c45g-jfjaa-zbu53-r4oid-5nigq-pqe",
@@ -41306,7 +41306,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wnuri-kqarn-qyjem-ae34x-dhkub-ocuug-3xjnj-xydiu-pmpkx-56lnn-3ae",
@@ -41326,7 +41326,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wolwk-thbgv-pnuak-dodxy-l5owl-mrfgz-alrb6-whu2h-rbmbq-5obcq-wqe",
@@ -41346,7 +41346,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wonxb-wwggg-nxsfi-mkmmd-b5g65-2h3ct-glu5s-o6jb5-5ifbv-w3zdv-vqe",
@@ -41366,7 +41366,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wp6mx-2sb63-kcsof-76nut-6lsfr-gwwxe-xjbxf-gwc3w-jztl4-kjag4-mae",
@@ -41386,7 +41386,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wpqor-fmb7a-s57pj-fpk73-jlsrf-njegl-oepy3-qwwkv-54wjl-qmlev-oqe",
@@ -41406,7 +41406,7 @@
       "dc_id": "ch3",
       "node_provider_id": "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wpypp-7pqo2-223kj-yh5ey-j2iyz-yvj7v-phrzl-ecdji-eecpl-54j3k-lqe",
@@ -41426,7 +41426,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "wq2um-36gqt-pvygv-uwfwa-qthgq-bgrrl-76hlx-qu5ig-557sj-i3ekh-lqe",
@@ -41446,7 +41446,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wq5v7-ngito-7ztqs-zlf2v-ibk6f-e54em-t3hou-x24kz-v5j77-6vo72-kqe",
@@ -41466,7 +41466,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wqpvr-pr3vg-4xbik-zfhld-l27xq-r65f2-sxb3t-2vej3-hfvk4-lmsz2-hqe",
@@ -41486,7 +41486,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wqqsg-ww46o-muchq-pty53-amebx-mucdz-ugjkt-fvjqr-5ncmg-knqg4-aqe",
@@ -41506,7 +41506,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wr22o-nmso7-rmkqr-vzkv5-eg2cd-kxx3o-jbjnc-e5tjy-ety5p-rz4vf-uqe",
@@ -41526,7 +41526,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "wucjd-56dwd-trvkn-wolro-tdsxw-v4nw3-hnmtl-a55bf-y3mov-r6x2v-nae",
@@ -41546,7 +41546,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wumhk-r53t6-jf2n6-7yi5y-levhb-jbvqk-cxdwc-3tbh2-fe3nq-d25q7-jae",
@@ -41566,7 +41566,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wvdeg-tfq6p-ahjbt-mdicu-hh3hr-243lv-hd5pw-xz2ym-xgaz6-bwmg6-mae",
@@ -41586,7 +41586,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wvxfb-eqeex-26z4r-vefff-llfh7-vv76x-pje4o-oh57m-eklny-zcs56-wae",
@@ -41606,7 +41606,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wwpob-ttemi-zg5fc-us2jz-3q3gm-mhzmm-higzj-2bqrr-7tmoz-ajy7l-wqe",
@@ -41626,7 +41626,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "wwwxf-wrvqf-3l3mr-iryoj-gvsjj-yex74-mhput-ag4mv-yftkg-xny2a-gqe",
@@ -41646,7 +41646,7 @@
       "dc_id": "ge2",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wxhcm-5armm-j6fvs-lts6q-waitz-k6t4q-ncfbh-2t6ee-nv2tn-keod2-uae",
@@ -41672,7 +41672,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wxpaf-p35qf-lgbep-ea4cu-dfxwf-65xgh-5hoyq-lplcs-ztt5m-nbweu-zae",
@@ -41698,7 +41698,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wz42c-ah6mx-lt7c6-vnqcm-kjnd7-52x65-2yfqw-ibpxs-th23v-7z3hl-qae",
@@ -41718,7 +41718,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wz454-xw43u-5u4rs-z3dlw-l5wjv-jj5xi-s2yvk-3j5on-my3ld-qmnex-lae",
@@ -41738,7 +41738,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wzlzb-tsogt-yb3nr-l44x6-moo2i-ccd2g-i3mu7-66e2n-6bacx-i2h47-hqe",
@@ -41758,7 +41758,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wzobn-oqy6r-qnhrl-6qvxp-3dizc-5gb2q-tbtnc-ptnfl-vyxkw-g7gxc-4qe",
@@ -41778,7 +41778,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "wzrqt-5cxzt-i5g2h-irxh3-33pao-qke5v-6rfz3-brj2a-ibjnw-ycqlx-xqe",
@@ -41798,7 +41798,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x2il3-dwivw-7rtte-qifaa-73bee-srh65-5slbq-l7dnd-xz3lc-mjoey-7qe",
@@ -41818,7 +41818,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "x34do-riu6i-7pn3y-5pl7d-zs532-xduns-xaadp-4e34h-casgh-qywuj-7ae",
@@ -41838,7 +41838,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x3rso-73u7b-3pyeo-3fmcu-g635n-ri47m-jv3kg-zjfub-aqxsb-tnxbq-nqe",
@@ -41858,7 +41858,7 @@
       "dc_id": "fr2",
       "node_provider_id": "wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x3t5j-kmxkj-vmc6d-jxrqf-qd2v7-bszg3-mh4j3-a6yn5-2bgkv-wtmu7-iae",
@@ -41884,7 +41884,7 @@
       "dc_id": "lj1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x42ek-p4h7e-aaj3o-qydgt-mbr7g-uzakg-peeec-dtle7-oi2fa-d536i-cae",
@@ -41904,7 +41904,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x52y3-d4e7u-rbtst-24n4z-vviy7-z5oxq-tjgzi-v4gpb-auyly-4pin5-bqe",
@@ -41930,7 +41930,7 @@
       "dc_id": "ty3",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x65cx-a7sdm-q3sli-wg2gi-ooqns-nrfui-cfhrq-hl4vg-i2qb4-4mluf-hae",
@@ -41950,7 +41950,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "x6ufc-46e3d-cvse3-vbjz6-gkrnq-4lpvu-6lloe-l24kd-y75gq-3pmt4-tqe",
@@ -41970,7 +41970,7 @@
       "dc_id": "nd1",
       "node_provider_id": "7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "x766n-gnzao-y5q7i-4truy-tzh26-lt3a7-nobwi-4zjjy-a73af-utbwa-wqe",
@@ -41990,7 +41990,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xatzx-j3mph-3xzxk-jz53j-afa3d-qxnac-fbejn-hvgpy-cmhlb-dkuhv-nqe",
@@ -42010,7 +42010,7 @@
       "dc_id": "sl1",
       "node_provider_id": "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "xav3a-kdo3a-2rgbg-o6vnk-clat5-bcc7w-vmnej-z55rx-mfx26-7xugo-tqe",
@@ -42030,7 +42030,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "xbcli-rnhjh-26fm2-om2gn-ysqvs-kufba-vvz4a-dy32s-ntpwk-pdkfs-aae",
@@ -42050,7 +42050,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xbeha-2lqtl-qb5tx-t2zgf-y3t22-iuqkv-fhemo-dnpr5-wwlxl-auyrq-jae",
@@ -42070,7 +42070,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xbsjm-f7kbx-wrerv-ponbs-e3kjp-pvt6d-lgjfv-kolpw-c4j3y-to5pe-7qe",
@@ -42090,7 +42090,7 @@
       "dc_id": "kr1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "xcf7l-ooft2-42awo-ey2j6-2tlnw-4faa2-tbw3c-kfjlh-sazyp-4sngc-lqe",
@@ -42110,7 +42110,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xcfmt-vumwz-773ew-pvwnt-lgwlu-prfzm-lvitu-bx7ru-ncgqg-srhut-mae",
@@ -42130,7 +42130,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xcwtx-6q6nc-6wdqw-exmsq-6e3rq-frj6x-ovoi6-f5ovs-vw3mn-5gkjn-wae",
@@ -42156,7 +42156,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xetvj-ysqpy-wnnd4-fbytw-n6arq-w7f5e-fhsuo-7xd67-lwpt2-novnx-iae",
@@ -42176,7 +42176,7 @@
       "dc_id": "tv1",
       "node_provider_id": "6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "xexdo-rsh52-bcci4-xrieo-3lazn-mws2u-xv4j2-egawj-gh5ps-t3oww-bae",
@@ -42196,7 +42196,7 @@
       "dc_id": "hk1",
       "node_provider_id": "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae",
       "status": "Healthy",
-      "node_type": "unknown:multiple_rewardable_nodes"
+      "node_reward_type": "unknown:multiple_rewardable_nodes"
     },
     {
       "node_id": "xg4uf-fjkka-g2ura-i7wjc-ymj7q-vxdrg-bplmf-7enlx-rkx6d-sys2j-lqe",
@@ -42216,7 +42216,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xgowg-hchuw-kyj2p-bmcs3-r6sb7-oc3nk-draiy-dyj3z-enhm7-ssvnl-kqe",
@@ -42236,7 +42236,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xhha5-oe4lp-ij2xv-gqhfe-pjavc-lwazu-y2wcm-rsvqw-hpvso-ksn7c-fqe",
@@ -42256,7 +42256,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "xiagf-4pdgj-efen3-ywuo5-jv2wz-fwc5y-bdzwj-epe6u-vxpa5-xc4nx-6qe",
@@ -42276,7 +42276,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xj356-s5zzj-23mti-c7mma-ac5mi-2b7ha-wouvr-oguww-qxjfw-ytgqa-vae",
@@ -42296,7 +42296,7 @@
       "dc_id": "se1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xkk4b-g3nki-3rz3f-3ffjs-i6zax-atwe4-kson4-27uqd-woqd5-mc4tn-iqe",
@@ -42316,7 +42316,7 @@
       "dc_id": "at2",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xll74-g2hbn-jkxky-c2m6n-bfobh-j4k33-haawc-ggiuh-ro5ce-uwm3z-xqe",
@@ -42336,7 +42336,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xmd24-at2b3-lu4ow-xmu7y-hdpcz-356q3-6b2re-vufkh-274hf-cirtr-dae",
@@ -42356,7 +42356,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "xmg5b-vziyw-6bzii-yfbmt-zll6k-v5bd5-m3ds6-7vdyy-wmnkd-lznvp-jqe",
@@ -42376,7 +42376,7 @@
       "dc_id": "ty1",
       "node_provider_id": "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae",
       "status": "Dead",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xnraq-n62so-zdfy3-63wd4-dbf55-m2h66-xcpbu-laatr-52ytd-5gdv3-wae",
@@ -42396,7 +42396,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xo5aj-2kwg2-svhz6-kvtc7-hrzw3-4dsx2-mrioo-h4pcb-6nwap-w5dqx-vae",
@@ -42416,7 +42416,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xoefx-zvgdp-ccp4e-3fri6-6r3dp-agydz-fcph4-xu4bz-n5wku-g7jk3-2qe",
@@ -42436,7 +42436,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xp737-mf6s2-27fc3-w22ge-g67ck-levhr-yf4a3-f2luo-4xd3y-3veag-pae",
@@ -42456,7 +42456,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xpit6-cyps4-ru26l-kw5rs-hbtll-yr7aw-ywa4o-2ibcf-zaich-qrzdq-3qe",
@@ -42476,7 +42476,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xqhoe-c5pck-wcytx-owvyr-mntbp-u22ct-nvcqi-bri5w-sjow2-rs4gp-sae",
@@ -42496,7 +42496,7 @@
       "dc_id": "tb1",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "xru5o-szzyw-iryui-xsejm-z7bjz-vdlql-mop2t-35so3-kyavu-ucmkw-fqe",
@@ -42516,7 +42516,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xs5iy-nxwwp-pf2br-3544d-el6uf-xu2kf-qxqzm-sizvd-vgwfm-iqifv-jae",
@@ -42536,7 +42536,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "xsa4m-ko3b7-2zvcf-56q55-ahyqi-2qkho-obuu3-l4otg-4z6fn-n2r6i-cae",
@@ -42556,7 +42556,7 @@
       "dc_id": "bc1",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xszxr-w2ae6-g2fof-f6hp4-cquvx-4vyu2-ux2tn-nij6l-b7hue-4r4kl-gqe",
@@ -42576,7 +42576,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xtnry-ylnfl-gxtju-wn57e-qjzs3-zjjti-l2cqb-ai3vi-ylhvo-auqir-7ae",
@@ -42602,7 +42602,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xu66k-6ji5o-ckrnq-2p5id-kqjua-gq33a-e5ucx-d7oqf-g2qdm-7ouc2-rqe",
@@ -42622,7 +42622,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "xu6mr-rd7cf-pq6uo-xf4bm-ivd5c-hpnp7-dpjhc-kkwnu-xeaqu-eue5r-sae",
@@ -42642,7 +42642,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xx3r5-cj7gw-wvtgl-57zur-asdjz-js3dk-xi6qx-kmhxr-lotud-r57jv-2ae",
@@ -42662,7 +42662,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xypz2-ls2al-37boh-5a22g-5z3qj-rh53t-63qjo-khc65-izr5n-hth7g-uae",
@@ -42682,7 +42682,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "xz3mr-oepgl-yylvr-4qaka-7itvg-kjntk-p4g52-pxbnz-2ztdc-q24o6-4qe",
@@ -42702,7 +42702,7 @@
       "dc_id": "ny1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "xzpf4-zeihc-upncx-zz65w-rep5j-xh2sy-yw6bg-qtgwu-5z3ez-er2gz-sae",
@@ -42722,7 +42722,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y3zlr-skryt-pz6zt-p6s2d-zynbn-bx3i6-z3tkp-itr54-67pt7-fvygi-gae",
@@ -42742,7 +42742,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y4kyj-fumcw-fv5xb-psiu5-m6amm-3gip4-v7loo-ikpys-fzneg-k5u6o-wae",
@@ -42762,7 +42762,7 @@
       "dc_id": "sg3",
       "node_provider_id": "x7uok-pi537-itm37-unjn3-ewkze-kuetg-kptap-nuqak-auq7z-tn5ey-dqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y6e2f-krz34-fbks6-zuqhd-hszxu-fynws-wnq36-am6jm-hpikb-4xtbe-mqe",
@@ -42782,7 +42782,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "y6mus-re3u7-vpqsx-xmhkh-jksck-rp2ko-xvjlb-7tdhu-jjm63-47alq-yae",
@@ -42802,7 +42802,7 @@
       "dc_id": "sg1",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y6xdi-6nbil-4w6ju-4vqux-wdl5m-uofuq-2hbv4-dels3-knu42-xievh-hae",
@@ -42822,7 +42822,7 @@
       "dc_id": "lj2",
       "node_provider_id": "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "y776u-wx7uf-annjy-h7ova-5nehw-iqgis-d7atm-cvlk7-z7rni-ag7bi-qqe",
@@ -42842,7 +42842,7 @@
       "dc_id": "ge1",
       "node_provider_id": "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y7bml-csbq7-euzyf-njmvm-qfftp-iy7lc-wisaq-jlmul-sdo7p-7lkx4-3ae",
@@ -42862,7 +42862,7 @@
       "dc_id": "pc1",
       "node_provider_id": "eatbv-nlydd-n655c-g7j7p-gnmpz-pszdg-6e6et-veobv-ftz2y-4m752-vqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "y7tlq-jft7u-4oboy-2gmah-skt5l-ofwoc-yp5aw-zpcik-5rrol-lnqkl-yqe",
@@ -42882,7 +42882,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "y7vmg-unfmv-u6gdl-piob6-7en2w-zmwjb-oqbpn-ufqkm-4i2cr-osl3d-iae",
@@ -42902,7 +42902,7 @@
       "dc_id": "zh2",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yahq2-6rnmm-n7ubm-q76zd-256dl-5f7k6-jxx5l-njyo2-hl7tk-sqcet-6ae",
@@ -42922,7 +42922,7 @@
       "dc_id": "ar1",
       "node_provider_id": "s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yakc4-7ajmd-g3e5u-w4a4m-qzb63-t62oi-pesr5-2okgm-a3swy-yodvd-wae",
@@ -42942,7 +42942,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yf2cg-6rxi2-5ieex-3swn4-xx3e7-qie7i-fwtkv-xi76w-prm3c-pdbvz-yqe",
@@ -42962,7 +42962,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yf2ct-a2auf-nofdz-acf6v-ugwyb-k5f6j-5sr3y-7h3xi-svcdg-mhpgg-aae",
@@ -42982,7 +42982,7 @@
       "dc_id": "rg1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yfrrx-cdjbg-wuvnu-okvjd-g72oy-t7xn5-i3kzy-yx2i6-vernm-wncxr-tae",
@@ -43002,7 +43002,7 @@
       "dc_id": "zh5",
       "node_provider_id": "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yh3a6-fzjir-23ow3-cnsz4-w56dj-veho7-qvu6c-psj3h-uscb5-4ikej-pae",
@@ -43022,7 +43022,7 @@
       "dc_id": "br1",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yi5cv-jplzh-hnw2e-cmfyt-qpfvw-pes2g-7jc4j-qfrmd-o66m6-iz4f3-iae",
@@ -43042,7 +43042,7 @@
       "dc_id": "ge1",
       "node_provider_id": "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yi6r6-u4kax-jphcr-jcqr5-t3zpm-gmp3b-2hiew-iinpf-sgjos-eabha-aqe",
@@ -43062,7 +43062,7 @@
       "dc_id": "ma1",
       "node_provider_id": "ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yidup-dwmh5-hruhg-lx45z-jjtys-mym7n-bafb4-lillx-gstnz-o4vvl-gqe",
@@ -43082,7 +43082,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yiepb-ll5lo-bu6ew-umwpb-cuvwh-7ohfx-lcuzd-zdqvn-vha7z-kg44m-kae",
@@ -43102,7 +43102,7 @@
       "dc_id": "jv1",
       "node_provider_id": "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "yikms-ku6l6-3brmt-a7wji-oizgc-gopwj-my4wn-y2nsq-mjq6q-acuaw-7ae",
@@ -43122,7 +43122,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yim23-u5r3y-yffo3-3hrab-vtvok-nw2qw-uzzbf-mvepc-fvnso-hjar4-6ae",
@@ -43142,7 +43142,7 @@
       "dc_id": "mtl1",
       "node_provider_id": "ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "yjbaw-7mgap-u2qrc-ol6db-ncf2z-wgxuy-4337g-2wjw2-6jjcj-wzdgc-5ae",
@@ -43162,7 +43162,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yld6m-kvarh-m5a63-yxlak-4ukqc-zxa6g-aenp4-hjb3o-muwtu-h3zba-zae",
@@ -43182,7 +43182,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yomjt-bk7tm-oklzv-hzqof-gfmfh-owb5j-zfmm5-rflzu-sdalq-gh4dp-xae",
@@ -43202,7 +43202,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yov4k-2vzzr-kr3vj-6nypl-4ymyn-7earu-72mkn-c5yeq-mhveu-yjrdn-vqe",
@@ -43228,7 +43228,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yqbop-eo5w3-icwxg-vnpny-4dk4m-3z2bk-7cfyy-zobni-mo3hh-r6owh-oae",
@@ -43248,7 +43248,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yqbqe-whgvn-teyic-zvtln-rcolf-yztin-ecal6-smlwy-6imph-6isdn-qqe",
@@ -43274,7 +43274,7 @@
       "dc_id": "hu1",
       "node_provider_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ys2ji-bntna-i5qn5-omhyt-vsqwk-6pgox-ruzaa-hwcid-idaoa-w7gge-pqe",
@@ -43294,7 +43294,7 @@
       "dc_id": "or1",
       "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ys5ct-b73ij-z33xq-y4tej-vby6a-pwzjk-t7ob5-y5nub-oe4vo-alrjn-oae",
@@ -43314,7 +43314,7 @@
       "dc_id": "bu1",
       "node_provider_id": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yszpk-lt4rh-gktee-rctwj-hrajy-vbg62-jy24t-47ua3-mu55b-yxonx-zae",
@@ -43334,7 +43334,7 @@
       "dc_id": "jb2",
       "node_provider_id": "nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "ytf6u-gadvf-mhb2p-pd6nh-ff7ca-a6xjp-vkmno-k2xum-vyzg5-jc756-rqe",
@@ -43354,7 +43354,7 @@
       "dc_id": "st1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yu73y-hspj7-taffm-lg54j-jxarz-44y53-kbn3m-4cpj5-56ksj-4ttyv-cae",
@@ -43374,7 +43374,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "ywdqr-vd2io-gz6n3-ey4ns-h7gu7-l4huz-dk36s-fr7er-lsftp-77wde-gae",
@@ -43394,7 +43394,7 @@
       "dc_id": "im2",
       "node_provider_id": "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ywict-j2wwx-ioq63-wqlrz-pmcsg-dcxrw-ibgcp-chmr5-m3dla-cjvjk-2ae",
@@ -43414,7 +43414,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yyjdt-kk2xx-ddp26-4rioj-spbg2-pvh5w-omag3-odlzq-nscru-4k4vq-oae",
@@ -43434,7 +43434,7 @@
       "dc_id": "ta1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yzcfk-wf4nx-j74ab-53zvs-hoj36-grjpu-q2rjd-22hpy-2wbdz-t343a-lae",
@@ -43454,7 +43454,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yzemk-6b2rp-oacic-mfwgt-ktwl7-u2wx3-ue4ma-wafwx-lp4oc-q3dgv-uqe",
@@ -43474,7 +43474,7 @@
       "dc_id": "hk4",
       "node_provider_id": "64xe5-tx2s3-4gjmj-pnozr-fejw2-77y5y-rhcjk-glnmx-62brf-qin5q-pqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "yzi7p-lnf22-u2wot-tgxzn-v3ubs-4yuqq-fywh7-4tkk7-ly2xh-r5byg-mqe",
@@ -43494,7 +43494,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "yzwxm-j2n2r-whdxh-xqftn-lobyp-h5c5c-zomu3-uqc7k-gatex-aoayd-pae",
@@ -43514,7 +43514,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z23fe-7tw5j-f3lfl-4vprq-f6pdm-22uqa-73lqa-pokor-bvb2z-gsu5f-xqe",
@@ -43534,7 +43534,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z2tgr-ilz6g-ifi6c-3yeiq-zo5sc-humd5-vc6s6-wogpu-yj5rp-wwuta-sqe",
@@ -43554,7 +43554,7 @@
       "dc_id": "an1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z44cx-f7ijv-m3muc-wzq4t-zsfrv-vu5ve-nu4k2-bk3rc-giwuj-2jn7o-3qe",
@@ -43574,7 +43574,7 @@
       "dc_id": "dl1",
       "node_provider_id": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z4b3v-2fo53-x4dpi-bso27-23pxa-g2dp5-6xll6-rchzy-2qzwn-op4cf-4ae",
@@ -43594,7 +43594,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z5dvz-5gafo-kxisu-skeph-hwzu3-x6ict-sogrj-ca32u-5v5i3-fq3fd-xae",
@@ -43614,7 +43614,7 @@
       "dc_id": "im1",
       "node_provider_id": "rpfvr-s3kuw-xdqrr-pvuuj-hc7hl-olytw-yxlie-fmr74-sr572-6gdqx-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "z5jll-2kgdy-vuzye-orvjn-u3uyz-2jrdt-5jxzj-hu5zv-pkts2-cvuhe-mqe",
@@ -43640,7 +43640,7 @@
       "dc_id": "mb1",
       "node_provider_id": "c5svp-7pkmf-agz5x-536k7-r7rcw-4wn3a-eo7pt-ry7su-j42uq-bvnzf-iqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "za7cm-bcsh6-dkayq-wbbbi-5pw7l-5dsqk-7isoh-osqdi-rmcot-pswxd-aae",
@@ -43660,7 +43660,7 @@
       "dc_id": "hk3",
       "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zatyv-4l26n-3lecc-xpeme-ul34o-yiye2-3d447-aiiz4-5pxtm-v44nh-cqe",
@@ -43680,7 +43680,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zbzin-kgyio-vai3o-ghyz4-36boi-4tjvv-7fis2-d2mlq-xk7fx-d4udt-xae",
@@ -43700,7 +43700,7 @@
       "dc_id": "vl2",
       "node_provider_id": "vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zcxej-wovzy-rxnvs-bcz3a-ruh4s-a3blo-24ej7-izr7h-toic5-ix5gu-qqe",
@@ -43720,7 +43720,7 @@
       "dc_id": "zh6",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zdean-nwelu-yqpdn-juy4c-avlne-xpl6z-5hj4p-gh7s3-nkfyg-piu5w-jqe",
@@ -43740,7 +43740,7 @@
       "dc_id": "an1",
       "node_provider_id": "acqus-l4yyc-h44lw-grfxw-h7jqf-mtvt3-huwmj-4s372-sc5db-5nsfr-2ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zeqw6-qucg4-gjbvm-ienht-zeoyv-tbqxt-bg7ia-i4zn7-xzlbr-3akbn-xqe",
@@ -43760,7 +43760,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zflhz-jyyxm-zccq2-s7jia-5nqio-alzke-6ccoe-pk3iw-bp5fz-5xd62-2qe",
@@ -43786,7 +43786,7 @@
       "dc_id": "jb2",
       "node_provider_id": "unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe",
       "status": "Healthy",
-      "node_type": "type3"
+      "node_reward_type": "type3"
     },
     {
       "node_id": "zgeaf-fcq4e-fcnht-g7mpg-sb7ff-r6awk-zvkwp-gkloc-rr6jl-ghsse-mqe",
@@ -43806,7 +43806,7 @@
       "dc_id": "ta2",
       "node_provider_id": "diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zgtrt-4vlgr-pbytl-t2yqq-qf4nk-wyoos-vrfpu-hxqcw-tcnfu-73kjb-pae",
@@ -43826,7 +43826,7 @@
       "dc_id": "bn1",
       "node_provider_id": "4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zi64g-qzbnp-3eu7w-mcz3p-2jb7a-he5lk-aru4t-goyi6-p2gtf-i4yqh-2ae",
@@ -43846,7 +43846,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zjcl6-i6eie-fllmg-27ohu-lm4cy-4dax2-7ppcd-4mgig-rtfpz-typl6-yqe",
@@ -43866,7 +43866,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zjiki-pzvnv-m4rnn-fodt3-poon4-uldx7-d3wkq-gptsu-g2mjs-boi35-3qe",
@@ -43886,7 +43886,7 @@
       "dc_id": "sc1",
       "node_provider_id": "fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zjmit-bxrzl-s7h6p-dua23-iwjyl-wbwa6-xlnaf-ouv3i-amdei-vw7al-zae",
@@ -43906,7 +43906,7 @@
       "dc_id": "to1",
       "node_provider_id": "2wxzd-qrbrs-ailta-kdtyb-ucg35-xcxd4-txevb-ot7hx-wiyus-szcca-nqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zk4lm-5c2p7-zhlqv-3pi2i-hxxlf-xy6t7-ttvyc-hxenc-ixtcf-66ezn-cqe",
@@ -43926,7 +43926,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zk7wk-ueuvm-5quvh-lm6kq-etjru-i63xr-u2xmc-srfx6-uzqq4-jx5j2-nae",
@@ -43946,7 +43946,7 @@
       "dc_id": "bt1",
       "node_provider_id": "4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zlzvg-qepml-jp74r-rdjie-fbyqa-3sxrm-rwh6o-gvfvq-ngbdn-y65hs-aqe",
@@ -43966,7 +43966,7 @@
       "dc_id": "pl1",
       "node_provider_id": "dodsd-rsjlg-sgekb-gr6mi-l6fck-tscwk-4jzgl-fwk4q-ncoyu-ulx53-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zmkb5-5khu3-vqojh-uhuie-d6ma5-dwcuf-cq2d2-546d3-cgrw6-lgqzx-yqe",
@@ -43986,7 +43986,7 @@
       "dc_id": "mm1",
       "node_provider_id": "g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "znxsu-imnwg-deowz-2hqly-kdvsg-yr7mt-h6cht-uc3js-w7s32-xf6fk-zae",
@@ -44006,7 +44006,7 @@
       "dc_id": "ph1",
       "node_provider_id": "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zos66-lmcn7-satbv-gcdzj-q3cdf-4n6zc-2hlei-gc453-uoh7r-4sj3w-vqe",
@@ -44026,7 +44026,7 @@
       "dc_id": "sh1",
       "node_provider_id": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zoz3k-zs7oo-fkv4l-jvyhd-qpzky-7jxpf-46spt-bzxqp-ld63n-dxo4n-pae",
@@ -44046,7 +44046,7 @@
       "dc_id": "ch2",
       "node_provider_id": "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zpp25-phdzv-sjnw6-yrxbt-sfame-frmw4-qnwmm-plosc-anojw-uub2c-dqe",
@@ -44066,7 +44066,7 @@
       "dc_id": "sg2",
       "node_provider_id": "6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zpyka-vu7a6-3hfen-oa5q5-cjpht-ynkw5-bc7mq-ndbdm-r36ex-bfgcb-wqe",
@@ -44086,7 +44086,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zqwwk-hrvpl-isozp-ls5ab-wsej3-bvfry-gkebu-6542b-grakp-yxffy-4ae",
@@ -44106,7 +44106,7 @@
       "dc_id": "br2",
       "node_provider_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "ztrgw-a7sec-ynzfd-utn5y-lnjjs-eb3w5-3yc6s-rygch-tizry-xvjwr-uae",
@@ -44126,7 +44126,7 @@
       "dc_id": "mn2",
       "node_provider_id": "ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zu5xp-ejlxh-jnmw7-pk3se-h3vfb-nmns6-kukie-e6lno-5fa6s-ssyki-aae",
@@ -44146,7 +44146,7 @@
       "dc_id": "zh4",
       "node_provider_id": "ucjqj-jmbj3-rs4aq-ekzpw-ltjs3-zrcma-t6r3t-m5wxc-j5yrj-unwoj-mae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zuabx-u7xyp-pgluz-tdqxl-eubuu-oxg65-i5lup-qh2c5-5wool-rsvp4-oqe",
@@ -44172,7 +44172,7 @@
       "dc_id": "zh7",
       "node_provider_id": "6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zuquq-ubjo4-cx6ej-xojhr-pgcxl-bv3ee-c62da-euj3r-ccu7p-umhm7-wqe",
@@ -44192,7 +44192,7 @@
       "dc_id": "ty2",
       "node_provider_id": "dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae",
       "status": "Healthy",
-      "node_type": "unknown:no_rewardable_nodes_found"
+      "node_reward_type": "unknown:no_rewardable_nodes_found"
     },
     {
       "node_id": "zv7yn-pa2fv-x4jms-x4ynr-bghtf-zwviq-6wtyi-jywso-fqxoy-vbmpv-pqe",
@@ -44212,7 +44212,7 @@
       "dc_id": "sj2",
       "node_provider_id": "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zxph7-ibisu-l2d7c-k6klg-za5kr-scrws-manc5-cknfw-thpyi-vzmij-xqe",
@@ -44232,7 +44232,7 @@
       "dc_id": "to2",
       "node_provider_id": "7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zxxo4-abmdb-uj3ok-cbj4k-is36g-b5o2d-c6akl-vmgyu-d2wie-hgr3y-uae",
@@ -44252,7 +44252,7 @@
       "dc_id": "mb1",
       "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     },
     {
       "node_id": "zzuq4-xiygt-ypkox-2tgdr-yvpzp-optye-xazeq-vnpw5-pata3-4jlle-wqe",
@@ -44278,7 +44278,7 @@
       "dc_id": "hk3",
       "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
       "status": "Healthy",
-      "node_type": "type3.1"
+      "node_reward_type": "type3.1"
     },
     {
       "node_id": "zzzie-aooer-6ecit-rw42z-h2aym-jn3gt-baeys-kmdgd-c3p46-7te4i-2qe",
@@ -44298,7 +44298,7 @@
       "dc_id": "aw1",
       "node_provider_id": "7a4u2-gevsy-5c5fs-hsgri-n2kdz-dxxwf-btcfp-jykro-l4y7c-7xky2-aqe",
       "status": "Healthy",
-      "node_type": "type1.1"
+      "node_reward_type": "type1.1"
     }
   ],
   "unassigned_nodes_config": {

--- a/tests/test_hostos_rollout.py
+++ b/tests/test_hostos_rollout.py
@@ -249,6 +249,73 @@ def test_exclude_hk_nodes(mocker: Any, registry: dre.RegistrySnapshot) -> None:
     )
 
 
+def test_type4_nodes_are_globally_excluded(
+    mocker: Any, registry: dre.RegistrySnapshot
+) -> None:
+    """type4* nodes are globally opted out of HostOS rollouts.
+
+    Regardless of which selectors a rollout plan uses, a node whose
+    node_reward_type starts with "type4" must never appear in any batch.
+    """
+    # Relabel a handful of healthy nodes (a mix of assigned, unassigned and
+    # API boundary) as type4* to verify they all get filtered out.
+    apibn_ids = set(s["principal"] for s in registry["api_bns"])
+    relabelled_assigned = 0
+    relabelled_unassigned = 0
+    relabelled_apibn = 0
+    type4_node_ids: set[str] = set()
+    for n in registry["nodes"]:
+        if n["status"] != "Healthy":
+            continue
+        if n["node_id"] in apibn_ids and relabelled_apibn < 2:
+            n["node_reward_type"] = "type4"
+            type4_node_ids.add(n["node_id"])
+            relabelled_apibn += 1
+        elif n["subnet_id"] is not None and relabelled_assigned < 5:
+            n["node_reward_type"] = "type4.1"
+            type4_node_ids.add(n["node_id"])
+            relabelled_assigned += 1
+        elif (
+            n["subnet_id"] is None
+            and n["node_id"] not in apibn_ids
+            and relabelled_unassigned < 5
+        ):
+            n["node_reward_type"] = "type4.2"
+            type4_node_ids.add(n["node_id"])
+            relabelled_unassigned += 1
+    assert relabelled_assigned and relabelled_unassigned and relabelled_apibn, (
+        "expected to relabel some healthy nodes of each kind as type4*"
+    )
+
+    sys.path.append(os.path.dirname(os.path.dirname("{__file__}")))
+    try:
+        from dags.defaults import DEFAULT_HOSTOS_ROLLOUT_PLANS
+    finally:
+        sys.path.pop()
+
+    params: DagParams = {
+        "simulate": True,
+        "plan": DEFAULT_HOSTOS_ROLLOUT_PLANS["mainnet"],
+        "git_revision": "0",
+    }
+    mocker.patch("dfinity.dre.DRE.get_registry", return_value=registry)
+    sched = schedule(IC_NETWORKS["mainnet"], params)
+
+    scheduled_node_ids: set[str] = set()
+    for batches in (
+        sched["canary"],
+        sched["main"],
+        sched["unassigned"],
+        sched["stragglers"],
+    ):
+        for batch in batches:
+            for node in batch["nodes"]:
+                scheduled_node_ids.add(node["node_id"])
+
+    leaked = scheduled_node_ids & type4_node_ids
+    assert not leaked, f"type4* nodes leaked into the rollout schedule: {leaked}"
+
+
 def test_subnet_healthy_threshold_filters_unhealthy_subnets(
     mocker: Any, registry: dre.RegistrySnapshot
 ) -> None:


### PR DESCRIPTION
## Summary

- Add a global filter at the HostOS rollout candidate-pool level so that nodes whose `node_reward_type` starts with `type4` (cloud engines) are never targeted by any batch, regardless of which selectors a rollout plan uses. The exclusion lives in `plugins/operators/hostos_rollout.py` as a single tuple constant `EXCLUDED_NODE_REWARD_TYPE_PREFIXES = ("type4",)` and a small `_is_excluded_node_type` helper applied in both `compute_provisional_node_batches` (planning path) and `compute_actual_plan_for_batch` (per-batch runtime path).
- Align `RegistryNode` with the current `dre registry` schema. The reward-type field was renamed `node_type` → `node_reward_type` in dfinity/dre#1617 and the latest dre release (v0.7.7) emits the new name; the test fixture was previously using the stale name. Introduces a `NodeRewardType` type alias in `dfinity.rollout_types`, declares the field as a required string on `RegistryNode`, and renames every occurrence in `tests/registry.json` to match.

## Test plan

- [x] `make ruff` clean
- [x] `make mypy` clean
- [x] `make pytest` -- 75/75 tests pass, including the new `test_type4_nodes_are_globally_excluded` which relabels a mix of healthy assigned, unassigned and API boundary nodes in the fixture as `type4` / `type4.1` / `type4.2` and asserts none of them appear in any batch produced by `schedule()` against the default mainnet plan.