### PR TITLE
Upgrade CloudEngine subnets after upgrading unassigned nodes

### DIFF
--- a/dags/rollout_ic_os_to_subnets.py
+++ b/dags/rollout_ic_os_to_subnets.py
@@ -239,6 +239,14 @@ for network_name, network in IC_NETWORKS.items():
             retries=retries,
         )
 
+        upgrade_cloud_engines = ic_os_rollout.UpgradeCloudEngines(
+            task_id="upgrade_cloud_engines",
+            git_revision="{{ params.git_revision }}",
+            simulate=cast(bool, "{{ params.simulate }}"),
+            network=network,
+            retries=retries,
+        )
+
         task_groups = []
         for batch in range(MAX_BATCHES):
             batch_name = str(batch + 1)
@@ -252,6 +260,7 @@ for network_name, network in IC_NETWORKS.items():
             ),
             *task_groups,
             upgrade_unassigned_nodes,
+            upgrade_cloud_engines,
         )
 
 

--- a/plugins/operators/ic_os_rollout.py
+++ b/plugins/operators/ic_os_rollout.py
@@ -303,6 +303,102 @@ class UpgradeUnassignedNodes(BaseOperator):
             raise AirflowException("dre exited with status code %d", p.exit_code)
 
 
+class UpgradeCloudEngines(BaseOperator):
+    """
+    Submit a `deploy-guestos-to-all-subnet-nodes` proposal for every subnet
+    registered with type `cloud_engine`, targeting the rollout's git revision.
+
+    Idempotent: a subnet is skipped if its most recent IC OS deployment
+    proposal already targets the requested revision and is open / adopted /
+    executed.  Succeeds as a no-op if no CloudEngine subnets exist.  Like
+    `UpgradeUnassignedNodes`, this does NOT wait for proposal voting,
+    proposal acceptance, replica revision rollout, or alert quiescence.
+    """
+
+    template_fields = ("simulate", "git_revision")
+    network: ic_types.ICNetwork
+    simulate: bool
+    git_revision: str
+
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        network: ic_types.ICNetwork,
+        git_revision: str,
+        simulate: bool,
+        **kwargs: Any,
+    ):
+        self.simulate = simulate
+        self.git_revision = git_revision
+        self.network = network
+        BaseOperator.__init__(self, task_id=task_id, **kwargs)
+
+    def execute(self, context: Context) -> None:
+        if self.simulate:
+            self.log.info(f"simulate={self.simulate}")
+        runner = dre.DRE(network=self.network, subprocess_hook=SubprocessHook())
+        cloud_engine_subnet_ids = runner.get_cloud_engine_subnet_ids()
+        if not cloud_engine_subnet_ids:
+            self.log.info(
+                "No subnets with type cloud_engine are registered.  Nothing to do."
+            )
+            return
+
+        self.log.info(
+            "Found %d CloudEngine subnet(s); upgrading to revision %s: %s",
+            len(cloud_engine_subnet_ids),
+            self.git_revision,
+            cloud_engine_subnet_ids,
+        )
+
+        authenticated_runner = runner.authenticated()
+        for subnet_id in cloud_engine_subnet_ids:
+            props = sorted(
+                runner.get_ic_os_version_deployment_proposals_for_subnet(
+                    subnet_id=subnet_id,
+                ),
+                key=lambda prop: -prop["proposal_id"],
+            )
+            props_for_git_revision = [
+                p
+                for p in props
+                if p["payload"]["replica_version_id"] == self.git_revision
+            ]
+            if (
+                props_for_git_revision
+                and props_for_git_revision[0]["proposal_id"] == props[0]["proposal_id"]
+                and props_for_git_revision[0]["status"]
+                in (
+                    ic_types.ProposalStatus.PROPOSAL_STATUS_OPEN,
+                    ic_types.ProposalStatus.PROPOSAL_STATUS_ADOPTED,
+                    ic_types.ProposalStatus.PROPOSAL_STATUS_EXECUTED,
+                )
+            ):
+                self.log.info(
+                    "Subnet %s already has proposal %s for revision %s in state %s;"
+                    " skipping.",
+                    subnet_id,
+                    props_for_git_revision[0]["proposal_id"],
+                    self.git_revision,
+                    props_for_git_revision[0]["status"].name,
+                )
+                continue
+
+            self.log.info(
+                "Creating proposal for CloudEngine subnet %s to adopt revision %s"
+                " (simulate=%s).",
+                subnet_id,
+                self.git_revision,
+                self.simulate,
+            )
+            authenticated_runner.propose_to_update_subnet_replica_version(
+                subnet_id=subnet_id,
+                git_revision=self.git_revision,
+                dry_run=self.simulate,
+            )
+
+
 @task
 def schedule(
     network: ic_types.ICNetwork, **context: dict[str, Any]

--- a/rollout-dashboard/frontend/src/lib/types.ts
+++ b/rollout-dashboard/frontend/src/lib/types.ts
@@ -70,6 +70,10 @@ const GuestOsState = {
         icon: "⏩",
         name: "upgrading unassigned nodes",
     },
+    upgrading_cloud_engines: {
+        icon: "⏩",
+        name: "upgrading cloud engines",
+    },
     waiting: { icon: "⌛", name: "waiting" },
     problem: { icon: "⚠️", name: "problem" },
 };

--- a/rollout-dashboard/server/src/live_state/guestos_rollout.rs
+++ b/rollout-dashboard/server/src/live_state/guestos_rollout.rs
@@ -472,6 +472,25 @@ impl Parser {
                     }
                     None => {}
                 }
+            } else if task_instance.task_id == "upgrade_cloud_engines" {
+                match task_instance.state {
+                    Some(TaskInstanceState::Skipped) | Some(TaskInstanceState::Removed) => (),
+                    Some(TaskInstanceState::UpForRetry) | Some(TaskInstanceState::Restarting) => {
+                        rollout.state = State::Problem
+                    }
+                    Some(TaskInstanceState::Failed) | Some(TaskInstanceState::UpstreamFailed) => {
+                        rollout.state = State::Failed
+                    }
+                    Some(TaskInstanceState::UpForReschedule)
+                    | Some(TaskInstanceState::Running)
+                    | Some(TaskInstanceState::Deferred)
+                    | Some(TaskInstanceState::Queued)
+                    | Some(TaskInstanceState::Scheduled)
+                    | Some(TaskInstanceState::Success) => {
+                        update_state_unless_problem!(State::UpgradingCloudEngines)
+                    }
+                    None => {}
+                }
             } else {
                 warn!(target: tgt, "{}: unknown task {}", task_instance.dag_run_id, task_instance.task_id)
             }

--- a/rollout-dashboard/server/src/types.rs
+++ b/rollout-dashboard/server/src/types.rs
@@ -80,6 +80,8 @@ pub mod v1 {
         UpgradingSubnets,
         /// The rollout is upgrading unassigned nodes.
         UpgradingUnassignedNodes,
+        /// The rollout is upgrading CloudEngine subnets.
+        UpgradingCloudEngines,
         /// The rollout has finished successfully or was marked as such by the operator.
         Complete,
     }

--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -72,6 +72,8 @@ class RegistrySubnet(TypedDict):
     subnet_id: PossibleSubnetId
     membership: list[rollout_types.NodeId]
     nodes: dict[rollout_types.NodeId, RegistryNode]
+    # One of "application", "verified_application", "system", "cloud_engine".
+    subnet_type: str
     #  "max_ingress_bytes_per_message": 2097152,
     #  "max_ingress_messages_per_block": 1000,
     #  "max_block_payload_size": 4194304,
@@ -81,7 +83,6 @@ class RegistrySubnet(TypedDict):
     #  "dkg_interval_length": 499,
     #  "dkg_dealings_per_block": 1,
     #  "start_as_nns": false,
-    #  "subnet_type": "application",
     #  "features": {
     #    "canister_sandboxing": false,
     #    "http_requests": true,
@@ -422,6 +423,17 @@ class DRE:
         if r.exit_code != 0:
             raise AirflowException("dre exited with status code %d", r.exit_code)
         return cast(list[str], json.loads(r.output))
+
+    def get_cloud_engine_subnet_ids(self) -> list[rollout_types.SubnetId]:
+        """
+        Return the subnet IDs of all subnets registered with type `cloud_engine`.
+        """
+        snapshot = self.get_registry()
+        return [
+            cast(rollout_types.SubnetId, s["subnet_id"])
+            for s in snapshot["subnets"]
+            if s.get("subnet_type") == "cloud_engine" and s.get("subnet_id")
+        ]
 
     def get_blessed_replica_versions(self) -> list[str]:
         r = self.run("get", "blessed-replica-versions", "--json", full_stdout=True)


### PR DESCRIPTION
## Motivation

The mainnet GuestOS rollout DAG ends with `upgrade_unassigned_nodes`, but subnets registered with type `cloud_engine` are not on the rollout plan and therefore never get rolled to the new revision. Add a final step that fans out a `deploy-guestos-to-all-subnet-nodes` proposal to every CloudEngine subnet so they advance with the rest of the network.