### PR TITLE
Remove jmfme from GuestOS rollout plan

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -33,8 +33,7 @@ Thursday:
   9:00:      [yinp6, bkfrj, jtdsg]
   11:00:     [mpubz, x33ed, gmq5v]
   13:00:     [3hhby, nl6hn, pzp6e]
-  14:00:     [rtvil, xlkub]
-  15:00:     [3zsyy, jmfme]
+  14:00:     [rtvil, xlkub, 3zsyy]
 Monday next week:
   7:00:
     subnets: [tdb26]


### PR DESCRIPTION
## Summary

- The `jmfme` engine subnet no longer exists, so it is removed from the Thursday GuestOS mainnet rollout plan.
- `3zsyy` is moved up into the 14:00 batch and the now-empty 15:00 batch is dropped.

## Test plan

- [ ] Confirm the rollout plan still parses as a valid `SubnetRolloutPlanSpec` (push the reload button in the Airflow DAG list to reload defaults).