### PR TITLE
Pin DRE binary to v0.7.8

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -22,7 +22,7 @@ import dfinity.ic_types as ic_types
 import dfinity.rollout_types as rollout_types
 
 DRE_URL = (
-    "https://github.com/dfinity/dre/releases/latest/download/dre-x86_64-unknown-linux"
+    "https://github.com/dfinity/dre/releases/download/v0.7.8/dre-x86_64-unknown-linux"
 )
 FAKE_PROPOSAL_NUMBER = -123456
 


### PR DESCRIPTION
Pins the DRE tool downloaded by the airflow rollout code to the new `v0.7.8` release instead of `latest`.

`shared/dfinity/dre.py` pulls the `dre` binary from GitHub releases. It was pointing at `releases/latest/download/`; this pins it to the explicit `v0.7.8` tag (matching the prior convention, e.g. the earlier `v0.5.9` pin).

Note: depends on the `v0.7.8` GitHub release being published (it is created as a draft/pre-release by the dre release pipeline). The asset URL resolves once the release is published.