### PR TITLE
Add hqakm and i55je API boundary nodes to mainnet rollout plan

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -55,6 +55,8 @@ nodes:
   - dl74z-6vpps-k6bpu-5hjsj-fb6lb-34tsv-ue5gt-bdkjn-35pt5-fdu2a-rae
   - ec62l-q44va-5lyw2-gbl4w-xcx55-c3qv4-q67vc-fu6s7-xpm2r-7tjrw-tae
   - ek6px-kxr47-noli7-nyjql-au5uc-tmj3k-777mf-lfla5-k4xx4-msu3j-dae
+  - hqakm-buvkm-5onrb-4ja5j-pne2h-mnlgv-ei4sf-nqn7l-3ir4g-z6xq5-zqe
+  - i55je-j5vzn-z4odr-yhmrb-nlf46-gbgfg-6uk5e-gssxu-b7hmf-ntlay-pqe
   - jlifv-mddo3-zfwdc-x2wmu-xklbj-dai3i-3pvjy-j4hqm-sarqr-fhkq6-zae
   - lwxeh-xayoz-wu5eb-hwraj-a3pew-yeioj-cnwat-5uow4-ugxkc-kx44o-4ae
   - mbsyf-dtlsd-ccjq4-63rmh-u2lv7-dwxuq-ym6bk-63i2l-5uyki-zccek-mqe


### PR DESCRIPTION
## What

Add the two API boundary nodes to the mainnet `DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS` list in `dags/defaults.py` (kept in sorted order, between `ek6px…` and `jlifv…`):

- `hqakm-buvkm-5onrb-4ja5j-pne2h-mnlgv-ei4sf-nqn7l-3ir4g-z6xq5-zqe`
- `i55je-j5vzn-z4odr-yhmrb-nlf46-gbgfg-6uk5e-gssxu-b7hmf-ntlay-pqe`

List goes from 20 → 22 nodes (matching the live registry's API boundary node count).

## Why

These two nodes were added as API boundary nodes on 2026-05-04 but were never in the auto-compute rollout list, so `auto_compute_rollout_to_mainnet` never updated them. They were only bumped by one-off 2-node proposals on an irregular cadence (`DeployGuestosToSomeApiBoundaryNodes`: 141781 on 2026-05-18 → `62e841d…`, then nothing until 142146 on 2026-06-09 → `a47e5434…`).

That ~3-week gap left them on `62e841d…` (rc--2026-05-07) long enough for it to age out of the release controller's active window while still in use. The release controller's unelect logic doesn't account for API-boundary-node versions, so it tried to retire `62e841d…` while these nodes still ran it — failing the GuestOS election twice (NNS proposals 142125 and 142145, registry `replica_version` invariant).

Folding them into the weekly rollout keeps them current so this can't recur.

## Test plan

- [ ] `DEFAULT_API_BOUNDARY_NODES_ROLLOUT_PLANS["mainnet"]` parses as valid YAML with 22 unique, sorted node IDs (verified locally).
- [ ] Next `auto_compute_rollout_to_mainnet` run includes both nodes in the API boundary nodes rollout.

## Note

Reminder per `dags/defaults.py` docstring: changing defaults may require hitting the reload button on the Airflow DAGs screen for the new defaults to take effect.