### PR TITLE
fix(dre): parse plaintext output for blessed replica versions

### DIFF
--- a/shared/dfinity/dre.py
+++ b/shared/dfinity/dre.py
@@ -436,10 +436,17 @@ class DRE:
         ]
 
     def get_blessed_replica_versions(self) -> list[str]:
-        r = self.run("get", "blessed-replica-versions", "--json", full_stdout=True)
+        # ic-admin's get-blessed-replica-versions (alias of
+        # get-elected-guestos-versions) ignores --json and prints one Git
+        # revision per line, just like get-elected-hostos-versions.
+        r = self.run("get", "blessed-replica-versions", full_stdout=True)
         if r.exit_code != 0:
             raise AirflowException("dre exited with status code %d", r.exit_code)
-        return cast(list[str], json.loads(r.output)["value"]["blessed_version_ids"])
+        decoded = [x.strip() for x in r.output.splitlines() if x.strip()]
+        assert all(re.match("^[0-9a-f]{40}$", x) for x in decoded), (
+            "One of the returned values in %s is not a valid Git revision" % decoded
+        )
+        return cast(list[str], decoded)
 
     def get_elected_hostos_versions(self) -> list[str]:
         r = self.run("get", "elected-hostos-versions", full_stdout=True)


### PR DESCRIPTION
## Summary

- The `wait_for_revision_to_be_elected` sensor in the mainnet GuestOS rollout DAG was failing with `JSONDecodeError: Extra data: line 1 column 7 (char 6)`.
- Root cause: `DRE.get_blessed_replica_versions()` ran `dre get blessed-replica-versions --json`, which forwards to `ic-admin get-blessed-replica-versions`. That subcommand is now an alias of `GetElectedGuestosVersions`, whose handler **ignores `--json`** and prints one Git revision per line. `json.loads` then parsed the first hash's leading digits as an integer and choked on the 7th character.
- Fix: drop `--json` and parse newline-separated revisions with the same hex-validation already used by `get_elected_hostos_versions()`.

## Test plan

- [ ] Re-run the failed `wait_for_revision_to_be_elected` mapped task in `rollout_ic_os_to_mainnet_subnets` after deploy; it should read the elected versions and proceed.
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check passes.