### PR TITLE
chore: schedule upgrades of some cloud engines as part of the schedule

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -17,13 +17,16 @@ DEFAULT_GUESTOS_ROLLOUT_PLANS: dict[str, str] = {
 Monday:
   9:00:      [io67a, xok3w, vcpt7]
   11:00:     [shefu, fuqsr, 4utr6]
+  13:00:     [eibym, g556q, 56zwx]
 Tuesday:
   7:00:      [pjljw, qdvhd, 2fq7c]
   9:00:      [snjp4, w4asl, qxesv]
   11:00:     [4zbus, ejbmu, uzr34]
   13:00:     [re2t4, c4isl, mkbc3]
+  15:00:     [eajxw, nx5oj, cynor]
 Wednesday:
   7:00:      [pae4o, 5kdm2, csyj4]
+  8:00:      [hbcn5, aguy2, kindg]
   9:00:      [eq6en, lhg73, brlsh]
   11:00:     [k44fs, cv73p, 4ecnw]
   13:00:     [opn46, lspz2, o3ow2]


### PR DESCRIPTION
Core Protocol requested that we schedule some of the cloud engines as part of the normal rollout, such that we upgrade cloud engines before the NNS and find potential problems earlier.

I added:
**Monday 13:00** 
* 2 Gen1 cloud engines (`eibym`, `g556q`)
* 1 nano cloud engine (`56zwx`)

**Tuesday 15:00**
* Pakistani engine (`eajxw`)
* DFINITY engine (`nx5oj`)
* first paid engine (`cynor`)

**Wednesday 08:00**
* Dom's engine (`hbcn5`)
* second paid (`aguy2`)
* third paid engine (`kindg`)

All other engines will be upgraded at the end as before. We will just have to keep an eye out in case the subnet doesn't exist anymore.