### PR TITLE
chore: update guestos rollout plan -- remove unused subnets

### DIFF
--- a/dags/defaults.py
+++ b/dags/defaults.py
@@ -15,25 +15,24 @@ that might have side effects.  This is only for defaults.
 DEFAULT_GUESTOS_ROLLOUT_PLANS: dict[str, str] = {
     "mainnet": """
 Monday:
-  9:00:      [io67a, xok3w, vcpt7]
-  11:00:     [shefu, fuqsr, 4utr6]
+  9:00:      [io67a, 4utr6]
+  11:00:     [shefu, fuqsr]
 Tuesday:
   7:00:      [pjljw, qdvhd, 2fq7c]
   9:00:      [snjp4, w4asl, qxesv]
   11:00:     [4zbus, ejbmu, uzr34]
-  13:00:     [re2t4, c4isl, mkbc3]
+  13:00:     [re2t4, c4isl]
 Wednesday:
   7:00:      [pae4o, 5kdm2, csyj4]
   9:00:      [eq6en, lhg73, brlsh]
   11:00:     [k44fs, cv73p, 4ecnw]
-  13:00:     [opn46, lspz2, o3ow2, x4jtx]
-  15:00:     [2zs4v, 6excn, kp5jj]
+  13:00:     [opn46, lspz2, o3ow2]
 Thursday:
   7:00:      [w4rem, 6pbhf, e66qm]
   9:00:      [yinp6, bkfrj, jtdsg]
   11:00:     [mpubz, x33ed, gmq5v]
   13:00:     [3hhby, nl6hn, pzp6e]
-  14:00:     [rtvil, xlkub, 3zsyy]
+  14:00:     [x4jtx, 3zsyy]
 Monday next week:
   7:00:
     subnets: [tdb26]


### PR DESCRIPTION
The following subnets are not being used and will be deleted via a proposal next week. Hence, we do not need to include them in our coming guestOS rollouts:
```
2zs4v-uoqha-xsuun-lveyr-i4ktc-5y3ju-aysud-niobd-gxnqa-ctqem-hae
6excn-doq5g-bmrxd-3774i-hjnn2-3ovbo-xjwz7-3yozt-fsbzx-bethy-bae
kp5jj-kpgmn-f4ohx-uqot6-wtbbr-lmtqv-kpkaf-gcksv-snkwm-43kmy-iae
mkbc3-fzim5-s5pye-pbnzo-uj5yv-raphe-ceecn-ejd6g-5poxm-dzuot-iae
rtvil-s5u5d-jbj7o-prlhw-bzlr5-3j5kn-2iu7a-jq2hl-avkhn-w7oa7-6ae
vcpt7-niq42-6snup-7kcgy-cndz6-srq6n-h6vwi-oswri-a3guc-v5ssd-5qe
xlkub-3thlm-uha3c-hqmfw-qykp5-6rldi-hpfxy-nwyxy-w6bbk-tpg5h-vqe
xok3w-cnepj-fg6aa-cjitt-uoxod-4ddsy-nc7dq-zwudz-o6jar-rzstb-gqe
```